### PR TITLE
docs: align project structure trees with actual layout

### DIFF
--- a/Docs/sdk-overview.md
+++ b/Docs/sdk-overview.md
@@ -19,23 +19,28 @@ To start using this SDK, see the [SDK setup](sdk-setup.md)
 ## SDK Project Structure
 
 ```
-SDK/
+una-sdk/
 ├── Libs/
-│   ├── Header/SDK/           # SDK Interface Headers
+│   ├── Header/SDK/           # Public SDK headers
 │   │   ├── Interfaces/       # Core API interfaces
 │   │   ├── Messages/         # Message type definitions
 │   │   ├── SensorLayer/      # Sensor data structures
 │   │   ├── Kernel/           # Kernel provider interfaces
+│   │   ├── Port/             # Platform port headers (TouchGFX)
+│   │   ├── Simulator/        # Simulator headers (mocks, sim sensors)
 │   │   └── Wrappers/         # Standard library wrappers
-│   └── Source/SDK/           # SDK Implementation
-├── Port/
-│   └── TouchGFX/             # TouchGFX integration
-├── ThirdParty/               # External dependencies
-│   ├── coreJSON/            # JSON parsing library
-│   └── FitSDK/              # Fitness data format
+│   └── Source/               # SDK implementation
+│       ├── Port/TouchGFX/    # TouchGFX integration
+│       └── Simulator/        # Mock kernel and desktop simulator runtime
+├── ThirdParty/               # Vendored dependencies
+│   ├── coreJSON/             # JSON parsing library
+│   ├── FitSDKRelease_21.171.00/  # Garmin FIT format
+│   ├── tinycbor_version/     # CBOR encoder/decoder
+│   └── touchgfx/             # TouchGFX framework (sources + prebuilt libs)
 ├── Utilities/Scripts/        # Build and packaging tools
-├── Simulator/                # Development simulator
-└── Visual Studio/            # Windows development support
+├── Examples/                 # Sample applications (git submodule -> UNAWatch/una-apps)
+├── cmake/                    # CMake toolchain and helpers
+└── Docs/                     # Documentation and tutorials
 ```
 
 ### High-Level Utilities

--- a/README.md
+++ b/README.md
@@ -26,16 +26,15 @@ For full setup instructions (Linux/Windows, toolchain, environment variables, an
 ### SDK Project Structure
 
 ```
-SDK/
-├── Libs/                    # SDK Interface Headers and Implementation
-│   ├── Header/SDK/         # Core API interfaces
-│   └── Source/SDK/         # SDK Implementation
-├── Port/                   # Platform-specific integrations
-├── ThirdParty/             # External dependencies (coreJSON, FitSDK)
-├── Utilities/Scripts/      # Build and packaging tools
-├── Examples/              # Sample applications
-├── cmake/                 # CMake build system files
-└── Simulator/             # Development simulator
+una-sdk/
+├── Libs/
+│   ├── Header/SDK/         # Public SDK headers (Interfaces, Messages, Kernel, Simulator, Port, ...)
+│   └── Source/             # SDK implementation (incl. Port/TouchGFX and Simulator)
+├── ThirdParty/             # Vendored dependencies (TouchGFX, coreJSON, FitSDK, tinycbor)
+├── Utilities/Scripts/      # Build, packaging, and tooling scripts
+├── Examples/               # Sample applications (git submodule -> UNAWatch/una-apps)
+├── cmake/                  # CMake toolchain and helpers
+└── Docs/                   # Documentation and tutorials
 ```
 
 ### High-Level Utilities


### PR DESCRIPTION
Both the README and sdk-overview tree diagrams listed top-level Port/, Simulator/, and Visual Studio/ directories that don't exist. Port and Simulator actually live under Libs/{Header/SDK,Source}/, and the ThirdParty list omitted touchgfx and tinycbor. Update both trees to match the on-disk layout.