### PR TITLE
fix(ci): fix release permissions in sdk-release and tutorials-ci

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -30,14 +30,12 @@ jobs:
         with:
           fetch-depth: 0
           submodules: false
-          token: ${{ secrets.CROSS_REPO_PAT }}
 
       - id: create_release
         name: Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          token: ${{ secrets.CROSS_REPO_PAT }}
 
       - name: Make release immutable
         run: |

--- a/.github/workflows/tutorials-ci.yml
+++ b/.github/workflows/tutorials-ci.yml
@@ -73,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: cmake-build
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
sdk-release.yml: remove CROSS_REPO_PAT from checkout and release steps — GITHUB_TOKEN is sufficient since there are no submodules being checked out.

tutorials-ci.yml: add permissions.contents: write to release job — softprops/action-gh-release requires write access to upload release assets.