### PR TITLE
Fix Linux x86-64 simulator build compatibility

### DIFF
--- a/Docs/SDK_LINUX_FIXES.md
+++ b/Docs/SDK_LINUX_FIXES.md
@@ -1,0 +1,94 @@
+# UNA SDK — Linux Simulator Compatibility Fixes
+
+This document records the changes made to the SDK to enable the TouchGFX simulator
+to build on x86-64 Linux (Ubuntu 24.04, GCC 13). All changes are backward-compatible:
+the embedded ARM build is unaffected and Windows simulator builds continue to work.
+
+---
+
+## Summary of changes
+
+| File | Issue | Fix |
+|------|-------|-----|
+| `Libs/Header/SDK/Simulator/OS/OS.hpp` | `#include <array>` only in `#ifdef _WIN32` block; `OS::Queue<T,N>` uses `std::array` | Add `#include <array>` to `#else` (Linux) branch |
+| `Libs/Header/SDK/Simulator/Kernel/Mock/App.hpp` | `#include <windows.h>` unconditional; nothing in the file actually uses it on Linux | Guard with `#ifdef _WIN32` |
+| `Libs/Header/SDK/Simulator/Kernel/Mock/Logger.hpp` | `GetTickCount64()` is Win32-only | Add portable `GetTickCount64()` wrapper using `clock_gettime(CLOCK_MONOTONIC)` for `#ifndef _WIN32` |
+| `Libs/Source/Simulator/Kernel/Mock/System.cpp` | `GetTickCount64()` and `Sleep()` are Win32-only | Add local wrappers using `clock_gettime` and `usleep` for `#ifndef _WIN32` |
+| `Libs/Header/SDK/Messages/MessageBase.hpp` | `static_assert(sizeof(MessageBase) == 32)` fails on x86-64 where `void*` and vtable pointer are 8 bytes | Guard with `#if __SIZEOF_POINTER__ == 4` |
+| `Libs/Header/SDK/Messages/CommandMessages.hpp` | 18 `static_assert` size checks that assume 32-bit pointer layout | Guard each with `#if __SIZEOF_POINTER__ == 4` |
+| `Libs/Source/Wrappers/StdLibWrappers.c` | `std::strncpy` used in a `.c` (C) file; `std::` namespace is C++ only | Replace with plain `strncpy` |
+
+---
+
+## Detail
+
+### `OS.hpp` — missing `#include <array>`
+
+`OS::Queue<T, N>` uses `std::array<T, N>` for its internal buffer. The `#include <array>`
+was inside the `#ifdef _WIN32` block, so it was never included on Linux, leaving
+`std::array` with only a forward declaration (from `<tuple>` pulled in transitively).
+This caused an "incomplete type" error when the template was instantiated.
+
+**Fix**: add `#include <array>` to the `#else` block.
+
+---
+
+### `App.hpp` — unconditional `#include <windows.h>`
+
+`App.hpp` included `<windows.h>` at the top level even though no Windows-specific types
+or functions are referenced in the class body. The include was likely a copy-paste artifact.
+
+**Fix**: guard with `#ifdef _WIN32`.
+
+---
+
+### `Logger.hpp` and `System.cpp` — `GetTickCount64()` / `Sleep()`
+
+`GetTickCount64()` returns milliseconds since boot on Windows. The POSIX equivalent
+is `clock_gettime(CLOCK_MONOTONIC, ...)`. `Sleep(ms)` maps to `usleep(ms * 1000)` on POSIX.
+
+Both are provided as `static inline` wrappers in `#ifndef _WIN32` blocks so they are
+only defined when the platform-provided versions are absent.
+
+---
+
+### `MessageBase.hpp` / `CommandMessages.hpp` — pointer-size assertions
+
+The SDK message structs contain a `void* mCompletionSemaphore` field and a vtable pointer,
+both of which are 4 bytes on 32-bit ARM and 8 bytes on x86-64. The struct size checks
+hardcoded 32-bit sizes (e.g. `sizeof(MessageBase) == 32`).
+
+On x86-64 the structs are larger (e.g. `sizeof(MessageBase) == 40`), but this does not
+affect simulator correctness because:
+- The GUI and service threads run in the **same process** and share the same memory layout.
+- Binary-format IPC (packed structs sent over a wire) is not used in the simulator.
+
+The assertions are valuable for the embedded ARM build where memory layout matters.
+They are preserved under `#if __SIZEOF_POINTER__ == 4` so they still fire for ARM GCC.
+
+---
+
+### `StdLibWrappers.c` — `std::strncpy` in a C file
+
+`StdLibWrappers.c` is compiled as C (not C++). The Linux branch used `std::strncpy`
+which is a C++ qualified name and is not valid in C. GCC 13 rejects this.
+
+**Fix**: replace with plain `strncpy` (both C and C++ have it in `<string.h>` / `<cstring>`).
+
+---
+
+## What is NOT fixed in the SDK (handled at app level)
+
+`Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp` and the corresponding header use
+Win32 file APIs (`GetFileAttributesA`, `CreateDirectoryA`, `FindFirstFileA`, etc.)
+throughout the implementation. Rather than a surgical patch, the rowing app provides
+a complete POSIX-based replacement at:
+
+```
+apps/rowing/Software/Apps/TouchGFX-GUI/simulator_linux/FileSystem.cpp
+apps/rowing/Software/Apps/TouchGFX-GUI/simulator_linux/SDK/Simulator/Kernel/Mock/FileSystem.hpp
+```
+
+The `config/gcc/app.mk` selects this replacement by:
+1. Adding `simulator_linux/` to the front of `ADDITIONAL_INCLUDE_PATHS` (shadows the SDK header).
+2. Replacing the SDK `FileSystem.cpp` entry in `ADDITIONAL_SOURCES_UNA` with the local one.

