### PR TITLE
feat(running): default lap alerts and add SDK host tests

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -1,0 +1,40 @@
+name: SDK Host Tests
+
+on:
+  push:
+    branches: [ main, develop ]
+    tags: [ 'sdk-v*' ]
+  pull_request:
+
+jobs:
+  host-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Cache host test dependencies
+        uses: actions/cache@v4
+        with:
+          path: build-host/_deps
+          key: ${{ runner.os }}-sdk-host-tests-${{ hashFiles('Tests/Host/CMakeLists.txt', 'Tests/Host/cmake/FetchGoogleTest.cmake') }}
+          restore-keys: |
+            ${{ runner.os }}-sdk-host-tests-
+
+      - name: Configure host tests
+        run: cmake -S Tests/Host -B build-host -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build host tests
+        run: cmake --build build-host
+
+      - name: Run host tests
+        run: ctest --test-dir build-host --output-on-failure
+
+      - name: Upload host test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: host-tests-logs
+          path: build-host/Testing/Temporary/**
+          if-no-files-found: ignore

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Cache host test dependencies
         uses: actions/cache@v4
         with:
           path: build-host/_deps
           key: ${{ runner.os }}-sdk-host-tests-${{ hashFiles('Tests/Host/CMakeLists.txt', 'Tests/Host/cmake/FetchGoogleTest.cmake') }}
-          restore-keys: |
-            ${{ runner.os }}-sdk-host-tests-
 
       - name: Configure host tests
         run: cmake -S Tests/Host -B build-host -DCMAKE_BUILD_TYPE=Debug

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Docs/Tutorials/*/Software/App*/*-CMake/build
 Docs/Templates/TouchGFX-Widgets/Unpacked
 
 .claude/
+build-host/

--- a/Docs/sdk-setup.md
+++ b/Docs/sdk-setup.md
@@ -351,6 +351,27 @@ cmake --build build
 
 For clean rebuild: `rm -rf build && cmake -S . -B build && cmake --build build`.
 
+(host-unit-tests)=
+## Host Unit Tests
+
+The SDK provides a reusable GoogleTest-based host test harness under `Tests/Host`.
+
+From the SDK root:
+
+```bash
+cmake -S Tests/Host -B build-host -DCMAKE_BUILD_TYPE=Debug
+cmake --build build-host
+ctest --test-dir build-host --output-on-failure
+```
+
+On Windows multi-config generators use:
+
+```powershell
+ctest --test-dir build-host -C Debug --output-on-failure
+```
+
+For test layout and guidance on adding tests for app examples, see [Host Unit Testing](unit-testing.md).
+
 (touchgfx-require-a-windows-host)=
 ## TouchGFX (Windows-only for Designer)
 

--- a/Docs/unit-testing.md
+++ b/Docs/unit-testing.md
@@ -1,0 +1,64 @@
+# SDK Host Unit Testing
+
+This guide describes the reusable host-side unit test harness for SDK code and app example libraries.
+
+## Layout
+
+```text
+SDK/Tests/Host/
+├── CMakeLists.txt
+├── cmake/
+│   └── FetchGoogleTest.cmake
+├── support/
+│   ├── KernelTestDoubles.hpp
+│   └── KernelTestDoubles.cpp
+└── apps/
+    └── Running/
+        ├── Settings_test.cpp
+        └── SettingsSerializer_test.cpp
+```
+
+- `cmake/`: third-party bootstrap (GoogleTest).
+- `support/`: reusable fakes and fixtures (kernel facade dependencies, in-memory filesystem).
+- `apps/<AppName>/`: app-specific test cases.
+
+## Build and Run
+
+From SDK root:
+
+```bash
+cmake -S Tests/Host -B build-host -DCMAKE_BUILD_TYPE=Debug
+cmake --build build-host
+ctest --test-dir build-host --output-on-failure
+```
+
+On Windows multi-config generators:
+
+```powershell
+ctest --test-dir build-host -C Debug --output-on-failure
+```
+
+Expected: `una-sdk-host-tests` passes.
+
+## Add Tests For Another App
+
+1. Create a folder under `Tests/Host/apps/<YourApp>/`.
+2. Add one or more `*_test.cpp` files.
+3. Add test files and required app sources to `Tests/Host/CMakeLists.txt` executable source list.
+4. Reuse support doubles from `support/KernelTestDoubles.*` when the code requires `SDK::Kernel` or filesystem interactions.
+
+## Serializer/Settings Test Pattern
+
+Use `SDK::TestSupport::KernelFixture`:
+
+- `fixture.kernel` provides a ready `SDK::Kernel` with stubbed dependencies.
+- `fixture.fileSystem.seedFile(path, json)` seeds in-memory input files.
+- Instantiate serializer with `SettingsSerializer(fixture.kernel, "settings.json")`.
+- Verify load/save behavior without device firmware or simulator runtime.
+
+## Troubleshooting
+
+- If `core_json.h` is missing, confirm include path:
+  `SDK/ThirdParty/coreJSON/source/include`.
+- If linker errors mention logger symbols, ensure `SDK/Libs/Source/UnaLogger/Logger.cpp` is linked.
+- If app headers are not found, add app lib header paths to `target_include_directories(...)` for the test target.

--- a/Examples/Apps/Running/Software/Libs/Header/Settings.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Settings.hpp
@@ -88,7 +88,7 @@ struct Settings {
 
     bool autoPauseEn = false; ///< Serialized only; not on settings wheel until auto-pause is implemented.
     bool     phoneNotifEn  = true;  ///< Flag to enable receiving phone notification when app is run.
-    Alerts::Distance::Id alertDistanceId = Alerts::Distance::ID_OFF; ///< Distance alert option.
+    Alerts::Distance::Id alertDistanceId = Alerts::Distance::ID_DEFAULT; ///< Distance alert option.
     Alerts::Time::Id     alertTimeId     = Alerts::Time::ID_OFF;     ///< Time alert option.
 
     Intervals intervals {};  ///< Interval training settings.

--- a/Examples/Apps/Running/Software/Libs/Sources/SettingsSerializer.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/SettingsSerializer.cpp
@@ -154,13 +154,13 @@ bool SettingsSerializer::load(Settings &settings)
     reader.get("version",        settings.version);
     reader.get("auto_pause_en",  settings.autoPauseEn);
     reader.get("phone_notif_en", settings.phoneNotifEn);
-    uint8_t distId = static_cast<uint8_t>(Settings::Alerts::Distance::ID_OFF);
+    uint8_t distId = static_cast<uint8_t>(Settings::Alerts::Distance::ID_DEFAULT);
     uint8_t timeId = static_cast<uint8_t>(Settings::Alerts::Time::ID_OFF);
     reader.get("alert_distance_id", distId);
     reader.get("alert_time_id",     timeId);
     settings.alertDistanceId = distId < Settings::Alerts::Distance::ID_COUNT
         ? static_cast<Settings::Alerts::Distance::Id>(distId)
-        : Settings::Alerts::Distance::ID_OFF;
+        : Settings::Alerts::Distance::ID_DEFAULT;
     settings.alertTimeId = timeId < Settings::Alerts::Time::ID_COUNT
         ? static_cast<Settings::Alerts::Time::Id>(timeId)
         : Settings::Alerts::Time::ID_OFF;

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ For examples with GUI components like Hiking:
 - Explore the [SDK Setup Guide](Docs/sdk-setup.md) for detailed workflows
 - Read the [Platform Overview](Docs/platform-overview.md) for architecture details
 - Try building the [Alarm App Tutorial](Docs/Examples/Alarm-ARCHITECTURE.md)
+- Read [Host Unit Testing](Docs/unit-testing.md) for SDK/app host-side tests
 - Join the community at [UNAWatch/una-sdk](https://github.com/UNAWatch/una-sdk)
 
 For additional support, see the [Community Support](Docs/community-support.md) guide.

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.21)
+project(una-sdk-host-tests CXX C)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "Export compile commands for host tests" FORCE)
+
+if(MSVC)
+    add_compile_options(/W4 /utf-8)
+else()
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set(UNA_SDK_ROOT "${CMAKE_CURRENT_LIST_DIR}/../..")
+
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/FetchGoogleTest.cmake)
+
+add_library(sdk_host_test_support STATIC
+    support/KernelTestDoubles.cpp
+    "${UNA_SDK_ROOT}/Libs/Source/UnaLogger/Logger.cpp"
+)
+
+target_include_directories(sdk_host_test_support PUBLIC
+    "${CMAKE_CURRENT_LIST_DIR}/support"
+    "${UNA_SDK_ROOT}/Libs/Header"
+)
+
+add_executable(una-sdk-host-tests
+    apps/Running/Settings_test.cpp
+    apps/Running/SettingsSerializer_test.cpp
+    "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/SettingsSerializer.cpp"
+    "${UNA_SDK_ROOT}/Libs/Source/JSON/JsonStreamReader.cpp"
+    "${UNA_SDK_ROOT}/Libs/Source/JSON/JsonStreamWriter.cpp"
+    "${UNA_SDK_ROOT}/ThirdParty/coreJSON/source/core_json.c"
+)
+
+target_include_directories(una-sdk-host-tests PRIVATE
+    "${UNA_SDK_ROOT}/Libs/Header"
+    "${UNA_SDK_ROOT}/ThirdParty/coreJSON/source/include"
+    "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Header"
+)
+
+target_link_libraries(una-sdk-host-tests PRIVATE
+    sdk_host_test_support
+    GTest::gtest_main
+    GTest::gmock
+)
+
+enable_testing()
+add_test(NAME una-sdk-host-tests COMMAND una-sdk-host-tests)

--- a/Tests/Host/apps/Running/SettingsSerializer_test.cpp
+++ b/Tests/Host/apps/Running/SettingsSerializer_test.cpp
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+
+#include "KernelTestDoubles.hpp"
+#include "Settings.hpp"
+#include "SettingsSerializer.hpp"
+
+namespace {
+
+using SDK::TestSupport::KernelFixture;
+
+TEST(RunningSettingsSerializer, MissingDistanceAlertDefaultsToDistanceIdDefault)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("settings.json", R"({
+        "version": 1,
+        "phone_notif_en": true,
+        "alert_time_id": 0
+    })");
+
+    Settings settings {};
+    settings.alertDistanceId = Settings::Alerts::Distance::ID_OFF;
+    settings.alertTimeId = Settings::Alerts::Time::ID_MIN_10;
+
+    SettingsSerializer serializer(fixture.kernel, "settings.json");
+    ASSERT_TRUE(serializer.load(settings));
+
+    EXPECT_EQ(settings.alertDistanceId, Settings::Alerts::Distance::ID_DEFAULT);
+    EXPECT_EQ(settings.alertTimeId, Settings::Alerts::Time::ID_OFF);
+}
+
+TEST(RunningSettingsSerializer, InvalidDistanceAlertFallsBackToDistanceIdDefault)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("settings.json", R"({
+        "version": 1,
+        "phone_notif_en": true,
+        "alert_distance_id": 255,
+        "alert_time_id": 0
+    })");
+
+    Settings settings {};
+    settings.alertDistanceId = Settings::Alerts::Distance::ID_OFF;
+
+    SettingsSerializer serializer(fixture.kernel, "settings.json");
+    ASSERT_TRUE(serializer.load(settings));
+
+    EXPECT_EQ(settings.alertDistanceId, Settings::Alerts::Distance::ID_DEFAULT);
+    EXPECT_EQ(settings.alertTimeId, Settings::Alerts::Time::ID_OFF);
+}
+
+TEST(RunningSettingsSerializer, ValidNonDefaultAlertValuesAreLoadedAsIs)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("settings.json", R"({
+        "version": 1,
+        "phone_notif_en": true,
+        "alert_distance_id": 5,
+        "alert_time_id": 3
+    })");
+
+    Settings settings {};
+    settings.alertDistanceId = Settings::Alerts::Distance::ID_DEFAULT;
+    settings.alertTimeId = Settings::Alerts::Time::ID_OFF;
+
+    SettingsSerializer serializer(fixture.kernel, "settings.json");
+    ASSERT_TRUE(serializer.load(settings));
+
+    EXPECT_EQ(settings.alertDistanceId, Settings::Alerts::Distance::ID_KM_MILL_5);
+    EXPECT_EQ(settings.alertTimeId, Settings::Alerts::Time::ID_MIN_10);
+}
+
+} // namespace

--- a/Tests/Host/apps/Running/Settings_test.cpp
+++ b/Tests/Host/apps/Running/Settings_test.cpp
@@ -1,0 +1,11 @@
+#include <gtest/gtest.h>
+
+#include "Settings.hpp"
+
+TEST(RunningSettings, DefaultsUseDistanceLapAlertAndTimeOff)
+{
+    Settings settings {};
+
+    EXPECT_EQ(settings.alertDistanceId, Settings::Alerts::Distance::ID_DEFAULT);
+    EXPECT_EQ(settings.alertTimeId, Settings::Alerts::Time::ID_OFF);
+}

--- a/Tests/Host/cmake/FetchGoogleTest.cmake
+++ b/Tests/Host/cmake/FetchGoogleTest.cmake
@@ -1,0 +1,13 @@
+include(FetchContent)
+
+set(BUILD_GMOCK ON CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        52eb8108c5bdec04579160ae17225d66034bd723
+)
+
+FetchContent_MakeAvailable(googletest)

--- a/Tests/Host/support/KernelTestDoubles.cpp
+++ b/Tests/Host/support/KernelTestDoubles.cpp
@@ -1,0 +1,427 @@
+#include "KernelTestDoubles.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <new>
+
+#include "SDK/Messages/MessageBase.hpp"
+
+namespace SDK::TestSupport {
+
+void StubSystem::exit(int status)
+{
+    lastExitStatus = status;
+}
+
+uint32_t StubSystem::getTimeMs()
+{
+    return nowMs;
+}
+
+void StubSystem::delay(uint32_t ms)
+{
+    nowMs += ms;
+}
+
+void StubSystem::yield()
+{
+}
+
+void StubLogger::printf(const char* format, ...)
+{
+    (void)format;
+}
+
+void StubLogger::vprintf(const char* format, va_list args)
+{
+    (void)format;
+    (void)args;
+}
+
+void StubLogger::mvprintf(const char* level, const char* module_name, const char* func, int line, const char* fmt, va_list args)
+{
+    (void)level;
+    (void)module_name;
+    (void)func;
+    (void)line;
+    (void)fmt;
+    (void)args;
+}
+
+void* StubAppMemory::malloc(size_t size)
+{
+    return std::malloc(size);
+}
+
+void StubAppMemory::free(void* ptr)
+{
+    std::free(ptr);
+}
+
+void* StubAppMemory::realloc(void* ptr, size_t size)
+{
+    return std::realloc(ptr, size);
+}
+
+uint32_t StubAppComm::getProcessId() const
+{
+    return 1;
+}
+
+bool StubAppComm::getMessage(SDK::MessageBase*& msg, uint32_t timeoutMs)
+{
+    (void)msg;
+    (void)timeoutMs;
+    return false;
+}
+
+void StubAppComm::sendResponse(SDK::MessageBase* msg)
+{
+    (void)msg;
+}
+
+void StubAppComm::releaseMessage(SDK::MessageBase* msg)
+{
+    if (msg != nullptr) {
+        ::operator delete(msg);
+    }
+}
+
+bool StubAppComm::sendMessage(SDK::MessageBase* msg, uint32_t timeoutMs)
+{
+    (void)msg;
+    (void)timeoutMs;
+    return true;
+}
+
+void* StubAppComm::allocateMessage(size_t size)
+{
+    return ::operator new(size, std::nothrow);
+}
+
+InMemoryFileSystem::InMemoryFile::InMemoryFile(InMemoryFileSystem& fs, std::string path)
+    : mFs(fs)
+    , mPath(std::move(path))
+{
+}
+
+void InMemoryFileSystem::InMemoryFile::setPath(const char* path)
+{
+    mPath = path != nullptr ? path : "";
+}
+
+const char* InMemoryFileSystem::InMemoryFile::getPath() const
+{
+    return mPath.c_str();
+}
+
+bool InMemoryFileSystem::InMemoryFile::exist() const
+{
+    auto it = mFs.files.find(mPath);
+    return it != mFs.files.end() && it->second.exists;
+}
+
+bool InMemoryFileSystem::InMemoryFile::rename(const char* newPath)
+{
+    if (newPath == nullptr) {
+        return false;
+    }
+    return mFs.rename(mPath.c_str(), newPath);
+}
+
+bool InMemoryFileSystem::InMemoryFile::remove()
+{
+    return mFs.remove(mPath.c_str());
+}
+
+size_t InMemoryFileSystem::InMemoryFile::size() const
+{
+    auto it = mFs.files.find(mPath);
+    if (it == mFs.files.end() || !it->second.exists) {
+        return 0;
+    }
+    return it->second.content.size();
+}
+
+bool InMemoryFileSystem::InMemoryFile::open(bool wMode, bool override)
+{
+    mWriteMode = wMode;
+    auto& entry = mFs.files[mPath];
+
+    if (wMode) {
+        entry.exists = true;
+        if (override) {
+            entry.content.clear();
+        }
+    } else if (!entry.exists) {
+        return false;
+    }
+
+    mOpen = true;
+    mPos = 0;
+    return true;
+}
+
+bool InMemoryFileSystem::InMemoryFile::isOpen() const
+{
+    return mOpen;
+}
+
+bool InMemoryFileSystem::InMemoryFile::close()
+{
+    mOpen = false;
+    return true;
+}
+
+bool InMemoryFileSystem::InMemoryFile::read(char* buff, size_t btr, size_t& br)
+{
+    if (!mOpen || mWriteMode || buff == nullptr) {
+        return false;
+    }
+
+    auto it = mFs.files.find(mPath);
+    if (it == mFs.files.end() || !it->second.exists) {
+        return false;
+    }
+
+    const size_t available = it->second.content.size() > mPos ? it->second.content.size() - mPos : 0;
+    const size_t toRead = std::min(btr, available);
+    if (toRead > 0) {
+        std::memcpy(buff, it->second.content.data() + mPos, toRead);
+    }
+    mPos += toRead;
+    br = toRead;
+    return true;
+}
+
+bool InMemoryFileSystem::InMemoryFile::write(const char* buff, size_t btw, size_t& bw)
+{
+    if (!mOpen || !mWriteMode || buff == nullptr) {
+        return false;
+    }
+
+    auto& entry = mFs.files[mPath];
+    entry.exists = true;
+
+    if (mPos > entry.content.size()) {
+        entry.content.resize(mPos, '\0');
+    }
+
+    if (mPos + btw > entry.content.size()) {
+        entry.content.resize(mPos + btw);
+    }
+
+    std::memcpy(entry.content.data() + mPos, buff, btw);
+    mPos += btw;
+    bw = btw;
+    return true;
+}
+
+bool InMemoryFileSystem::InMemoryFile::seek(size_t offset)
+{
+    if (!mOpen) {
+        return false;
+    }
+    mPos = offset;
+    return true;
+}
+
+bool InMemoryFileSystem::InMemoryFile::truncate(size_t offset)
+{
+    auto it = mFs.files.find(mPath);
+    if (!mOpen || it == mFs.files.end() || !it->second.exists) {
+        return false;
+    }
+    it->second.content.resize(offset);
+    if (mPos > offset) {
+        mPos = offset;
+    }
+    return true;
+}
+
+bool InMemoryFileSystem::InMemoryFile::flush()
+{
+    return mOpen;
+}
+
+size_t InMemoryFileSystem::InMemoryFile::getPosition() const
+{
+    return mPos;
+}
+
+InMemoryFileSystem::EmptyDirectory::EmptyDirectory(std::string path)
+    : mPath(std::move(path))
+{
+}
+
+void InMemoryFileSystem::EmptyDirectory::setPath(const char* path)
+{
+    mPath = path != nullptr ? path : "";
+}
+
+const char* InMemoryFileSystem::EmptyDirectory::getPath() const
+{
+    return mPath.c_str();
+}
+
+bool InMemoryFileSystem::EmptyDirectory::exist() const
+{
+    return true;
+}
+
+bool InMemoryFileSystem::EmptyDirectory::rename(const char* newPath)
+{
+    if (newPath == nullptr) {
+        return false;
+    }
+    mPath = newPath;
+    return true;
+}
+
+bool InMemoryFileSystem::EmptyDirectory::remove()
+{
+    return true;
+}
+
+bool InMemoryFileSystem::EmptyDirectory::create()
+{
+    return true;
+}
+
+bool InMemoryFileSystem::EmptyDirectory::open()
+{
+    mOpen = true;
+    return true;
+}
+
+bool InMemoryFileSystem::EmptyDirectory::isOpen() const
+{
+    return mOpen;
+}
+
+bool InMemoryFileSystem::EmptyDirectory::readNext(SDK::Interface::IFileSystem::ObjectInfo& item, bool reset)
+{
+    (void)item;
+    (void)reset;
+    return false;
+}
+
+bool InMemoryFileSystem::EmptyDirectory::close()
+{
+    mOpen = false;
+    return true;
+}
+
+bool InMemoryFileSystem::mkdir(const char* path)
+{
+    (void)path;
+    return true;
+}
+
+std::unique_ptr<SDK::Interface::IFile> InMemoryFileSystem::file(const char* path)
+{
+    if (path == nullptr) {
+        return {};
+    }
+    return std::make_unique<InMemoryFile>(*this, path);
+}
+
+std::unique_ptr<SDK::Interface::IDirectory> InMemoryFileSystem::dir(const char* path)
+{
+    return std::make_unique<EmptyDirectory>(path != nullptr ? path : "");
+}
+
+bool InMemoryFileSystem::exist(const char* path) const
+{
+    if (path == nullptr) {
+        return false;
+    }
+    auto it = files.find(path);
+    return it != files.end() && it->second.exists;
+}
+
+bool InMemoryFileSystem::remove(const char* path)
+{
+    if (path == nullptr) {
+        return false;
+    }
+    auto it = files.find(path);
+    if (it == files.end()) {
+        return false;
+    }
+    it->second.exists = false;
+    it->second.content.clear();
+    return true;
+}
+
+bool InMemoryFileSystem::rename(const char* oldPath, const char* newPath)
+{
+    if (oldPath == nullptr || newPath == nullptr) {
+        return false;
+    }
+    auto it = files.find(oldPath);
+    if (it == files.end()) {
+        return false;
+    }
+    files[newPath] = std::move(it->second);
+    files.erase(it);
+    return true;
+}
+
+bool InMemoryFileSystem::copy(const char* oldPath, const char* newPath)
+{
+    if (oldPath == nullptr || newPath == nullptr) {
+        return false;
+    }
+    auto it = files.find(oldPath);
+    if (it == files.end()) {
+        return false;
+    }
+    files[newPath] = it->second;
+    return true;
+}
+
+bool InMemoryFileSystem::objectInfo(const char* path, ObjectInfo& item) const
+{
+    if (path == nullptr) {
+        return false;
+    }
+    auto it = files.find(path);
+    if (it == files.end() || !it->second.exists) {
+        return false;
+    }
+    std::strncpy(item.name, path, sizeof(item.name) - 1);
+    item.name[sizeof(item.name) - 1] = '\0';
+    item.isDir = false;
+    item.isHidden = false;
+    item.isSystem = false;
+    item.size = it->second.content.size();
+    item.utc = 0;
+    return true;
+}
+
+void InMemoryFileSystem::seedFile(const std::string& path, std::string content)
+{
+    files[path] = InMemoryFileEntry{ std::move(content), true };
+}
+
+std::string InMemoryFileSystem::readFile(const std::string& path) const
+{
+    auto it = files.find(path);
+    if (it == files.end() || !it->second.exists) {
+        return {};
+    }
+    return it->second.content;
+}
+
+KernelFixture::KernelFixture()
+    : system()
+    , logger()
+    , memory()
+    , comm()
+    , fileSystem()
+    , kernel(system, logger, memory, comm, fileSystem)
+{
+}
+
+} // namespace SDK::TestSupport

--- a/Tests/Host/support/KernelTestDoubles.cpp
+++ b/Tests/Host/support/KernelTestDoubles.cpp
@@ -126,7 +126,11 @@ bool InMemoryFileSystem::InMemoryFile::rename(const char* newPath)
     if (newPath == nullptr) {
         return false;
     }
-    return mFs.rename(mPath.c_str(), newPath);
+    if (!mFs.rename(mPath.c_str(), newPath)) {
+        return false;
+    }
+    mPath = newPath;
+    return true;
 }
 
 bool InMemoryFileSystem::InMemoryFile::remove()
@@ -146,15 +150,18 @@ size_t InMemoryFileSystem::InMemoryFile::size() const
 bool InMemoryFileSystem::InMemoryFile::open(bool wMode, bool override)
 {
     mWriteMode = wMode;
-    auto& entry = mFs.files[mPath];
 
     if (wMode) {
+        auto& entry = mFs.files[mPath];
         entry.exists = true;
         if (override) {
             entry.content.clear();
         }
-    } else if (!entry.exists) {
-        return false;
+    } else {
+        auto it = mFs.files.find(mPath);
+        if (it == mFs.files.end() || !it->second.exists) {
+            return false;
+        }
     }
 
     mOpen = true;

--- a/Tests/Host/support/KernelTestDoubles.hpp
+++ b/Tests/Host/support/KernelTestDoubles.hpp
@@ -1,0 +1,143 @@
+#pragma once
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "SDK/Kernel/Kernel.hpp"
+#include "SDK/Interfaces/IAppComm.hpp"
+#include "SDK/Interfaces/IAppMemory.hpp"
+#include "SDK/Interfaces/IFileSystem.hpp"
+#include "SDK/Interfaces/ILogger.hpp"
+#include "SDK/Interfaces/ISystem.hpp"
+
+namespace SDK::TestSupport {
+
+class StubSystem : public SDK::Interface::ISystem {
+public:
+    void exit(int status = 0) override;
+    uint32_t getTimeMs() override;
+    void delay(uint32_t ms) override;
+    void yield() override;
+
+    int lastExitStatus = 0;
+    uint32_t nowMs = 0;
+};
+
+class StubLogger : public SDK::Interface::ILogger {
+public:
+    void printf(const char *format, ...) override;
+    void vprintf(const char *format, va_list args) override;
+    void mvprintf(const char *level, const char *module_name, const char *func, int line, const char *fmt, va_list args) override;
+};
+
+class StubAppMemory : public SDK::Interface::IAppMemory {
+public:
+    void* malloc(size_t size) override;
+    void free(void* ptr) override;
+    void* realloc(void* ptr, size_t size) override;
+};
+
+class StubAppComm : public SDK::Interface::IAppComm {
+public:
+    uint32_t getProcessId() const override;
+    bool getMessage(SDK::MessageBase*& msg, uint32_t timeoutMs = 0xFFFFFFFF) override;
+    void sendResponse(SDK::MessageBase* msg) override;
+    void releaseMessage(SDK::MessageBase* msg) override;
+    bool sendMessage(SDK::MessageBase* msg, uint32_t timeoutMs = 0) override;
+
+protected:
+    void* allocateMessage(size_t size) override;
+};
+
+struct InMemoryFileEntry {
+    std::string content;
+    bool exists = false;
+};
+
+class InMemoryFileSystem : public SDK::Interface::IFileSystem {
+public:
+    class InMemoryFile : public SDK::Interface::IFile {
+    public:
+        InMemoryFile(InMemoryFileSystem& fs, std::string path);
+        ~InMemoryFile() override = default;
+
+        void setPath(const char* path) override;
+        const char* getPath() const override;
+        bool exist() const override;
+        bool rename(const char* newPath) override;
+        bool remove() override;
+
+        size_t size() const override;
+        bool open(bool wMode = false, bool override = false) override;
+        bool isOpen() const override;
+        bool close() override;
+        bool read(char* buff, size_t btr, size_t& br) override;
+        bool write(const char* buff, size_t btw, size_t& bw) override;
+        bool seek(size_t offset) override;
+        bool truncate(size_t offset) override;
+        bool flush() override;
+        size_t getPosition() const override;
+
+    private:
+        InMemoryFileSystem& mFs;
+        std::string mPath;
+        bool mOpen = false;
+        bool mWriteMode = false;
+        size_t mPos = 0;
+    };
+
+    class EmptyDirectory : public SDK::Interface::IDirectory {
+    public:
+        explicit EmptyDirectory(std::string path);
+        ~EmptyDirectory() override = default;
+
+        void setPath(const char* path) override;
+        const char* getPath() const override;
+        bool exist() const override;
+        bool rename(const char* newPath) override;
+        bool remove() override;
+
+        bool create() override;
+        bool open() override;
+        bool isOpen() const override;
+        bool readNext(SDK::Interface::IFileSystem::ObjectInfo& item, bool reset = false) override;
+        bool close() override;
+
+    private:
+        std::string mPath;
+        bool mOpen = false;
+    };
+
+    bool mkdir(const char* path) override;
+    std::unique_ptr<SDK::Interface::IFile> file(const char* path) override;
+    std::unique_ptr<SDK::Interface::IDirectory> dir(const char* path) override;
+    bool exist(const char* path) const override;
+    bool remove(const char* path) override;
+    bool rename(const char* oldPath, const char* newPath) override;
+    bool copy(const char* oldPath, const char* newPath) override;
+    bool objectInfo(const char* path, ObjectInfo& item) const override;
+
+    void seedFile(const std::string& path, std::string content);
+    std::string readFile(const std::string& path) const;
+
+    std::unordered_map<std::string, InMemoryFileEntry> files;
+};
+
+struct KernelFixture {
+    StubSystem system;
+    StubLogger logger;
+    StubAppMemory memory;
+    StubAppComm comm;
+    InMemoryFileSystem fileSystem;
+    SDK::Kernel kernel;
+
+    KernelFixture();
+};
+
+} // namespace SDK::TestSupport


### PR DESCRIPTION
## Summary
- default Running lap alerts to distance (`1 km`/`1 mile` via unit-aware distance IDs), including serializer fallback for missing/invalid persisted distance alert IDs
- add reusable SDK host unit-test harness under `Tests/Host` (GoogleTest bootstrap + reusable kernel/filesystem doubles)
- add initial Running host tests for settings defaults and serializer behavior (fallback + valid non-default persisted values)
- document SDK host-test workflow in `Docs/unit-testing.md` and link it from `README.md` and `Docs/sdk-setup.md`
- add SDK CI workflow to run host tests with timeout, cache for fetched deps, and failure log artifact upload

## Test plan
- [x] `cmake -S Tests/Host -B build-host -DCMAKE_BUILD_TYPE=Debug`
- [x] `cmake --build build-host`
- [x] `ctest --test-dir build-host -C Debug --output-on-failure` (local Windows)
- [x] Verify `SDK Host Tests` workflow passes in GitHub Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hosted unit testing suite with GoogleTest and automated CI that runs on pushes, tags, and pull requests (uploads logs on failure).
  * Added host-side test support utilities to facilitate unit testing.

* **Tests**
  * Added unit tests validating settings serialization and default alert behavior.

* **Documentation**
  * New Host Unit Testing guide and SDK setup updates with build/run instructions.

* **Changes**
  * Default distance alert selection now uses the distance metric’s default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UNAWatch/una-sdk/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->