### PR TITLE
fix(simulator): Directory::readNext returns one entry per call

### DIFF
--- a/Libs/Header/SDK/Simulator/Kernel/Mock/FileSystem.hpp
+++ b/Libs/Header/SDK/Simulator/Kernel/Mock/FileSystem.hpp
@@ -97,6 +97,7 @@ private:
     HANDLE handle;
     WIN32_FIND_DATAA findData;
     bool isOpenFlag = false;
+    bool hasEntry = false; // 'true' when findData holds an entry not yet returned by readNext
     char pathBuffer[SDK::Interface::IFileSystem::skMaxPathLen]; // Buffer to hold the path without prefix
 
     const char *mPathPrefix;

--- a/Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp
+++ b/Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp
@@ -258,6 +258,7 @@ bool Directory::open()
     std::string searchPath = path + "/*";
     handle = FindFirstFileA(searchPath.c_str(), &findData);
     isOpenFlag = (handle != INVALID_HANDLE_VALUE);
+    hasEntry = isOpenFlag;
     return isOpenFlag;
 }
 
@@ -272,17 +273,19 @@ bool Directory::readNext(SDK::Interface::IFileSystem::ObjectInfo &item, bool res
 
     if (reset) {
         FindClose(handle);
-        open();
+        return open();
     }
 
-    do {
-        safe_strcpy(item.name, findData.cFileName, sizeof(item.name));
-        item.isDir = (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
-        item.isHidden = (findData.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0;
-        item.isSystem = (findData.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM) != 0;
-        item.size = findData.nFileSizeLow;
-        item.utc = FileTimeToUnixTime(findData.ftCreationTime);
-    } while (FindNextFileA(handle, &findData));
+    if (!hasEntry) return false;
+
+    safe_strcpy(item.name, findData.cFileName, sizeof(item.name));
+    item.isDir = (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+    item.isHidden = (findData.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0;
+    item.isSystem = (findData.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM) != 0;
+    item.size = findData.nFileSizeLow;
+    item.utc = FileTimeToUnixTime(findData.ftCreationTime);
+
+    hasEntry = (FindNextFileA(handle, &findData) != 0);
 
     return true;
 }
@@ -292,6 +295,7 @@ bool Directory::close()
     if (isOpenFlag) {
         FindClose(handle);
         isOpenFlag = false;
+        hasEntry = false;
         return true;
     }
     return false;


### PR DESCRIPTION
Aligns Mock::Directory::readNext with the IDirectory contract.

readNext is a cursor: one entry per call, advancing each time, returning false when there's nothing left. reset is a pure rewind that returns without reading and leaves item alone. That's now spelled out in the IFileSystem.hpp doxygen (#163).

The mock doesn't do that. It loops over the whole directory in one do/while and always returns true:
```
do {
    safe_strcpy(item.name, findData.cFileName, ...);
    ...
} while (FindNextFileA(handle, &findData));
return true;
```

So the first call after open() runs through every entry and leaves item on the last one. Later calls re-run the body with stale findData and keep handing back that same last entry, with no way to signal "done", so while (dir->readNext(info)) never ends.

The fix keeps the Win32 calls (FindFirstFileA, FindNextFileA, FindClose) and adds a hasEntry flag for whether findData holds an entry that hasn't been returned yet:

- open() sets hasEntry from the open result, so the first readNext already has FindFirstFileA's entry ready.
- readNext() with reset reopens to rewind and returns right away without reading; the next call returns the first entry. Otherwise it returns false when there's no entry, copies findData into item, advances with FindNextFileA, and updates hasEntry.
- close() clears hasEntry so a stale entry can't survive open/close/open.

Same entries (including "." and "..") in the same order as before.

Nothing in the SDK, the Examples submodule, or the tutorials calls readNext today, so this is safe to land.
