### PR TITLE
fix(simulator): make Windows.h includes Linux-safe

### DIFF
--- a/Docs/Tutorials/Buttons/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Docs/Tutorials/Buttons/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -11,7 +11,9 @@
 
 #if defined(SIMULATOR)
     #include "touchgfx/canvas_widget_renderer/CanvasWidgetRenderer.hpp"
+    #ifdef _WIN32
     #include "Windows.h"
+    #endif
     #include <chrono>
     #include <ctime>
 #endif

--- a/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -11,7 +11,9 @@
 
 #if defined(SIMULATOR)
     #include "touchgfx/canvas_widget_renderer/CanvasWidgetRenderer.hpp"
+    #ifdef _WIN32
     #include "Windows.h"
+    #endif
     #include <chrono>
     #include <ctime>
 #endif

--- a/Docs/Tutorials/HelloWorld/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Docs/Tutorials/HelloWorld/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -11,7 +11,9 @@
 
 #if defined(SIMULATOR)
     #include "touchgfx/canvas_widget_renderer/CanvasWidgetRenderer.hpp"
+    #ifdef _WIN32
     #include "Windows.h"
+    #endif
     #include <chrono>
     #include <ctime>
 #endif

--- a/Docs/Tutorials/Images/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Docs/Tutorials/Images/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -11,7 +11,9 @@
 
 #if defined(SIMULATOR)
     #include "touchgfx/canvas_widget_renderer/CanvasWidgetRenderer.hpp"
+    #ifdef _WIN32
     #include "Windows.h"
+    #endif
     #include <chrono>
     #include <ctime>
 #endif

--- a/Docs/Tutorials/ScrollMenu/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Docs/Tutorials/ScrollMenu/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -11,7 +11,9 @@
 
 #if defined(SIMULATOR)
     #include "touchgfx/canvas_widget_renderer/CanvasWidgetRenderer.hpp"
+    #ifdef _WIN32
     #include "Windows.h"
+    #endif
     #include <chrono>
     #include <ctime>
 #endif

--- a/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -11,7 +11,9 @@
 
 #if defined(SIMULATOR)
     #include "touchgfx/canvas_widget_renderer/CanvasWidgetRenderer.hpp"
+    #ifdef _WIN32
     #include "Windows.h"
+    #endif
     #include <chrono>
     #include <ctime>
 #endif

--- a/Libs/Source/Simulator/OS/SwTimer.cpp
+++ b/Libs/Source/Simulator/OS/SwTimer.cpp
@@ -1,5 +1,4 @@
 #include "SDK/Simulator/OS/SwTimer.hpp"
-#include <windows.h>
 #include <cstdint>
 #include <chrono>
 


### PR DESCRIPTION
Six tutorial Model.cpp files (HelloWorld, Sensors, Buttons, Files, Images, ScrollMenu) and the SDK's SwTimer.cpp unconditionally included a Windows header inside a section guarded only by SIMULATOR. The header doesn't exist on Linux, so the simulator build fails there with "fatal error: Windows.h: No such file or directory" before any source has a chance to compile.

Follows the same approach as #123 (rebase of #66), which fixed the equivalent issue in the SDK-side mock layer. That PR's commit (e2b8fc6) wrapped the `Kernel/Mock/App.hpp` `windows.h` include in `#ifdef _WIN32`; this one applies the same pattern to the remaining unguarded Windows headers in the tutorials and SwTimer.cpp.

In the tutorial Model.cpp files the include sits next to <chrono> and <ctime> in a block already wrapped in `#if defined(SIMULATOR)`. The simulator code in these files calls no Windows API, so the header is dead even on Windows, but the minimum-risk fix is to wrap it in `#ifdef _WIN32` / `#endif` rather than delete it.

SwTimer.cpp's `#include <windows.h>` is dead unconditionally — the file's only function uses `std::chrono::steady_clock` and references no Win32 symbol. It is removed outright rather than guarded.

Impact on Windows: none. Windows.h is still included where it was before; <windows.h> in SwTimer.cpp was not contributing any symbol used by the file.

Impact on Linux: the simulator can compile these translation units.