### PR TITLE
build(build-cube): remove commented UNA_SDK override and set UNA_WORK…

### DIFF
--- a/Utilities/Scripts/build-cube/build-cube.sh
+++ b/Utilities/Scripts/build-cube/build-cube.sh
@@ -24,13 +24,6 @@ if [ -f "$PREFS_FILE" ]; then
         && echo "Overridden __BUILD_VERSION__ to '$BUILD_VERSION' in $PREFS_FILE" \
         || echo "Pattern __BUILD_VERSION__ not found in $PREFS_FILE"
   fi
-
-  # Overriding SDK path with STM32CubeIDE for examples is not supported for this script
-  # if [ -n "$UNA_SDK" ]; then
-  #   sed -i 's#/UNA_SDK/value=.*#/UNA_SDK/value='"$UNA_SDK"'#g' "$PREFS_FILE" \
-  #       && echo "Overridden UNA_SDK to '$UNA_SDK' in $PREFS_FILE" \
-  #       || echo "Pattern UNA_SDK not found in $PREFS_FILE"
-  # fi
 else
   echo "Warning: Prefs file not found at $PREFS_FILE"
 fi

--- a/Utilities/Scripts/build-cube/una-version.sh
+++ b/Utilities/Scripts/build-cube/una-version.sh
@@ -25,6 +25,8 @@ else
   toplevel=$(git rev-parse --show-toplevel)
 fi
 echo "toplevel: $toplevel"
+cd "$toplevel" || echo "Failed to cd to $toplevel"
+UNA_WORKSPACE=$toplevel
 
 if git rev-parse --git-dir > /dev/null 2>&1; then
   COMMIT_HASH=$(git rev-parse --short=7 HEAD)


### PR DESCRIPTION
…SPACE

Removed unused commented code for SDK path override in build-cube.sh.

Added cd to git toplevel and export UNA_WORKSPACE in una-version.sh to ensure consistent workspace handling.