### PR TITLE
TouchGFX Bug reproduction for drawPartialBitmap Y-clipping bug

### DIFF
--- a/Docs/Tutorials/HelloWorld/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
+++ b/Docs/Tutorials/HelloWorld/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
@@ -3,6 +3,47 @@
 
 #include <gui_generated/main_screen/MainViewBase.hpp>
 #include <gui/main_screen/MainPresenter.hpp>
+#include <touchgfx/widgets/Widget.hpp>
+#include <touchgfx/Bitmap.hpp>
+#include <touchgfx/hal/HAL.hpp>
+
+// Minimal reproduction for a Y-clipping defect in
+// LCD::drawPartialBitmap, observed on the Linux simulator with the
+// prebuilt libtouchgfx.a 4.26.1. The widget draws a 50x50 ABGR2222
+// dynamic external bitmap at screen (60, 220) so the source rect
+// extends 30 px past the bottom of the 240x240 dirty rect, exercising
+// the renderer's clipping path.
+//
+// Expected: a single red strip about 20 rows tall near the bottom of
+// the widget; the upper part shows the default HelloWorld content.
+//
+// On the defective build, a second red strip also appears near the
+// top of the widget because the clipping path writes destination rows
+// starting at dirtyRect.y instead of screenY. Two red strips means
+// the bug reproduces on your platform; a single strip near the bottom
+// means it does not.
+class DrawPartialBitmapBugRepro : public touchgfx::Widget
+{
+public:
+    void setBitmap(touchgfx::BitmapId id) { mId = id; invalidate(); }
+
+    virtual void draw(const touchgfx::Rect& /*area*/) const override
+    {
+        if (mId == touchgfx::BITMAP_INVALID) {
+            return;
+        }
+        touchgfx::Bitmap bmp(mId);
+        const touchgfx::Rect src(0, 0,
+            static_cast<int16_t>(bmp.getWidth()),
+            static_cast<int16_t>(bmp.getHeight()));
+        touchgfx::HAL::lcd().drawPartialBitmap(bmp, 60, 220, src, 255, true);
+    }
+
+    virtual touchgfx::Rect getSolidRect() const override { return touchgfx::Rect(); }
+
+private:
+    touchgfx::BitmapId mId = touchgfx::BITMAP_INVALID;
+};
 
 class MainView : public MainViewBase
 {
@@ -14,6 +55,9 @@ public:
 
 protected:
     virtual void handleKeyEvent(uint8_t key) override;
+
+private:
+    DrawPartialBitmapBugRepro reproWidget;
 };
 
 #endif // MAINVIEW_HPP

--- a/Docs/Tutorials/HelloWorld/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
+++ b/Docs/Tutorials/HelloWorld/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
@@ -1,5 +1,15 @@
 #include <gui/main_screen/MainView.hpp>
 
+namespace
+{
+// ABGR2222: one byte per pixel, bits MSB->LSB are AABBGGRR. Opaque
+// red is alpha=3, blue=0, green=0, red=3 -> 0b11000011 = 0xC3.
+constexpr uint8_t kABGR_Red = 0xC3;
+constexpr uint16_t kReproDim = 50;
+uint8_t  sReproPattern[kReproDim * kReproDim];
+uint16_t sReproPool[2048];
+} // namespace
+
 MainView::MainView()
 {
 
@@ -8,6 +18,17 @@ MainView::MainView()
 void MainView::setupScreen()
 {
     MainViewBase::setupScreen();
+
+    for (size_t i = 0; i < sizeof(sReproPattern); ++i) {
+        sReproPattern[i] = kABGR_Red;
+    }
+    touchgfx::Bitmap::setCache(sReproPool, sizeof(sReproPool), 1);
+    const touchgfx::BitmapId id = touchgfx::Bitmap::dynamicBitmapCreateExternal(
+        kReproDim, kReproDim, sReproPattern, touchgfx::Bitmap::ABGR2222);
+
+    reproWidget.setPosition(0, 0, 240, 240);
+    reproWidget.setBitmap(id);
+    add(reproWidget);
 
     buttons.setL1(ButtonsSet::NONE);
     buttons.setL2(ButtonsSet::NONE);


### PR DESCRIPTION
**Do not merge**

This is a quirky one that is ultimately a bug with TouchGFX. It's definitely a bug on Linux, this branch is intended to be a disposable, easy-to-reproduce case to see if it also impacts Windows. I'll open a bug with STM regardless. I ran into this trying to get maps loading on the simulator.

If someone on Windows is able to check out this branch and run this, update with the outcome, then this is the expectation:

| Expected | Bug |
|--------|--------|
| <img width="240" height="240" alt="pr-screenshot-fix" src="https://github.com/user-attachments/assets/947c4bee-9f32-4379-985f-ae97e55c0a45" /> | <img width="240" height="240" alt="pr-screenshot-bug" src="https://github.com/user-attachments/assets/662c3fd1-6cbb-48b5-9b8e-b2d70a339bd3" /> | 

When you draw an ABGR2222 dynamic-external bitmap with LCD::drawPartialBitmap and part of the bitmap extends past the dirty rect on the Y axis, the renderer writes those rows starting at the dirty rect's top instead of at the requested screenY, producing a duplicate/misplaced copy at the wrong vertical position. Hits any code that scrolls bitmaps in/out of view, anchors them near screen edges, or clips them vertically for any other reason.

  Triggers (all must hold):
  - Bitmap format Bitmap::ABGR2222 (or sibling 8bpp 2222 - static analysis shows identical compiled code in all four)
  - Bitmap registered via Bitmap::dynamicBitmapCreateExternal (other registration types untested)
  - Routed through LCD::drawPartialBitmap, or LCD::blitCopy with a full-bitmap blitRect
  - Source rect extends past the dirty rect on the Y axis (screenY + height > dirty.y + dirty.height, or screenY < dirty.y)
  - screenY ≠ dirtyRect.y (typically screenY ≠ 0)

  Non-triggers: X axis is handled correctly — screenX can be negative or off-screen without effect. Non-zero screenY alone is harmless when the bitmap fits inside the dirty rect (verified at screenY = 1).