### PR TITLE
fix(cmake): point UNA_SDK_INCLUDE_DIRS_GUI at the actual header location

### DIFF
--- a/cmake/una-sdk.cmake
+++ b/cmake/una-sdk.cmake
@@ -78,8 +78,8 @@ set(UNA_SDK_INCLUDE_DIRS_JSON
 )
 
 set(UNA_SDK_INCLUDE_DIRS_GUI
-    "$ENV{UNA_SDK}/Libs/include/Port/TouchGFX"
-    "$ENV{UNA_SDK}/Libs/include/Port/TouchGFX/generated"
+    "$ENV{UNA_SDK}/Libs/Header/SDK/Port/TouchGFX"
+    "$ENV{UNA_SDK}/Libs/Header/SDK/Port/TouchGFX/generated"
 )
 
 # Combined service includes for backward compatibility


### PR DESCRIPTION
The two paths in UNA_SDK_INCLUDE_DIRS_GUI referenced $UNA_SDK/Libs/include/Port/TouchGFX[/generated], but Libs/include/ does not exist; the TouchGFX port headers live at Libs/Header/SDK/Port/TouchGFX/.

Introduced in a2af5cb ("build: update SDK paths to new Libs structure"), which moved the TouchGFX sources to Libs/Source/Port/TouchGFX/ correctly but mis-targeted the include side at Libs/include/ instead of Libs/Header/SDK/. The breakage went unnoticed because every TouchGFX cpp includes its headers via "SDK/Port/TouchGFX/..." long paths that resolve through UNA_SDK_INCLUDE_DIRS_COMMON ($UNA_SDK/Libs/Header), so the dangling -I flags from the GUI variable were silently ignored by the compiler.

Repoint both entries at Libs/Header/SDK/Port/TouchGFX[/generated] so the variable matches reality and short-form includes from GUI sources will work if anyone adds them.