--- a/Libs/Header/SDK/Messages/CommandMessages.hpp
+++ b/Libs/Header/SDK/Messages/CommandMessages.hpp
@@ -128,7 +128,9 @@ struct RequestAppTerminate : public MessageBase {
         , code(0)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestAppTerminate) == 36, "RequestAppTerminate size must be 36 bytes");
+#endif
 
 /**
  * @brief Notify the Kernel that the activity session has ended.
@@ -156,7 +158,9 @@ struct RequestSetCapabilities : public MessageBase {
         , enMusicControl(false)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestSetCapabilities) == 36, "RequestSetCapabilities size must be 36 bytes");
+#endif
 
 /**
  * @brief Battery status request
@@ -176,7 +180,9 @@ struct RequestBatteryStatus : public MessageBase {
         , isCharging(false)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestBatteryStatus) == 44, "RequestBatteryStatus size must be 44 bytes");
+#endif
 
 /**
  * @brief System settings request
@@ -209,7 +215,9 @@ struct RequestSystemSettings : public MessageBase {
         , heartRateTh {}
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestSystemSettings) == 56, "RequestSystemSettings size must be 56 bytes");
+#endif
 
 /**
  * @brief System information request
@@ -232,7 +240,9 @@ struct RequestSystemInfo : public MessageBase {
         hardwareVersion[0] = '\0';
     }
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestSystemInfo) == 72, "RequestSystemInfo size must be 72 bytes");
+#endif
 
 /**
  * @brief Memory information request
@@ -256,7 +266,9 @@ struct RequestMemoryInfo : public MessageBase {
         , fragmentation(0)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestMemoryInfo) == 52, "RequestMemoryInfo size must be 52 bytes");
+#endif
 
 /**
  * @brief Display configuration request
@@ -280,7 +292,9 @@ struct RequestDisplayConfig : public MessageBase {
         , format(0)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestDisplayConfig) == 40, "RequestDisplayConfig size must be 40 bytes");
+#endif
 
 /**
  * @brief Display update request
@@ -304,7 +318,9 @@ struct RequestDisplayUpdate : public MessageBase {
         , width(0), height(0)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestDisplayUpdate) == 44, "RequestDisplayUpdate size must be 44 bytes");
+#endif
 
 /**
  * @brief Backlight control request
@@ -321,7 +337,9 @@ struct RequestBacklightSet : public MessageBase {
         , autoOffTimeoutMs(0)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestBacklightSet) == 40, "RequestBacklightSet size must be 40 bytes");
+#endif
 
 /**
  * @brief Buzzer play request
@@ -346,7 +364,9 @@ struct RequestBuzzerPlay : public MessageBase {
         , notes {}
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestBuzzerPlay) == 116, "RequestBuzzerPlay size must be 116 bytes");
+#endif
 
 /**
  * @brief Vibration play request
@@ -394,7 +414,9 @@ struct RequestVibroPlay : public MessageBase {
         , notes {}
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestVibroPlay) == 100, "RequestVibroPlay size must be 100 bytes");
+#endif
 
 // =============================================================================
 // Event messages
@@ -416,7 +438,9 @@ struct EventSystemPowerLow : public MessageBase {
         , estimatedMinutes(0)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(EventSystemPowerLow) == 36, "EventSystemPowerLow size must be 36 bytes");
+#endif
 
 /**
  * @brief System power critical event
@@ -434,7 +458,9 @@ struct EventSystemPowerCritical : public MessageBase {
         , estimatedMinutes(0)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(EventSystemPowerCritical) == 36, "EventSystemPowerCritical size must be 36 bytes");
+#endif
 
 /**
  * @brief GUI frame tick command
@@ -452,7 +478,9 @@ struct EventGuiTick : public MessageBase {
         , timestamp(0)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(EventGuiTick) == 40, "EventGuiTick size must be 40 bytes");
+#endif
 
 /**
  * @brief Button event
@@ -500,7 +528,9 @@ struct EventButton : public MessageBase {
         , event(Event::PRESS)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(EventButton) == 40, "EventButton size must be 40 bytes");
+#endif
 
 // =============================================================================
 // Glance messages
@@ -524,7 +554,9 @@ struct RequestGlanceConfig : public MessageBase {
         , maxControls(0)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestGlanceConfig) == 40, "RequestGlanceConfig size must be 40 bytes");
+#endif
 
 /**
  * @brief Glance update request
@@ -544,7 +576,9 @@ struct RequestGlanceUpdate : public MessageBase {
         , controlsNumber(0)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(RequestGlanceUpdate) == 44, "RequestGlanceUpdate size must be 44 bytes");
+#endif
 
 /**
  * @brief Notify service that glance mode started
@@ -568,7 +602,9 @@ struct EventGlanceTick : public MessageBase {
         , timestamp(0)
     {}
 };
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(EventGlanceTick) == 40, "EventGlanceTick size must be 40 bytes");
+#endif
 
 /**
  * @brief Notify service that glance mode stopped

--- a/Libs/Header/SDK/Messages/MessageBase.hpp
+++ b/Libs/Header/SDK/Messages/MessageBase.hpp
@@ -294,11 +294,17 @@ private:
 
 // Verify memory layout assumptions
 // Note: Size includes vtable pointer (4 bytes on 32-bit systems)
+// Fix: Size checks are architecture-specific. MessageBase contains a void* field
+// and a vtable pointer, both of which are 8 bytes on 64-bit Linux, making the
+// struct 40 bytes instead of 32. The checks are skipped on 64-bit targets;
+// they remain active for the 32-bit ARM embedded build where layout matters.
 static_assert(sizeof(MessageResult) == 1, "MessageResult must be 1 byte");
 static_assert(sizeof(bool) == 1, "bool must be 1 byte");
 static_assert(sizeof(std::atomic<uint32_t>) == 4, "atomic<uint32_t> must be 4 bytes");
 static_assert(sizeof(std::atomic<bool>) == 1, "atomic<bool> must be 1 bytes");
+#if __SIZEOF_POINTER__ == 4
 static_assert(sizeof(MessageBase) == 32, "MessageBase size must be 32 bytes");
+#endif
 
 /**
  * @brief ID-only message without payload

--- a/Libs/Header/SDK/Simulator/Kernel/Mock/App.hpp
+++ b/Libs/Header/SDK/Simulator/Kernel/Mock/App.hpp
@@ -14,7 +14,9 @@
 #include <cstdint>
 #include <cstdarg>
 #include <stdio.h>
-#include <windows.h>
+#ifdef _WIN32
+#include <windows.h>  // Fix: was unconditional; not used on Linux
+#endif
 
 #include "SDK/Simulator/OS/OS.hpp"
 #include "SDK/Interfaces/IApp.hpp"

--- a/Libs/Header/SDK/Simulator/Kernel/Mock/Logger.hpp
+++ b/Libs/Header/SDK/Simulator/Kernel/Mock/Logger.hpp
@@ -17,6 +17,19 @@
 #include "SDK/Simulator/OS/OS.hpp"
 #include "touchgfx/Utils.hpp"
 
+// Fix: GetTickCount64() is Windows-only. Provide a portable wrapper.
+#ifndef _WIN32
+#include <cstdint>
+#include <time.h>
+static inline uint64_t GetTickCount64()
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<uint64_t>(ts.tv_sec) * 1000ULL +
+           static_cast<uint64_t>(ts.tv_nsec) / 1000000ULL;
+}
+#endif
+
 namespace SDK::Simulator::Mock
 {
 

--- a/Libs/Header/SDK/Simulator/OS/OS.hpp
+++ b/Libs/Header/SDK/Simulator/OS/OS.hpp
@@ -26,6 +26,7 @@
     #include <semaphore.h>
     #include <ctime>
     #include <atomic>
+    #include <array>  // Fix: <array> was missing in Linux build (std::array used by Queue<T,N>)
 #endif
 
 namespace OS {

--- a/Libs/Source/Simulator/Kernel/Mock/System.cpp
+++ b/Libs/Source/Simulator/Kernel/Mock/System.cpp
@@ -1,6 +1,24 @@
 
 #include "SDK/Simulator/Kernel/Mock/System.hpp"
 
+// Fix: GetTickCount64() and Sleep() are Windows-only. Provide portable replacements.
+#ifndef _WIN32
+#include <cstdint>
+#include <time.h>
+#include <unistd.h>
+static inline uint64_t GetTickCount64()
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<uint64_t>(ts.tv_sec) * 1000ULL +
+           static_cast<uint64_t>(ts.tv_nsec) / 1000000ULL;
+}
+static inline void Sleep(uint32_t ms)
+{
+    usleep(ms * 1000U);
+}
+#endif
+
 #define LOG_MODULE_PRX      "Mock.System"
 #define LOG_MODULE_LEVEL    LOG_LEVEL_DEBUG
 #include "SDK/UnaLogger/Logger.h"

--- a/Libs/Source/Wrappers/StdLibWrappers.c
+++ b/Libs/Source/Wrappers/StdLibWrappers.c
@@ -40,7 +40,7 @@ void safe_strcpy(char* dest, const char* src, size_t destSize)
 #ifdef _WIN32
     strncpy_s(dest, destSize, src, _TRUNCATE);      // Windows
 #else
-    std::strncpy(dest, src, destSize - 1);          // Linux, POSIX
+    strncpy(dest, src, destSize - 1);          // Linux, POSIX (fix: std:: is C++ only)
     dest[destSize - 1] = '\0';
 #endif
 }


### PR DESCRIPTION
## Problem

The TouchGFX simulator could not be built on x86-64 Linux (Ubuntu 24.04, GCC 13). Seven issues were found and fixed:

## Changes

### `Libs/Header/SDK/Simulator/OS/OS.hpp`
`OS::Queue<T,N>` uses `std::array<T,N>` but `#include <array>` was inside the `#ifdef _WIN32` block only. On Linux, `std::array` had only a forward declaration (pulled in transitively via `<tuple>`), causing an "incomplete type" error at template instantiation. Added `#include <array>` to the `#else` branch.

### `Libs/Header/SDK/Simulator/Kernel/Mock/App.hpp`
`#include <windows.h>` was unconditional at the top of the file. Nothing in the class body uses any Windows-specific type or function. Guarded with `#ifdef _WIN32`.

### `Libs/Header/SDK/Simulator/Kernel/Mock/Logger.hpp`
`GetTickCount64()` is a Win32 API. Added a portable inline wrapper using `clock_gettime(CLOCK_MONOTONIC)` under `#ifndef _WIN32`.

### `Libs/Source/Simulator/Kernel/Mock/System.cpp`
`GetTickCount64()` and `Sleep()` are Win32-only. Added local inline wrappers (`clock_gettime` / `usleep`) under `#ifndef _WIN32`.

### `Libs/Header/SDK/Messages/MessageBase.hpp`
`static_assert(sizeof(MessageBase) == 32)` fails on x86-64 because `void* mCompletionSemaphore` and the vtable pointer are each 8 bytes (not 4), making the struct 40 bytes. The assertion is correct for the embedded ARM build. Guarded with `#if __SIZEOF_POINTER__ == 4`.

### `Libs/Header/SDK/Messages/CommandMessages.hpp`
18 struct-size `static_assert`s that assume 32-bit pointer layout. Same rationale as above — guarded with `#if __SIZEOF_POINTER__ == 4`.

### `Libs/Source/Wrappers/StdLibWrappers.c`
The Linux branch used `std::strncpy` in a `.c` file. `std::` is a C++ namespace and GCC 13 rejects it in C translation units. Replaced with plain `strncpy`.

## Notes

- All changes are backward-compatible. Windows simulator and ARM embedded builds are unaffected.
- The `MessageBase` / `CommandMessages` size assertions remain active for ARM (`__SIZEOF_POINTER__ == 4`) where binary layout matters.
- On x86-64, the structs are larger but the simulator runs both GUI and service in the same process, so both sides see the same layout.
- Full rationale documented in `Docs/SDK_LINUX_FIXES.md`.

## Test

Built and ran the TouchGFX simulator on Ubuntu 24.04 (GCC 13.3, x86-64) inside a Docker dev container. GUI renders correctly, screen navigation works.