### PR TITLE
docs: remove broken version selector

### DIFF
--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -55,7 +55,7 @@ language = 'en'
 
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
-html_js_files = ['version-selector.js']
+html_js_files = []
 html_css_files = ['custom.css']
 
 # -- Options for intersphinx extension ---------------------------------------


### PR DESCRIPTION
version selector not showing docs for older branches, so removed it