### PR TITLE
build(simulator): add -no-pie to Linux linker options for tutorial apps

### DIFF
--- a/Docs/Tutorials/Buttons/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Docs/Tutorials/Buttons/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32

--- a/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32

--- a/Docs/Tutorials/HelloWorld/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Docs/Tutorials/HelloWorld/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32

--- a/Docs/Tutorials/Images/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Docs/Tutorials/Images/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32

--- a/Docs/Tutorials/ScrollMenu/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Docs/Tutorials/ScrollMenu/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32

--- a/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32


### PR DESCRIPTION
Adds the -no-pie flag to the Linux linker_options in all six tutorial una/Makefiles (HelloWorld, Sensors, Buttons, Files, Images, ScrollMenu). The change is inside the ifeq ($(UNAME), Linux) branch and does not affect the Windows build.

Without this change, building the simulator on modern Linux toolchains fails at link time. The pre-built lib/linux/libtouchgfx.a shipped with the SDK is not compiled with -fPIE, while contemporary GCC defaults to PIE for executables (Ubuntu 18.04+, Debian 10+, Fedora 23+). Linking non-PIE archive objects into a PIE executable produces relocation errors such as:

  relocation R_X86_64_32 against \`.rodata' can not be used when making a PIE object; recompile with -fPIE

With -no-pie, the executable is linked as a position-dependent binary, which matches the build mode of the pre-built libtouchgfx.a and lets the link succeed.