### PR TITLE
fix(simulator): seek() must move both read and write positions

### DIFF
--- a/Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp
+++ b/Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp
@@ -161,6 +161,7 @@ bool File::seek(size_t offset)
 {
     if (!isOpenFlag) return false;
     file.seekg(offset);
+    file.seekp(offset);
     return !file.fail();
 }
 


### PR DESCRIPTION
  ## Bug
  
`std::fstream` maintains independent read (`seekg`) and write (`seekp`) positions. `File::seek()` moved only `seekg`, leaving `seekp` unchanged. Any `write()` call after `seek()` therefore appended to end-of-file instead of writing at the requested offset silently, with no error.
  
## Impact
  
  Any code that writes a file, seeks back to patch an earlier field, then writes again produces a corrupt file. The concrete failure is in the FIT activity writer: it writes the file header with `data_size = 0`, fills in all message data, then seeks to byte 0 to rewrite the header with the correct `data_size`. With the bug, the corrected header is appended at the end instead, leaving `data_size = 0` forever. Every FIT file produced by the SDK fails validation.
  
Before / After

  Before: data_size is always 0; validator rejects the file:
  File size : 606 bytes
  Header    : data_size=0

  After: header matches actual content; file passes validation, e.g.:
  File size : 738 bytes
  Header    : data_size=722
  Match     : True  (14 + 722 + 2 == 738)