### PR TITLE
Updated text around copying tutorials and touchgfx files

### DIFF
--- a/Docs/Tutorials/Buttons/ARCHITECTURE.md
+++ b/Docs/Tutorials/Buttons/ARCHITECTURE.md
@@ -106,11 +106,11 @@ After changing screen properties (like color), the `invalidate()` method is call
 ## Buttons app creation process
 
 1. **Copy HelloWorld tutorial**
-2. **Change naming**: Rename project directory, cmake directory and name of the project in CMakeLists.txt; Also change APP_ID to something else.
+2. **Change naming**: Rename project directory, cmake directory and name of the project in CMakeLists.txt; Also change APP_ID to something else. Step 2 in [Creating New Apps](https://www.developers.unawatch.com/latest/sdk-setup.html#creating-new-apps) gives commmands for generating your own APP ID programatically from the name. 
 3. **Commit initial changes**: it's a good practice to use version control system like git
 4. ***Edit TouchGFX**: 
-   - Rename `*.touchgfx` to `Buttons.touchgfx`
-   - Rename `Buttons.touchgfx:163` `"Name": "Buttons"`
+   - Rename `*.touchgfx` to `<MY_APP>.touchgfx`
+   - Rename the 'Name' field in Buttons.touchgfx at line 163: `Buttons.touchgfx:163` `"Name": "Buttons"` to `"Name": "<MY_APP>"`
    - Add 240x240 a box `box1` at X:0 Y:0
    - Click **Generate code**
 5. **Edit MainView.cpp**: 

--- a/Docs/Tutorials/Images/ARCHITECTURE.md
+++ b/Docs/Tutorials/Images/ARCHITECTURE.md
@@ -131,7 +131,9 @@ Follow these steps to import and display images in your UNA app:
 
 2. **Navigate to the Images tab** in TouchGFX Designer
 
-3. **Click "Import Images"** and select your `my_image.png` file\n\n   ![Add Image Button](doc-assets/add-image-button.png)
+3. **Click "Import Images"** and select your `my_image.png` file   
+
+![Add Image Button](doc-assets/add-image-button.png)
 
 4. **Configure image settings**:
     - Choose appropriate color format (RGB565, ARGB8888, etc.)
@@ -139,7 +141,10 @@ Follow these steps to import and display images in your UNA app:
     - Set compression options
 
 5. **Generate code** after importing:
-    - Click "Generate Code" in TouchGFX Designer\n\n   ![Generated Image Asset](doc-assets/generated-image-asset.png)
+    - Click "Generate Code" in TouchGFX Designer
+
+![Generated Image Asset](doc-assets/generated-image-asset.png)
+
     - This creates bitmap IDs and conversion code
 
 ### Step 3: Display the Image in Code

--- a/Docs/Tutorials/ScrollMenu/ARCHITECTURE.md
+++ b/Docs/Tutorials/ScrollMenu/ARCHITECTURE.md
@@ -114,7 +114,7 @@ After performing actions that change the menu display (such as updating the coun
 ## ScrollMenu app creation process
 
 1. **Copy HelloWorld tutorial**
-2. **Change naming**: Rename project directory, cmake directory and name of the project in CMakeLists.txt; Also change APP_ID to something else.
+2. **Change naming**: Rename project directory, cmake directory and name of the project in CMakeLists.txt; Also change APP_ID to something else. Step 2 in [Creating New Apps](https://www.developers.unawatch.com/latest/sdk-setup.html#creating-new-apps) gives commmands for generating your own APP ID programatically from the name. 
 3. **Commit initial changes**: it's a good practice to use version control system like git
 4. ***Add text keys using TouchGFX Designer**:
     - In TouchGFX Designer, go to the **Texts** tab
@@ -125,8 +125,8 @@ After performing actions that change the menu display (such as updating the coun
       - **Text Id**: "Decrease", **Alignment**: Center, **Typography**: Poppins_Medium_25, **Translation (GB)**: "Decrease"
     - These will generate the text keys T_COUNTER, T_INCREASE, T_DECREASE used in the code
 5. ***Edit TouchGFX**: 
-   - Rename `*.touchgfx` to `ScrollMenu.touchgfx`
-   - Rename `ScrollMenu.touchgfx:163` `"Name": "ScrollMenu"`
+   - Rename `*.touchgfx` to `MY_APP.touchgfx`
+   - Rename `ScrollMenu.touchgfx:163` `"Name": "MY_APP"`
    - Open the main screen in the designer
    - From the widget palette, locate and drag a **Menu** widget onto the main screen canvas
    - Name the menu widget `menu1` in the properties panel

--- a/Docs/Tutorials/Sensors/ARCHITECTURE.md
+++ b/Docs/Tutorials/Sensors/ARCHITECTURE.md
@@ -41,6 +41,19 @@ graph LR
 
 ## Implementation Steps
 
+
+### Optional step: copy the Sensor tutorial code to edit
+1. **Copy sensors tutorial**
+2. **Change naming**: Rename project directory, cmake directory and name of the project in CMakeLists.txt; Also change APP_ID to something else, Step 2 in [Creating New Apps](https://www.developers.unawatch.com/latest/sdk-setup.html#creating-new-apps) gives commmands for generating your own app ID programatically from the name. 
+3. **Commit initial changes**: it's a good practice to use version control system like git
+4. ***Edit TouchGFX if you changed the name**: 
+   - Rename `*.touchgfx` to `<MY_APP>.touchgfx`
+   - Rename `*.touchgfx:163` `"Name": "MY_APP"`
+   - Click **Generate code**
+
+
+
+
 ### Step 1: Define Custom Messages
 
 Create [`Commands.hpp`](Software/Libs/Header/Commands.hpp) with message types and structs:


### PR DESCRIPTION
      Modified the following markdown files to add new text for how to copy Tutorials as well as how naming the touch gfx files works when you rename the project. 
      
         
        modified:   Docs/Tutorials/Buttons/ARCHITECTURE.md
        modified:   Docs/Tutorials/Images/ARCHITECTURE.md
        modified:   Docs/Tutorials/ScrollMenu/ARCHITECTURE.md
        modified:   Docs/Tutorials/Sensors/ARCHITECTURE.md
