### PR TITLE
ci(release): use cross-repo PAT for sdk release

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: false
-          token: ${{ github.token }}
+          token: ${{ secrets.CROSS_REPO_PAT }}
 
       - id: create_release
         name: Release
@@ -38,13 +38,13 @@ jobs:
         with:
           generate_release_notes: true
         env:
-          GITHUB_TOKEN: ${{ github.token}}
+          GITHUB_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
 
       - name: Make release immutable
         run: |
           gh release edit ${{ github.ref_name }} --draft=false
         env:
-          GITHUB_TOKEN: ${{ github.token}}
+          GITHUB_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
 
       - id: get_slack_params
         name: Get required parameters for slack notification
@@ -58,7 +58,7 @@ jobs:
           echo "name=$(echo \"$RELEASE_JSON\" | jq -r '.name')" >> $GITHUB_OUTPUT
           echo "url=$(echo \"$RELEASE_JSON\" | jq -r '.url')" >> $GITHUB_OUTPUT
         env:
-          GITHUB_TOKEN: ${{ github.token}}
+          GITHUB_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
 
       - id: prepare_slack_payload
         name: Prepare Slack payload


### PR DESCRIPTION
Replace the default GitHub token with CROSS_REPO_PAT for checkout and release-related GitHub CLI actions.