### PR TITLE
ci(slack): replace sed with perl in message conversion

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -65,14 +65,14 @@ jobs:
         run: |
           BODY="${{ steps.get_slack_params.outputs.body }}"
           # Convert markdown to Slack mrkdwn
-          BODY=$(echo "$BODY" | sed -E 's/\[([^\]]+)\]\(([^)]+)\)/<\2|\1>/g' || { echo "Error converting links"; exit 1; })  # Links
-          BODY=$(echo "$BODY" | sed -E 's/\*\*([^*]+)\*\*/\*\1\*/g' || { echo "Error converting bold"; exit 1; })  # Bold
-          BODY=$(echo "$BODY" | sed -E 's/\*([^*]+)\*/_\1_/g' || { echo "Error converting italic"; exit 1; })  # Italic
-          BODY=$(echo "$BODY" | sed -E 's/^-\s*/- /g; s/^\*\s*/- /g' || { echo "Error converting lists"; exit 1; })  # Lists
-          BODY=$(echo "$BODY" | sed -E 's/^#\+\s*\(.*\)$/*\1*/g' || { echo "Error converting headers"; exit 1; })  # Headers
-          BODY=$(echo "$BODY" | sed -E 's/@\([a-zA-Z0-9_-]*\)/<https:\/\/github.com\/\1|@\1>/g' || { echo "Error converting mentions"; exit 1; })  # Mentions
-          BODY=$(echo "$BODY" | sed -E 's/\*\*Full Changelog\*\*:/ *Full Changelog*\n/' || { echo "Error adjusting changelog"; exit 1; })  # Changelog
-          BODY=$(echo "$BODY" | sed -E 's/"/\\"/g' || { echo "Error escaping quotes"; exit 1; })  # Escape double quotes
+          BODY=$(echo "$BODY" | perl -pe 's/\[([^\]]+)\]\(([^)]+)\)/<$2|$1>/g' || { echo "Error converting links"; exit 1; })  # Links
+          BODY=$(echo "$BODY" | perl -pe 's/\*\*([^*]+)\*\*/\*$1\*/g' || { echo "Error converting bold"; exit 1; })  # Bold
+          BODY=$(echo "$BODY" | perl -pe 's/\*([^*]+)\*/_$1_/g' || { echo "Error converting italic"; exit 1; })  # Italic
+          BODY=$(echo "$BODY" | perl -pe 's/^-\s*/- /g; s/^\*\s*/- /g' || { echo "Error converting lists"; exit 1; })  # Lists
+          BODY=$(echo "$BODY" | perl -pe 's/^#\+\s*\(.*\)$/*$1*/g' || { echo "Error converting headers"; exit 1; })  # Headers
+          BODY=$(echo "$BODY" | perl -pe 's/@\([a-zA-Z0-9_-]*\)/<https:\/\/github.com\/$1|@$1>/g' || { echo "Error converting mentions"; exit 1; })  # Mentions
+          BODY=$(echo "$BODY" | perl -pe 's/\*\*Full Changelog\*\*:/ *Full Changelog*\n/' || { echo "Error adjusting changelog"; exit 1; })  # Changelog
+          BODY=$(echo "$BODY" | perl -pe 's/"/\\"/g' || { echo "Error escaping quotes"; exit 1; })  # Escape double quotes
           PAYLOAD=$(jq -c -n --arg name "${{ steps.get_slack_params.outputs.name }}" --arg tag "${{ github.ref_name }}" --arg body "$BODY" --arg author "${{ steps.get_slack_params.outputs.author }}" --arg created "${{ steps.get_slack_params.outputs.created_at }}" --arg url "${{ steps.get_slack_params.outputs.url }}" '{
             text: (":books: *UNA SDK*: " + $name),
             blocks: [


### PR DESCRIPTION
The script was using sed for regex replacements, which failed in some cases due to backreference syntax differences. Switched to perl for reliable markdown-to-Slack conversion in the SDK release workflow.