### PR TITLE
fix(examples): hide auto-pause setting from activity app menus

### DIFF
--- a/Docs/Examples/Cycling-Architecture.md
+++ b/Docs/Examples/Cycling-Architecture.md
@@ -255,8 +255,16 @@ Lap data includes timing, distance, average speed, HR, and ascent/descent (writt
 Settings are stored in JSON format and include:
 - Alert distance threshold (`Settings::Alerts::Distance::Id`)
 - Alert time threshold (`Settings::Alerts::Time::Id`)
-- Auto-pause on/off
+- Auto-pause enable flag (`auto_pause_en`; persisted only — see below)
 - Phone notification enablement
+
+#### Auto-pause (hidden in UI)
+
+- **UI:** Auto Pause is not shown on the settings wheel (`ID_AUTO_PAUSE` is removed from `App::MenuNav::Root::Settings::Id`, and `MenuSettingsView` no longer contains auto-pause menu switch cases).
+- **Persisted:** `Settings::autoPauseEn` and JSON key `auto_pause_en` are still loaded and saved by `SettingsSerializer`.
+- **Runtime:** No service logic reads `autoPauseEn` today; only manual pause/resume (`TRACK_PAUSE` / `pauseTrack()`) is implemented.
+- **Rationale:** Auto-pause was never fully implemented; showing the toggle caused confusion. The feature is deferred while other work is prioritized.
+- **Re-enabling:** Re-add `ID_AUTO_PAUSE` to `AppMenu.hpp`, restore auto-pause branches in `MenuSettingsView`/`MenuSettingsPresenter`, then implement detection in `Service` gated on `mSettings.autoPauseEn`.
 
 ### Activity Data Management and Persistence
 
@@ -297,7 +305,7 @@ struct ActivitySummary {
 **Settings Structure**:
 ```cpp
 struct Settings {
-    bool autoPauseEn  = false;
+    bool autoPauseEn  = false;  // persisted; not on settings wheel until feature is implemented
     bool phoneNotifEn = true;
     Alerts::Distance::Id alertDistanceId = Alerts::Distance::ID_OFF;
     Alerts::Time::Id     alertTimeId     = Alerts::Time::ID_OFF;
@@ -418,7 +426,7 @@ Key responsibilities:
   - `SummaryFaceLaps` — paginated lap list (5 rows visible, paged by 3 per L1/L2)
 
 **Settings**:
-- `MenuSettingsView` — Root settings wheel (Alerts, Auto-Pause, Phone Notifications)
+- `MenuSettingsView` — Root settings wheel (Alerts, Phone Notifications; auto-pause hidden — see Auto-pause above)
 - `MenuAlertsView` — Alert type selection (Distance, Time)
 - `MenuDistanceView` — Distance alert value picker
 - `MenuDistanceSavedView` — Save confirmation (auto-dismisses after 3 s → `MenuAlertsView`)
@@ -472,7 +480,7 @@ MainView ──[Start, GPS ok]──► TrackView (faces: Total ◄──► Lap
     │                             not paused──► exitApp()
     │
     └──[Settings]──► MenuSettingsView
-                     (items: Alerts, Auto-Pause toggle, Phone Notifications toggle)
+                     (items: Alerts, Phone Notifications toggle)
                           │[Alerts]
                      MenuAlertsView
                        │             │

--- a/Docs/Examples/Hiking-Architecture.md
+++ b/Docs/Examples/Hiking-Architecture.md
@@ -258,8 +258,16 @@ Lap data includes timing, distance, elevation changes, steps, and floors climbed
 Settings are stored in JSON format and include:
 - Alert distance threshold (`Settings::Alerts::Distance::Id`)
 - Alert time threshold (`Settings::Alerts::Time::Id`)
-- Auto-pause on/off
+- Auto-pause enable flag (`auto_pause_en`; persisted only — see below)
 - Phone notification enablement
+
+#### Auto-pause (hidden in UI)
+
+- **UI:** Auto Pause is not shown on the settings wheel (`ID_AUTO_PAUSE` is removed from `App::MenuNav::Root::Settings::Id`, and `MenuSettingsView` no longer contains auto-pause menu switch cases).
+- **Persisted:** `Settings::autoPauseEn` and JSON key `auto_pause_en` are still loaded and saved by `SettingsSerializer`.
+- **Runtime:** No service logic reads `autoPauseEn` today; only manual pause/resume (`TRACK_PAUSE` / `pauseTrack()`) is implemented.
+- **Rationale:** Auto-pause was never fully implemented; showing the toggle caused confusion. The feature is deferred while other work is prioritized.
+- **Re-enabling:** Re-add `ID_AUTO_PAUSE` to `AppMenu.hpp`, restore auto-pause branches in `MenuSettingsView`/`MenuSettingsPresenter`, then implement detection in `Service` gated on `mSettings.autoPauseEn`.
 
 Activity summaries are persisted for historical data.
 
@@ -305,8 +313,8 @@ struct ActivitySummary {
 **Settings Structure**:
 ```cpp
 struct Settings {
+    bool autoPauseEn  = false;  // persisted; not on settings wheel until feature is implemented
     bool phoneNotifEn = true;
-    bool autoPause = false;
     Alerts::Distance::Id alertDistance = Alerts::Distance::Id::KM_1;
     Alerts::Time::Id     alertTime     = Alerts::Time::Id::MIN_10;
 };
@@ -425,7 +433,7 @@ Key responsibilities:
   - `SummaryFaceHeartRate` — max HR, average HR
 
 **Settings**:
-- `MenuSettingsView` — Root settings wheel (Alerts, Auto-Pause, Phone Notifications)
+- `MenuSettingsView` — Root settings wheel (Alerts, Phone Notifications; auto-pause hidden — see Auto-pause above)
 - `MenuAlertsView` — Alert type selection (Distance, Time)
 - `MenuDistanceView` — Distance alert value picker
 - `MenuDistanceSavedView` — Save confirmation (auto-dismisses after 3 s → `MenuAlertsView`)
@@ -478,7 +486,7 @@ MainView ──[Start, GPS ok]──► TrackView (faces: Total ◄──► Ove
     │                             [R2:back to track] ──► TrackView
     │
     └──[Settings]──► MenuSettingsView
-                     (items: Alerts, Auto-Pause toggle, Phone Notifications toggle)
+                     (items: Alerts, Phone Notifications toggle)
                           │[Alerts]
                      MenuAlertsView
                        │             │

--- a/Docs/Examples/Running-Architecture.md
+++ b/Docs/Examples/Running-Architecture.md
@@ -353,9 +353,17 @@ The `SENSOR_FUSION` connection is only active during tracking. Outside tracking 
 Settings are stored in JSON format and include:
 - Alert distance threshold (`Settings::Alerts::Distance::Id`)
 - Alert time threshold (`Settings::Alerts::Time::Id`)
-- Auto-pause on/off
+- Auto-pause enable flag (`auto_pause_en`; persisted only — see below)
 - Phone notification enablement
 - Interval workout configuration (`Settings::Intervals`)
+
+#### Auto-pause (hidden in UI)
+
+- **UI:** Auto Pause is not shown on the settings wheel (`ID_AUTO_PAUSE` is removed from `App::MenuNav::Root::Settings::Id`, and `MenuSettingsView` no longer contains auto-pause menu switch cases).
+- **Persisted:** `Settings::autoPauseEn` and JSON key `auto_pause_en` are still loaded and saved by `SettingsSerializer`.
+- **Runtime:** No service logic reads `autoPauseEn` today; only manual pause/resume (`TRACK_PAUSE` / `pauseTrack()`) is implemented.
+- **Rationale:** Auto-pause was never fully implemented; showing the toggle caused confusion. The feature is deferred while other work is prioritized.
+- **Re-enabling:** Re-add `ID_AUTO_PAUSE` to `AppMenu.hpp`, restore auto-pause branches in `MenuSettingsView`/`MenuSettingsPresenter`, then implement detection in `Service` gated on `mSettings.autoPauseEn`.
 
 ### Activity Data Management and Persistence
 
@@ -396,7 +404,7 @@ struct ActivitySummary {
 **Settings Structure**:
 ```cpp
 struct Settings {
-    bool autoPauseEn  = false;
+    bool autoPauseEn  = false;  // persisted; not on settings wheel until feature is implemented
     bool phoneNotifEn = true;
     Alerts::Distance::Id alertDistanceId = Alerts::Distance::ID_OFF;
     Alerts::Time::Id     alertTimeId     = Alerts::Time::ID_OFF;
@@ -527,7 +535,7 @@ Key responsibilities:
   - `SummaryFaceLaps` — paginated lap list (5 rows visible, paged by 3 per L1/L2)
 
 **Settings**:
-- `MenuSettingsView` — Root settings wheel (Alerts, Auto-Pause, Phone Notifications)
+- `MenuSettingsView` — Root settings wheel (Alerts, Phone Notifications; auto-pause hidden — see Auto-pause above)
 - `MenuAlertsView` — Alert type selection (Distance, Time)
 - `MenuDistanceView` — Distance alert value picker
 - `MenuDistanceSavedView` — Save confirmation (auto-dismisses after 3 s → `MenuAlertsView`)
@@ -608,7 +616,7 @@ MainView ──[Start, GPS ok]──► TrackView (faces: Intervals ◄──►
     │                                            → MenuIntervalsRestDistanceView
     │
     └──[Settings]──► MenuSettingsView
-                     (items: Alerts, Auto-Pause toggle, Phone Notifications toggle)
+                     (items: Alerts, Phone Notifications toggle)
                           │[Alerts]
                      MenuAlertsView
                        │             │

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
@@ -30,7 +30,6 @@ public:
     virtual void onIdleTimeout() override { model->exitApp(); }
     virtual void onGpsFix(bool acquired) override;
 
-    void saveAutoPause(bool state);
     void savePhoneNotif(bool state);
 
 private:

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
@@ -14,7 +14,6 @@ public:
     virtual void tearDownScreen();
 
     void setGpsFix(bool state);
-    void setAutoPause(bool state);
     void setPhoneNotif(bool state);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
@@ -23,7 +22,6 @@ protected:
     using Menu = App::MenuNav::Root::Settings;
 
     bool mGpsFix     = false;
-    bool mAutoPause  = false;
     bool mPhoneNotif = false;
 
     touchgfx::Callback<MenuSettingsView, MainMenuItem&, int16_t>       mUpdateItemCb;

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
@@ -62,7 +62,7 @@ struct Root {
 
     struct Settings {
         enum Id {
-            ID_ALERTS = 0, ID_AUTO_PAUSE, ID_PHONE_NOTIF,
+            ID_ALERTS = 0, ID_PHONE_NOTIF,
             ID_COUNT, ID_DEFAULT = ID_ALERTS
         };
 

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
@@ -14,7 +14,6 @@ void MenuSettingsPresenter::activate()
     model->resetIdleTimer();
 
     view.setGpsFix(model->hasGpsFix());
-    view.setAutoPause(model->getSettings().autoPauseEn);
     view.setPhoneNotif(model->getSettings().phoneNotifEn);
 }
 
@@ -26,13 +25,6 @@ void MenuSettingsPresenter::deactivate()
 void MenuSettingsPresenter::onGpsFix(bool acquired)
 {
     view.setGpsFix(acquired);
-}
-
-void MenuSettingsPresenter::saveAutoPause(bool state)
-{
-    Settings sett = model->getSettings();
-    sett.autoPauseEn = state;
-    model->saveSettings(sett);
 }
 
 void MenuSettingsPresenter::savePhoneNotif(bool state)

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
@@ -32,12 +32,6 @@ void MenuSettingsView::setGpsFix(bool state)
     menuLayout.setInfoMsg(state ? T_TEXT_SIGNAL_ACQUIRED : T_TEXT_ACQUIRING_SIGNAL);
 }
 
-void MenuSettingsView::setAutoPause(bool state)
-{
-    mAutoPause = state;
-    menuLayout.invalidate();
-}
-
 void MenuSettingsView::setPhoneNotif(bool state)
 {
     mPhoneNotif = state;
@@ -63,13 +57,6 @@ void MenuSettingsView::updateItem(MainMenuItem& item, int16_t index)
         cfg.style = MenuItemConfig::SIMPLE;
         cfg.msgId = T_TEXT_LAP_ALERTS;
         break;
-    case Menu::ID_AUTO_PAUSE:
-        cfg.style    = MenuItemConfig::TIP;
-        cfg.msgId    = T_TEXT_AUTO_PAUSE;
-        cfg.tipId    = mAutoPause ? T_TEXT_ON_UC : T_TEXT_OFF_UC;
-        cfg.tipColor = mAutoPause ? SDK::GUI::Color::YELLOW_DARK
-                                  : SDK::GUI::Color::TEAL;
-        break;
     case Menu::ID_PHONE_NOTIF:
         cfg.style    = MenuItemConfig::TIP;
         cfg.msgId    = T_TEXT_PHONE_NOTIF_DOT;
@@ -92,12 +79,6 @@ void MenuSettingsView::updateCenterItem(MainMenuCenterItem& item, int16_t index)
     case Menu::ID_ALERTS:
         cfg.style = MenuItemConfig::SIMPLE;
         cfg.msgId = T_TEXT_LAP_ALERTS;
-        break;
-    case Menu::ID_AUTO_PAUSE:
-        cfg.style       = MenuItemConfig::TOGGLE;
-        cfg.msgId       = T_TEXT_AUTO_BR_PAUSE;
-        cfg.msgIdType   = T_TMP_SEMIBOLD_25;
-        cfg.toggleState = mAutoPause;
         break;
     case Menu::ID_PHONE_NOTIF:
         cfg.style       = MenuItemConfig::TOGGLE;
@@ -128,11 +109,6 @@ void MenuSettingsView::handleKeyEvent(uint8_t key)
         switch (id) {
         case Menu::ID_ALERTS:
             application().gotoMenuAlertsScreenNoTransition();
-            break;
-        case Menu::ID_AUTO_PAUSE:
-            mAutoPause = !mAutoPause;
-            setAutoPause(mAutoPause);
-            presenter->saveAutoPause(mAutoPause);
             break;
         case Menu::ID_PHONE_NOTIF:
             mPhoneNotif = !mPhoneNotif;

--- a/Examples/Apps/Cycling/Software/Libs/Header/Settings.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Settings.hpp
@@ -51,7 +51,7 @@ struct Settings {
     // Fields
     uint32_t version = kVersion;    ///< Settings version.
 
-    bool     autoPauseEn  = false;  ///< Flag to enable auto pause during activity track.
+    bool autoPauseEn = false; ///< Serialized only; not on settings wheel until auto-pause is implemented.
     bool     phoneNotifEn = true;   ///< Flag to enable receiving phone notification when app is run.
     Alerts::Distance::Id alertDistanceId = Alerts::Distance::ID_OFF;    ///< Distance alert option.
     Alerts::Time::Id     alertTimeId     = Alerts::Time::ID_OFF;        ///< Time alert option.

--- a/Examples/Apps/Cycling/Software/Libs/Header/SettingsSerializer.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/SettingsSerializer.hpp
@@ -11,7 +11,7 @@
  * @code{.json}
  * {
  *     "version":1,
- *     "auto_pause_en":false,
+ *     "auto_pause_en":false,  // persisted; no GUI toggle until feature is implemented
  *     "phone_notif_en":true,
  *     "alert_distance_id":0,
  *     "alert_time_id":0

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
@@ -30,7 +30,6 @@ public:
     virtual void onIdleTimeout() override { model->exitApp(); }
     virtual void onGpsFix(bool acquired) override;
 
-    void saveAutoPause(bool state);
     void savePhoneNotif(bool state);
 
 private:

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
@@ -14,7 +14,6 @@ public:
     virtual void tearDownScreen();
 
     void setGpsFix(bool state);
-    void setAutoPause(bool state);
     void setPhoneNotif(bool state);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
@@ -23,7 +22,6 @@ protected:
     using Menu = App::MenuNav::Root::Settings;
 
     bool mGpsFix     = false;
-    bool mAutoPause  = false;
     bool mPhoneNotif = false;
 
     touchgfx::Callback<MenuSettingsView, MainMenuItem&, int16_t>       mUpdateItemCb;

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
@@ -62,7 +62,7 @@ struct Root {
 
     struct Settings {
         enum Id {
-            ID_ALERTS = 0, ID_AUTO_PAUSE, ID_PHONE_NOTIF,
+            ID_ALERTS = 0, ID_PHONE_NOTIF,
             ID_COUNT, ID_DEFAULT = ID_ALERTS
         };
 

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
@@ -14,7 +14,6 @@ void MenuSettingsPresenter::activate()
     model->resetIdleTimer();
 
     view.setGpsFix(model->hasGpsFix());
-    view.setAutoPause(model->getSettings().autoPauseEn);
     view.setPhoneNotif(model->getSettings().phoneNotifEn);
 }
 
@@ -26,13 +25,6 @@ void MenuSettingsPresenter::deactivate()
 void MenuSettingsPresenter::onGpsFix(bool acquired)
 {
     view.setGpsFix(acquired);
-}
-
-void MenuSettingsPresenter::saveAutoPause(bool state)
-{
-    Settings sett = model->getSettings();
-    sett.autoPauseEn = state;
-    model->saveSettings(sett);
 }
 
 void MenuSettingsPresenter::savePhoneNotif(bool state)

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
@@ -32,12 +32,6 @@ void MenuSettingsView::setGpsFix(bool state)
     menuLayout.setInfoMsg(state ? T_TEXT_SIGNAL_ACQUIRED : T_TEXT_ACQUIRING_SIGNAL);
 }
 
-void MenuSettingsView::setAutoPause(bool state)
-{
-    mAutoPause = state;
-    menuLayout.invalidate();
-}
-
 void MenuSettingsView::setPhoneNotif(bool state)
 {
     mPhoneNotif = state;
@@ -63,13 +57,6 @@ void MenuSettingsView::updateItem(MainMenuItem& item, int16_t index)
         cfg.style = MenuItemConfig::SIMPLE;
         cfg.msgId = T_TEXT_LAP_ALERTS;
         break;
-    case Menu::ID_AUTO_PAUSE:
-        cfg.style    = MenuItemConfig::TIP;
-        cfg.msgId    = T_TEXT_AUTO_PAUSE;
-        cfg.tipId    = mAutoPause ? T_TEXT_ON_UC : T_TEXT_OFF_UC;
-        cfg.tipColor = mAutoPause ? SDK::GUI::Color::YELLOW_DARK
-                                  : SDK::GUI::Color::TEAL;
-        break;
     case Menu::ID_PHONE_NOTIF:
         cfg.style    = MenuItemConfig::TIP;
         cfg.msgId    = T_TEXT_PHONE_NOTIF_DOT;
@@ -92,12 +79,6 @@ void MenuSettingsView::updateCenterItem(MainMenuCenterItem& item, int16_t index)
     case Menu::ID_ALERTS:
         cfg.style = MenuItemConfig::SIMPLE;
         cfg.msgId = T_TEXT_LAP_ALERTS;
-        break;
-    case Menu::ID_AUTO_PAUSE:
-        cfg.style       = MenuItemConfig::TOGGLE;
-        cfg.msgId       = T_TEXT_AUTO_BR_PAUSE;
-        cfg.msgIdType   = T_TMP_SEMIBOLD_25;
-        cfg.toggleState = mAutoPause;
         break;
     case Menu::ID_PHONE_NOTIF:
         cfg.style       = MenuItemConfig::TOGGLE;
@@ -128,11 +109,6 @@ void MenuSettingsView::handleKeyEvent(uint8_t key)
         switch (id) {
         case Menu::ID_ALERTS:
             application().gotoMenuAlertsScreenNoTransition();
-            break;
-        case Menu::ID_AUTO_PAUSE:
-            mAutoPause = !mAutoPause;
-            setAutoPause(mAutoPause);
-            presenter->saveAutoPause(mAutoPause);
             break;
         case Menu::ID_PHONE_NOTIF:
             mPhoneNotif = !mPhoneNotif;

--- a/Examples/Apps/Hiking/Software/Libs/Header/Settings.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Settings.hpp
@@ -51,7 +51,7 @@ struct Settings {
     // Fields
     uint32_t version = kVersion;    ///< Settings version.
 
-    bool     autoPauseEn  = false;  ///< Flag to enable auto pause during activity track.
+    bool autoPauseEn = false; ///< Serialized only; not on settings wheel until auto-pause is implemented.
     bool     phoneNotifEn = true;   ///< Flag to enable receiving phone notification when app is run.
     Alerts::Distance::Id alertDistanceId = Alerts::Distance::ID_OFF;    ///< Distance alert option.
     Alerts::Time::Id     alertTimeId     = Alerts::Time::ID_OFF;        ///< Time alert option.

--- a/Examples/Apps/Hiking/Software/Libs/Header/SettingsSerializer.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/SettingsSerializer.hpp
@@ -11,7 +11,7 @@
  * @code{.json}
  * {
  *     "version":1,
- *     "auto_pause_en":false,
+ *     "auto_pause_en":false,  // persisted; no GUI toggle until feature is implemented
  *     "phone_notif_en":true,
  *     "alert_steps_id":0,
  *     "alert_distance_id":0,

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
@@ -30,7 +30,6 @@ public:
     virtual void onIdleTimeout() override { model->exitApp(); }
     virtual void onGpsFix(bool acquired) override;
 
-    void saveAutoPause(bool state);
     void savePhoneNotif(bool state);
 
 private:

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
@@ -14,7 +14,6 @@ public:
     virtual void tearDownScreen();
 
     void setGpsFix(bool state);
-    void setAutoPause(bool state);
     void setPhoneNotif(bool state);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
@@ -23,7 +22,6 @@ protected:
     using Menu = App::MenuNav::Root::Settings;
 
     bool mGpsFix     = false;
-    bool mAutoPause  = false;
     bool mPhoneNotif = false;
 
     touchgfx::Callback<MenuSettingsView, MainMenuItem&, int16_t>       mUpdateItemCb;

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
@@ -108,7 +108,7 @@ struct Root {
 
     struct Settings {
         enum Id {
-            ID_ALERTS = 0, ID_AUTO_PAUSE, ID_PHONE_NOTIF,
+            ID_ALERTS = 0, ID_PHONE_NOTIF,
             ID_COUNT, ID_DEFAULT = ID_ALERTS
         };
 

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
@@ -14,7 +14,6 @@ void MenuSettingsPresenter::activate()
     model->resetIdleTimer();
 
     view.setGpsFix(model->hasGpsFix());
-    view.setAutoPause(model->getSettings().autoPauseEn);
     view.setPhoneNotif(model->getSettings().phoneNotifEn);
 }
 
@@ -26,13 +25,6 @@ void MenuSettingsPresenter::deactivate()
 void MenuSettingsPresenter::onGpsFix(bool acquired)
 {
     view.setGpsFix(acquired);
-}
-
-void MenuSettingsPresenter::saveAutoPause(bool state)
-{
-    Settings sett = model->getSettings();
-    sett.autoPauseEn = state;
-    model->saveSettings(sett);
 }
 
 void MenuSettingsPresenter::savePhoneNotif(bool state)

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
@@ -32,12 +32,6 @@ void MenuSettingsView::setGpsFix(bool state)
     menuLayout.setInfoMsg(state ? T_TEXT_SIGNAL_ACQUIRED : T_TEXT_ACQUIRING_SIGNAL);
 }
 
-void MenuSettingsView::setAutoPause(bool state)
-{
-    mAutoPause = state;
-    menuLayout.invalidate();
-}
-
 void MenuSettingsView::setPhoneNotif(bool state)
 {
     mPhoneNotif = state;
@@ -63,13 +57,6 @@ void MenuSettingsView::updateItem(MainMenuItem& item, int16_t index)
         cfg.style = MenuItemConfig::SIMPLE;
         cfg.msgId = T_TEXT_LAP_ALERTS;
         break;
-    case Menu::ID_AUTO_PAUSE:
-        cfg.style    = MenuItemConfig::TIP;
-        cfg.msgId    = T_TEXT_AUTO_PAUSE;
-        cfg.tipId    = mAutoPause ? T_TEXT_ON_UC : T_TEXT_OFF_UC;
-        cfg.tipColor = mAutoPause ? SDK::GUI::Color::YELLOW_DARK
-                                  : SDK::GUI::Color::TEAL;
-        break;
     case Menu::ID_PHONE_NOTIF:
         cfg.style    = MenuItemConfig::TIP;
         cfg.msgId    = T_TEXT_PHONE_NOTIF_DOT;
@@ -92,12 +79,6 @@ void MenuSettingsView::updateCenterItem(MainMenuCenterItem& item, int16_t index)
     case Menu::ID_ALERTS:
         cfg.style = MenuItemConfig::SIMPLE;
         cfg.msgId = T_TEXT_LAP_ALERTS;
-        break;
-    case Menu::ID_AUTO_PAUSE:
-        cfg.style       = MenuItemConfig::TOGGLE;
-        cfg.msgId       = T_TEXT_AUTO_BR_PAUSE;
-        cfg.msgIdType   = T_TMP_SEMIBOLD_25;
-        cfg.toggleState = mAutoPause;
         break;
     case Menu::ID_PHONE_NOTIF:
         cfg.style       = MenuItemConfig::TOGGLE;
@@ -128,11 +109,6 @@ void MenuSettingsView::handleKeyEvent(uint8_t key)
         switch (id) {
         case Menu::ID_ALERTS:
             application().gotoMenuAlertsScreenNoTransition();
-            break;
-        case Menu::ID_AUTO_PAUSE:
-            mAutoPause = !mAutoPause;
-            setAutoPause(mAutoPause);
-            presenter->saveAutoPause(mAutoPause);
             break;
         case Menu::ID_PHONE_NOTIF:
             mPhoneNotif = !mPhoneNotif;

--- a/Examples/Apps/Running/Software/Libs/Header/Settings.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Settings.hpp
@@ -86,7 +86,7 @@ struct Settings {
     // Fields
     uint32_t version = kVersion;    ///< Settings version.
 
-    bool     autoPauseEn   = false; ///< Flag to enable auto pause during activity track.
+    bool autoPauseEn = false; ///< Serialized only; not on settings wheel until auto-pause is implemented.
     bool     phoneNotifEn  = true;  ///< Flag to enable receiving phone notification when app is run.
     Alerts::Distance::Id alertDistanceId = Alerts::Distance::ID_OFF; ///< Distance alert option.
     Alerts::Time::Id     alertTimeId     = Alerts::Time::ID_OFF;     ///< Time alert option.

--- a/Examples/Apps/Running/Software/Libs/Header/SettingsSerializer.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/SettingsSerializer.hpp
@@ -11,7 +11,7 @@
  * @code{.json}
  * {
  *     "version":1,
- *     "auto_pause_en":false,
+ *     "auto_pause_en":false,  // persisted; no GUI toggle until feature is implemented
  *     "phone_notif_en":true,
  *     "alert_distance_id":0,
  *     "alert_time_id":0,


### PR DESCRIPTION
## Summary
The 3 main apps have a setting in the menu for "Auto Pause" but none of them do anything with the setting - The feature is not implemented. For now, to prevent confusion, we are going to remove the setting from the GUI. Later we will add it back when we implement the auto pause.

- remove the Auto Pause menu entry and related presenter/view toggle handling from Running, Hiking, and Cycling TouchGFX settings screens
- keep `Settings::autoPauseEn` and `auto_pause_en` serialization intact so existing settings remain compatible while the feature is deferred
- update example architecture docs to explain that auto-pause is persisted under the hood but intentionally hidden from the GUI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the Auto‑Pause toggle from the Settings menu in Cycling, Hiking, and Running apps.
  * Auto‑Pause remains persisted but is currently hidden and not used at runtime.
  * Settings menus now list only Alerts and Phone Notifications.
  * Documentation and app architecture diagrams updated with UI/persistence/runtime and re‑enable guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UNAWatch/una-sdk/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->