### PR TITLE
refactor(sensors-tutorial): adjust font sizes for text body based on verbosity levels

### DIFF
--- a/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
+++ b/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
@@ -177,10 +177,10 @@ void MainView::refreshDisplay()
 
     if (verbosity > FULL && verbosity < VERB_LEVEL_MAX) {
         // Smaller text size 50 for per-sensor
-        text_body.setTypedText(TypedText(T_TMP_REGULAR_9));
+        text_body.setTypedText(TypedText(T_TMP_REGULAR_18));
     } else {
         // Default size
-        text_body.setTypedText(TypedText(T_TMP_REGULAR_18)); // assume exists
+        text_body.setTypedText(TypedText(T_TMP_REGULAR_9)); // assume exists
     }
     LOG_DEBUG("Current verbosity: %d\\n", (int)verbosity);
     Unicode::strncpy(text_bodyBuffer, buffer, TEXT_BODY_SIZE);


### PR DESCRIPTION
Invert the font size logic in MainView::refreshDisplay() to use larger font (T_TMP_REGULAR_18) for verbosity levels between FULL and VERB_LEVEL_MAX, and smaller font (T_TMP_REGULAR_9) otherwise, improving readability in per-sensor display mode.