### PR TITLE
fix(ci): use event context for slack params and truncate long body

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -42,17 +42,20 @@ jobs:
 
       - id: get_slack_params
         name: Get required parameters for slack notification
-        run: |
-          RELEASE_JSON=$(gh release view ${{ github.ref_name }} --json name,body,author,createdAt,url)
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          echo "$RELEASE_JSON" | jq -r '.body' >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          echo "author=$(echo \"$RELEASE_JSON\" | jq -r '.author.login')" >> $GITHUB_OUTPUT
-          echo "created_at=$(echo \"$RELEASE_JSON\" | jq -r '.createdAt')" >> $GITHUB_OUTPUT
-          echo "name=$(echo \"$RELEASE_JSON\" | jq -r '.name')" >> $GITHUB_OUTPUT
-          echo "url=$(echo \"$RELEASE_JSON\" | jq -r '.url')" >> $GITHUB_OUTPUT
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_AUTHOR: ${{ github.event.release.author.login }}
+          RELEASE_CREATED: ${{ github.event.release.created_at }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "$RELEASE_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "author=$RELEASE_AUTHOR" >> $GITHUB_OUTPUT
+          echo "created_at=$RELEASE_CREATED" >> $GITHUB_OUTPUT
+          echo "name=$RELEASE_NAME" >> $GITHUB_OUTPUT
+          echo "url=$RELEASE_URL" >> $GITHUB_OUTPUT
 
       - id: prepare_slack_payload
         name: Prepare Slack payload
@@ -67,6 +70,7 @@ jobs:
           BODY=$(echo "$BODY" | perl -pe 's/@\([a-zA-Z0-9_-]*\)/<https:\/\/github.com\/$1|@$1>/g' || { echo "Error converting mentions"; exit 1; })  # Mentions
           BODY=$(echo "$BODY" | perl -pe 's/\*\*Full Changelog\*\*:/ *Full Changelog*\n/' || { echo "Error adjusting changelog"; exit 1; })  # Changelog
           BODY=$(echo "$BODY" | perl -pe 's/"/\\"/g' || { echo "Error escaping quotes"; exit 1; })  # Escape double quotes
+          if [ ${#BODY} -gt 2700 ]; then BODY="${BODY:0:2700}"$'\n''...'; fi
           PAYLOAD=$(jq -c -n --arg name "${{ steps.get_slack_params.outputs.name }}" --arg tag "${{ github.ref_name }}" --arg body "$BODY" --arg author "${{ steps.get_slack_params.outputs.author }}" --arg created "${{ steps.get_slack_params.outputs.created_at }}" --arg url "${{ steps.get_slack_params.outputs.url }}" '{
             text: (":books: *UNA SDK*: " + $name),
             blocks: [


### PR DESCRIPTION
Replace gh release view API call with github.event.release.* context variables — no API call needed, fields are always populated correctly.

Truncate release body to 2700 chars after markdown conversion to stay within Slack's 3000-char block text limit.