### PR TITLE
Simulator: add sensor layer mock handlers in KernelMessageDispatcher

### DIFF
--- a/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
+++ b/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
@@ -7,6 +7,7 @@
 
 #include "SDK/Simulator/App/KernelMessageDispatcher.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
+#include "SDK/Messages/SensorLayerMessages.hpp"
 
 #include <cstring>
 #include <memory>
@@ -437,6 +438,25 @@ void KernelMessageDispatcher::appMsgHandler(SDK::MessageBase* msg)
             //}
         }
 
+        mMessageManager.signalCompletion(msg, SDK::MessageResult::SUCCESS);
+    } break;
+
+    // Sensor Layer mock: respond SUCCESS so SensorConnection::subscribe() succeeds.
+    // No real sensor driver exists in the simulator; Service.cpp injects mock data directly.
+    case SDK::MessageType::REQUEST_SENSOR_LAYER_GET_DEFAULT: {
+        LOG_DEBUG("Sensor: RequestDefault (mock)\n");
+        auto* req = static_cast<SDK::Message::Sensor::RequestDefault*>(msg);
+        req->handle = static_cast<uint32_t>(req->id); // use type ID as unique handle
+        mMessageManager.signalCompletion(msg, SDK::MessageResult::SUCCESS);
+    } break;
+
+    case SDK::MessageType::REQUEST_SENSOR_LAYER_CONNECT: {
+        LOG_DEBUG("Sensor: RequestConnect (mock)\n");
+        mMessageManager.signalCompletion(msg, SDK::MessageResult::SUCCESS);
+    } break;
+
+    case SDK::MessageType::REQUEST_SENSOR_LAYER_DISCONNECT: {
+        LOG_DEBUG("Sensor: RequestDisconnect (mock)\n");
         mMessageManager.signalCompletion(msg, SDK::MessageResult::SUCCESS);
     } break;
 


### PR DESCRIPTION
## Summary

- `REQUEST_SENSOR_LAYER_GET_DEFAULT`, `REQUEST_SENSOR_LAYER_CONNECT`, and `REQUEST_SENSOR_LAYER_DISCONNECT` were falling through to the `default:` case in `KernelMessageDispatcher::appMsgHandler()`, so they were silently ignored
- This caused `SensorConnection::subscribe()` to never receive a `SUCCESS` result, making all sensor connections fail in the Linux x86-64 simulator
- Add minimal mock responses (return SUCCESS, assign handle = type ID for GET_DEFAULT) so apps can connect sensors and inject mock data directly in simulator builds

## Test plan

- [ ] Build Linux simulator for an app that uses sensors (e.g. Running, Rowing)
- [ ] Confirm sensor `subscribe()` returns true and connect succeeds in logs
- [ ] Confirm app logic that depends on sensors runs (e.g. GPS mock data flows through)

Relates to the existing Linux compatibility work in PR #66.