### PR TITLE
fix(simulator): remove double destructor in MessageManager::releaseMessage

### DIFF
--- a/Libs/Source/Simulator/App/MessageManager.cpp
+++ b/Libs/Source/Simulator/App/MessageManager.cpp
@@ -69,10 +69,8 @@ void MessageManager::releaseMessage(SDK::MessageBase* msg)
     if (oldCount == 1) {
         // Cleanup completion semaphore if exists
         cleanupCompletionSemaphore(msg);
-        // Call virtual destructor
-        msg->~MessageBase();
-
-		delete msg;
+        // operator delete is a no-op (pool allocator); this calls the virtual dtor once
+        delete msg;
     }
 }
 


### PR DESCRIPTION
Without this fix, pressing the exit key (key 4 / R2 / BACK) crashes the
simulator on shutdown:

```
  pure virtual method called
  terminate called without an active exception
  Aborted (core dumped)
```

The cause: releaseMessage() called msg->~MessageBase() explicitly before delete msg, invoking the virtual destructor twice. After the first call the vptr is reset to MessageBase's vtable; the subsequent delete dispatches through the base-class vtable and hits pure-virtual stubs in the derived message type's destructor.

Remove the explicit call so delete invokes the virtual dtor exactly once. operator delete is a no-op pool allocator and is unaffected.