### PR TITLE
ci(docs): quote tag names in version selector generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Generate version selector
       run: |
         TAGS_JSON=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -s https://api.github.com/repos/${{ github.repository }}/tags)
-        TAGS=$(echo "$TAGS_JSON" | jq -r '.[].name' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+        TAGS=$(echo "$TAGS_JSON" | jq -r '.[].name' 2>/dev/null | sed 's/.*/"&"/' | tr '\n' ',' | sed 's/,$//')
         if [ -z "$TAGS" ]; then
           TAGS='"v1.0","v2.0"'
         fi


### PR DESCRIPTION
Wrap each tag name in double quotes to ensure proper handling in the JSON output, preventing potential parsing issues with special characters.