### PR TITLE
Remove KeepEmptyLinesAtStartOfBlocks option

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -63,7 +63,6 @@ IndentCaseLabels: true
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtStartOfBlocks: false
 MacroBlockBegin: ''
 MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1


### PR DESCRIPTION
Remove KeepEmptyLinesAtStartOfBlocks setting as it causes an error in VisualStudio