### PR TITLE
fix(simulator): remove cross-thread handleTickEvent calls in AppCore::run

### DIFF
--- a/Libs/Source/Simulator/App/AppCore.cpp
+++ b/Libs/Source/Simulator/App/AppCore.cpp
@@ -9,7 +9,6 @@
 #include "SDK/Messages/MessageGuard.hpp"
 #include "SDK/Messages/MessageTypes.hpp"
 
-#include <gui/common/FrontendApplication.hpp>
 #include "SDK/Port/TouchGFX/TouchGFXCommandProcessor.hpp"
 
 #include <cstring>
@@ -63,8 +62,6 @@ namespace App {
 				break;
 			}
 		}
-
-		FrontendApplication& app = *static_cast<FrontendApplication*>(touchgfx::Application::getInstance());
 
 		mAppComm.sendToGui(SDK::make_msg(mSrvKernel.getKernel(), SDK::MessageType::COMMAND_APP_GUI_SUSPEND).release());
 		SDK::TouchGFXCommandProcessor::GetInstance().waitForFrameTick();


### PR DESCRIPTION
Without this fix, pressing the exit key (key 4 / R2 / BACK) crashes the simulator on shutdown:

```
  pure virtual method called
  terminate called without an active exception
  Aborted (core dumped)
```

The cause: AppCore::run() called app.handleTickEvent() from the kernel background thread after taskEntry() had already returned on the main thread. handleTickEvent() dispatches through FrontendApplication into the TouchGFX screen/presenter virtual chain — but those objects are already torn down at that point, so the call hits pure-virtual stubs.

Remove both handleTickEvent() calls and the now-unused FrontendApplication include. The queued COMMAND_APP_GUI_SUSPEND and COMMAND_APP_STOP messages are drained by ~DualAppComm()::clearAllQueues() during normal shutdown.