### PR TITLE
feat(treadmill): outdoor stride calibrator (SDK)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+reviews:
+  auto_review:
+    enabled: true
+    # Review draft PRs too (CodeRabbit skips drafts by default).
+    drafts: true
+    # Do not pause/skip the auto review when a PR looks like work-in-progress
+    # (no title keywords such as "WIP" suppress reviewing).
+    ignore_title_keywords: []
+  path_filters:
+    # TouchGFX Designer output / generator glue (generated, "do not edit").
+    - "!Docs/Tutorials/*/Software/Apps/TouchGFX-GUI/generated/**"
+    - "!Examples/Apps/*/Software/Apps/TouchGFX-GUI/generated/**"
+    - "!Libs/Header/SDK/Port/TouchGFX/generated/**"
+    - "!Libs/Source/Port/TouchGFX/generated/**"

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -44,6 +44,7 @@ ThirdParty/FitSDKRelease_21.171.00/c/fit_crc.c\
 ThirdParty/FitSDKRelease_21.171.00/c/fit_product.c\
 Libs/Source/JSON/JsonStreamReader.cpp\
 Libs/Source/JSON/JsonStreamWriter.cpp\
+Libs/Source/Calibration/OutdoorStrideCalibrator.cpp\
 Libs/Source/TrackMap/TrackMapBuilder.cpp\
 Libs/Source/Kernel/KernelBuilder.cpp\
 Libs/Source/FitHelper/FitHelper.cpp\

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -30,6 +30,7 @@
     <ClCompile Include="$(SdkPath)\ThirdParty\FitSDKRelease_21.202.00\c\fit_product.c"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\JSON\JsonStreamReader.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\JSON\JsonStreamWriter.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Calibration\OutdoorStrideCalibrator.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\TrackMap\TrackMapBuilder.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Timer\Timer.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Kernel\KernelBuilder.cpp"/>

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
@@ -421,6 +421,9 @@
     <Filter Include="SDK\Libs\Source\JSON">
       <UniqueIdentifier>{681f519e-2619-415d-b28b-2f31e2279e24}</UniqueIdentifier>
     </Filter>
+    <Filter Include="SDK\Libs\Source\Calibration">
+      <UniqueIdentifier>{7c1a5e90-3d24-4b6e-9a11-0c2f8e7b4a01}</UniqueIdentifier>
+    </Filter>
     <Filter Include="SDK\Libs\Header\TrackMap">
       <UniqueIdentifier>{d3f5dab6-09b9-4f3a-a091-e23f8bbbf5ea}</UniqueIdentifier>
     </Filter>
@@ -872,6 +875,9 @@
     </ClCompile>
     <ClCompile Include="$(SdkPath)\Libs\Source\JSON\JsonStreamWriter.cpp">
       <Filter>SDK\Libs\Source\JSON</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Calibration\OutdoorStrideCalibrator.cpp">
+      <Filter>SDK\Libs\Source\Calibration</Filter>
     </ClCompile>
     <ClCompile Include="$(SdkPath)\Libs\Source\TrackMap\TrackMapBuilder.cpp">
       <Filter>SDK\Libs\Source\TrackMap</Filter>

--- a/Examples/Apps/Running/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Service.hpp
@@ -1,6 +1,8 @@
 #ifndef SERVICE_HPP
 #define SERVICE_HPP
 
+#include <ctime>   // std::time_t (mLastCalibUtc, startTrack, ...)
+
 #include "SDK/Kernel/Kernel.hpp"
 #include "SDK/SensorLayer/SensorConnection.hpp"
 #include "SDK/SensorLayer/SensorDataBatch.hpp"
@@ -11,6 +13,8 @@
 #include "SDK/Metrics/DeltaCounter.hpp"
 #include "SDK/Metrics/ThrottledSample.hpp"
 #include "SDK/Filters/SimpleLPF.hpp"
+
+#include "SDK/Calibration/OutdoorStrideCalibrator.hpp"
 
 #include "SettingsSerializer.hpp"
 #include "ActivitySummarySerializer.hpp"
@@ -68,14 +72,23 @@ private:
     SDK::Sensor::Connection mSensorWristMotion;
     SDK::Sensor::Connection mSensorFusion;
     SDK::Sensor::Connection mSensorRunningCadence;
+    SDK::Sensor::Connection mSensorGrade;
     bool                    mIsSensorsConnected = false;
 
     struct {
         float cadenceSpm      = 0.0f;
         bool  cadenceValid    = false;
-        float stepLengthM     = 0.0f;
-        bool  stepLengthValid = false;
     } mRunningCadence{};
+
+    // -- Outdoor stride calibration inputs (latched per stream, §2.3) ---------
+    struct {
+        float gradePct        = 0.0f;
+        bool  gradeValid      = false;
+    } mGradeData{};
+    float       mGpsSpeedMs       = 0.0f; ///< Latest raw GPS speed (instantaneous source).
+    bool        mGpsSpeedValid    = false;
+    bool        mGpsDeadReckoning = false;
+    std::time_t mLastCalibUtc     = 0;   ///< For per-tick delta_t (§4.4).
 
     // -- Metrics --------------------------------------------------------------
 
@@ -138,6 +151,10 @@ private:
     // -- Wrist tilt -----------------------------------------------------------
 
     WristTiltDetector mWristTiltDetector;
+
+    // -- Outdoor stride calibrator (§2) ---------------------------------------
+
+    SDK::Calibration::OutdoorStrideCalibrator mCalibrator;
 
     // -- Lifecycle ------------------------------------------------------------
 

--- a/Examples/Apps/Running/Software/Libs/Header/Settings.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Settings.hpp
@@ -88,6 +88,7 @@ struct Settings {
 
     bool autoPauseEn = false; ///< Serialized only; not on settings wheel until auto-pause is implemented.
     bool     phoneNotifEn  = true;  ///< Flag to enable receiving phone notification when app is run.
+    bool     calibTraceEn  = false; ///< Debug: write per-tick outdoor-stride calibrator CSV trace (§9.2).
     Alerts::Distance::Id alertDistanceId = Alerts::Distance::ID_DEFAULT; ///< Distance alert option.
     Alerts::Time::Id     alertTimeId     = Alerts::Time::ID_OFF;     ///< Time alert option.
 

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -25,6 +25,9 @@
 #include "SDK/SensorLayer/DataParsers/SensorDataParserWristMotion.hpp"
 #include "SDK/SensorLayer/DataParsers/SensorDataParserFusionRaw.hpp"
 #include "SDK/SensorLayer/DataParsers/SensorDataParserRunningCadence.hpp"
+#include "SDK/SensorLayer/DataParsers/SensorDataParserGrade.hpp"
+
+#include "SDK/Calibration/StrideMath.hpp"
 
 #define LOG_MODULE_PRX      "Service"
 #define LOG_MODULE_LEVEL    LOG_LEVEL_INFO
@@ -60,12 +63,14 @@ Service::Service(SDK::Kernel &kernel)
         , mSensorWristMotion(SDK::Sensor::Type::WRIST_MOTION)
         , mSensorFusion(SDK::Sensor::Type::FUSION_RAW, 1000.0f / skFusionSampleRateHz, 100)
         , mSensorRunningCadence(SDK::Sensor::Type::RUNNING_CADENCE, skSamplePeriod, skSampleLatency)
+        , mSensorGrade(SDK::Sensor::Type::GRADE, skSamplePeriod, skSampleLatency)
         , mTimeTracker(kernel.sys)
         , mAltitudeFilter(0.8f)
         , mAltitudeCounter()
         , mBatterySoc(kernel.sys)
         , mBatteryVoltage(kernel.sys)
         , mWristTiltDetector()
+        , mCalibrator(mKernel.fs)
 
 {
     mTimeCounter.init();
@@ -249,6 +254,7 @@ void Service::connectSensors()
         mSensorHr.connect();
         mSensorFusion.connect();
         mSensorRunningCadence.connect();
+        mSensorGrade.connect();
 
         mIsSensorsConnected = true;
     }
@@ -259,6 +265,7 @@ void Service::disconnect()
     if (mIsSensorsConnected) {
         LOG_DEBUG("Disconnect from sensors...\n");
 
+        mSensorGrade.disconnect();
         mSensorFusion.disconnect();
         mSensorRunningCadence.disconnect();
         mSensorHr.disconnect();
@@ -294,8 +301,24 @@ void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)
     } else if (mSensorGpsSpeed.matchesDriver(handle)) {
         SDK::SensorDataParser::GpsSpeed parser(data[0]);
         if (parser.isDataValid()) {
-            mSpeedCounter.add(parser.getSpeed());
-            LOG_DEBUG("Speed:    %.2f m/s\n", parser.getSpeed());
+            mGpsSpeedMs       = parser.getSpeed();  // raw instantaneous speed
+            mGpsSpeedValid    = parser.isSpeedValid();
+            mGpsDeadReckoning = parser.isDeadReckoning();
+            // Only feed a current (valid-fix) speed into the aggregated metrics
+            // so acquisition/fix-loss readings don't pollute avg/max/distance.
+            if (mGpsSpeedValid) {
+                mSpeedCounter.add(parser.getSpeed());
+            }
+            LOG_DEBUG("Speed:    %.2f m/s (valid %u, dr %u)\n",
+                      parser.getSpeed(), mGpsSpeedValid, mGpsDeadReckoning);
+        }
+    } else if (mSensorGrade.matchesDriver(handle)) {
+        SDK::SensorDataParser::Grade parser(data[0]);
+        if (parser.isDataValid()) {
+            mGradeData.gradePct   = parser.getGradePct();
+            mGradeData.gradeValid = parser.isGradeValid();
+            LOG_DEBUG("Grade:    %.2f %% (valid %u)\n",
+                      mGradeData.gradePct, mGradeData.gradeValid);
         }
     } else if (mSensorGpsDistance.matchesDriver(handle)) {
         SDK::SensorDataParser::GpsDistance parser(data[0]);
@@ -343,10 +366,8 @@ void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)
     } else if (mSensorRunningCadence.matchesDriver(handle)) {
         SDK::SensorDataParser::RunningCadence parser(data[0]);
         if (parser.isDataValid()) {
-            mRunningCadence.cadenceSpm      = parser.getCadenceSpm();
-            mRunningCadence.cadenceValid    = parser.isCadenceValid();
-            mRunningCadence.stepLengthM     = parser.getStepLengthM();
-            mRunningCadence.stepLengthValid = parser.isStepLengthValid();
+            mRunningCadence.cadenceSpm   = parser.getCadenceSpm();
+            mRunningCadence.cadenceValid = parser.isCadenceValid();
         }
     } else if (mSensorFusion.matchesDriver(handle)) {
         static constexpr uint16_t kBatchSize = 10u;
@@ -590,8 +611,15 @@ ActivityWriter::RecordData Service::prepareRecordData()
     fitRecord.set(ActivityWriter::RecordData::Field::CADENCE, mRunningCadence.cadenceValid);
     fitRecord.cadenceSpm = mRunningCadence.cadenceSpm;
 
-    fitRecord.set(ActivityWriter::RecordData::Field::STEP_LENGTH, mRunningCadence.stepLengthValid);
-    fitRecord.stepLengthM = mRunningCadence.stepLengthM;
+    // Implied step length is derived SDK-side from GPS speed + cadence (the
+    // kernel no longer emits it). Gated to 0.15-2.50 m, preserving the prior
+    // record.step_length values. See Outdoor-Data-Collection.md §3.6.
+    const SDK::Calibration::StrideMath::StepLength stepLen =
+        SDK::Calibration::StrideMath::impliedStepLengthM(
+            mGpsSpeedMs, mGpsSpeedValid && !mGpsDeadReckoning,
+            mRunningCadence.cadenceSpm, mRunningCadence.cadenceValid);
+    fitRecord.set(ActivityWriter::RecordData::Field::STEP_LENGTH, stepLen.valid);
+    fitRecord.stepLengthM = stepLen.meters;
 
     return fitRecord;
 }
@@ -651,6 +679,18 @@ void Service::startTrack(std::time_t utc)
     mBatteryVoltage.reset(skBatteryLogPeriodMs);
     mGps.reset();
     mRunningCadence = {};
+
+    // Outdoor stride calibrator: reset latched inputs and load the stored LUT
+    // for this session (§6.3).
+    mGradeData = {};
+    mGpsSpeedValid    = false;
+    mGpsDeadReckoning = false;
+    mLastCalibUtc     = 0;
+    mCalibrator.load();
+    if (mSettings.calibTraceEn) {
+        // Debug: per-tick CSV trace pulled over USB mass storage (§9.2).
+        mCalibrator.enableTrace("../SharedData/stride_trace.csv");
+    }
 
     mSessionNotEmpty = false;
     mLapNotEmpty = false;
@@ -755,6 +795,27 @@ void Service::processTrack()
 
 
     if (mTrackState == Track::State::ACTIVE) {
+        // Feed the outdoor stride calibrator from the latest latched values,
+        // inline at the 1 Hz record-write point and before the FIT write (§2.1).
+        {
+            SDK::Calibration::CalibratorSample cs;
+            cs.gps_speed_ms           = mGpsSpeedMs;
+            cs.gps_speed_valid        = mGpsSpeedValid;
+            cs.gps_fix_dead_reckoning = mGpsDeadReckoning;
+            cs.cadence_spm            = mRunningCadence.cadenceSpm;
+            cs.cadence_valid          = mRunningCadence.cadenceValid;
+            cs.grade_pct              = mGradeData.gradePct;
+            cs.grade_valid            = mGradeData.gradeValid;
+
+            const std::time_t nowUtc = mTimeCounter.getCurrent();
+            cs.delta_t_s = (mLastCalibUtc == 0)
+                ? 1.0f
+                : static_cast<float>(nowUtc - mLastCalibUtc);
+            mLastCalibUtc = nowUtc;
+
+            mCalibrator.ingestSample(cs);
+        }
+
         // Save record to the FIT file
         ActivityWriter::RecordData fitRecord = prepareRecordData();
         mActivityWriter.addRecord(fitRecord);
@@ -921,6 +982,10 @@ void Service::stopTrack(bool discard)
 
     mGuiSender.trackState(mTrackState);
 
+    // Persist the outdoor stride LUT synchronously before the task tears down
+    // (only writes if >= 1 sample was accepted this session, §6.4).
+    mCalibrator.finalise();
+
     disconnect();
 }
 
@@ -939,6 +1004,8 @@ void Service::pauseTrack(bool pause)
 
         mActivityWriter.pause(mTimeCounter.getCurrent());
 
+        mCalibrator.pause();   // §4.4: stop ingesting, reset steady-state counter
+
         mTrackState = Track::State::PAUSED;
         LOG_INFO("Track paused. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
         mGuiSender.trackState(mTrackState);
@@ -953,6 +1020,9 @@ void Service::pauseTrack(bool pause)
         mAltitudeCounter.resume();
 
         mActivityWriter.resume(mTimeCounter.getCurrent());
+
+        mCalibrator.resume();  // restart steady-state counter from zero (§4.4)
+        mLastCalibUtc = 0;     // avoid a spurious cross-pause delta_t
 
         mTrackState = Track::State::ACTIVE;
         LOG_INFO("Track resumed. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));

--- a/Examples/Apps/Running/Software/Libs/Sources/SettingsSerializer.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/SettingsSerializer.cpp
@@ -77,6 +77,7 @@ bool SettingsSerializer::save(const Settings &settings)
     writer.add("version",        settings.version);
     writer.add("auto_pause_en",  settings.autoPauseEn);
     writer.add("phone_notif_en", settings.phoneNotifEn);
+    writer.add("calib_trace_en", settings.calibTraceEn);
     writer.add("alert_distance_id", static_cast<uint8_t>(settings.alertDistanceId));
     writer.add("alert_time_id",     static_cast<uint8_t>(settings.alertTimeId));
 
@@ -154,6 +155,8 @@ bool SettingsSerializer::load(Settings &settings)
     reader.get("version",        settings.version);
     reader.get("auto_pause_en",  settings.autoPauseEn);
     reader.get("phone_notif_en", settings.phoneNotifEn);
+    settings.calibTraceEn = false;  // deterministic default for legacy files
+    reader.get("calib_trace_en", settings.calibTraceEn);
     uint8_t distId = static_cast<uint8_t>(Settings::Alerts::Distance::ID_DEFAULT);
     uint8_t timeId = static_cast<uint8_t>(Settings::Alerts::Time::ID_OFF);
     reader.get("alert_distance_id", distId);

--- a/Libs/Header/SDK/Calibration/OutdoorStrideCalibConfig.hpp
+++ b/Libs/Header/SDK/Calibration/OutdoorStrideCalibConfig.hpp
@@ -1,0 +1,87 @@
+/**
+ ******************************************************************************
+ * @file    OutdoorStrideCalibConfig.hpp
+ * @brief   Tunable constants and bin layout for the outdoor stride calibrator.
+ *
+ * Mirrors Docs/Treadmill/Outdoor-Data-Collection.md §8 (tunable constants) and
+ * §5.1 (bin layout). These values are not user-configurable but are
+ * firmware-tunable for field adjustment.
+ ******************************************************************************
+ */
+
+#ifndef __OUTDOOR_STRIDE_CALIB_CONFIG_HPP
+#define __OUTDOOR_STRIDE_CALIB_CONFIG_HPP
+
+#include <cstddef>
+#include <cstdint>
+
+namespace SDK::Calibration
+{
+
+/**
+ * @brief Outdoor stride calibrator tunables (spec §8) and bin layout (spec §5.1).
+ */
+namespace Config
+{
+
+// --- Acceptance state machine (spec §4, §8) ---------------------------------
+
+/// Consecutive qualifying seconds before samples are accepted.
+constexpr float kSteadyStateMinSeconds = 15.0f;
+
+/// Max delta_t between ticks before a stream gap resets the counter (§4.4).
+constexpr float kMaxTickGapS = 1.5f;
+
+/// Fractional +/- band for speed and cadence steady-state (5%).
+constexpr float kSteadyBandFrac = 0.05f;
+
+/// GPS speed acceptance window, m/s.
+constexpr float kGpsSpeedMinMs = 0.5f;
+constexpr float kGpsSpeedMaxMs = 8.0f;
+
+/// Cadence acceptance window, SPM (matches the LUT range).
+constexpr float kCadenceMinSpm = 80.0f;
+constexpr float kCadenceMaxSpm = 220.0f;
+
+/// Maximum absolute terrain grade for acceptance, percent.
+constexpr float kGradeMaxPct = 3.0f;
+
+/// Rolling window for barometric grade computation, seconds (kernel).
+constexpr float kGradeWindowS = 10.0f;
+
+/// Implied stride-length plausibility bounds (post-gate sanity check), metres.
+constexpr float kStrideMinM = 0.3f;
+constexpr float kStrideMaxM = 5.0f;
+
+// --- Bin aggregation (spec §5) ----------------------------------------------
+
+/// Per-bin distance cap before aging kicks in, metres.
+constexpr float kDistanceCapM = 20000.0f;
+
+/// Minimum accumulated steps for a bin to be considered valid (~100 strides).
+constexpr float kBinValidMinSteps = 200.0f;
+
+// --- Phase-2 gate (spec §7) -------------------------------------------------
+
+/// Valid bins required for the phase-2 gate.
+constexpr size_t kOutdoorLutMinValidBins = 8;
+
+/// Total LUT distance required for the phase-2 gate, metres.
+constexpr float kOutdoorLutMinCalibrationDistanceM = 5000.0f;
+
+// --- Bin layout (spec §5.1) -------------------------------------------------
+
+/// Cadence bin width, SPM.
+constexpr float kBinWidthSpm = 4.0f;
+
+/// Lowest bin lower-edge cadence, SPM (bin 0 covers [80, 84)).
+constexpr float kBinBaseSpm = 80.0f;
+
+/// Number of cadence bins: centres 82, 86, ..., 218.
+constexpr size_t kBinCount = 35;
+
+} // namespace Config
+
+} // namespace SDK::Calibration
+
+#endif /* __OUTDOOR_STRIDE_CALIB_CONFIG_HPP */

--- a/Libs/Header/SDK/Calibration/OutdoorStrideCalibrator.hpp
+++ b/Libs/Header/SDK/Calibration/OutdoorStrideCalibrator.hpp
@@ -1,0 +1,222 @@
+/**
+ ******************************************************************************
+ * @file    OutdoorStrideCalibrator.hpp
+ * @brief   Background data-collection component that builds the outdoor
+ *          stride-length LUT during outdoor Running sessions.
+ *
+ * Implements Docs/Treadmill/Outdoor-Data-Collection.md. A plain C++ object owned
+ * by the Running app service task; ingestSample() is called inline at each 1 Hz
+ * record-write point. No FreeRTOS task, no IPC. Persistence uses the SDK
+ * JsonStreamReader / JsonStreamWriter over an injected IFileSystem.
+ ******************************************************************************
+ */
+
+#ifndef __OUTDOOR_STRIDE_CALIBRATOR_HPP
+#define __OUTDOOR_STRIDE_CALIBRATOR_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "SDK/Calibration/OutdoorStrideCalibConfig.hpp"
+#include "SDK/Interfaces/IFileSystem.hpp"
+
+namespace SDK::Calibration
+{
+
+/**
+ * @brief Per-tick input sample assembled by the Running service (spec §2.3).
+ *
+ * A plain POD: each field is the latest latched value from its own sensor
+ * stream at record-write time (the streams are not co-sampled).
+ */
+struct CalibratorSample {
+    float gps_speed_ms          = 0.0f;   ///< Horizontal GPS speed, m/s.
+    bool  gps_speed_valid       = false;  ///< False during acquisition / fix loss.
+    bool  gps_fix_dead_reckoning = false; ///< True when the fix is estimated (§3.5).
+    float cadence_spm           = 0.0f;   ///< Running cadence, steps/min.
+    bool  cadence_valid         = false;  ///< Cadence estimator validity.
+    float grade_pct             = 0.0f;   ///< Terrain grade, % (positive = uphill).
+    bool  grade_valid           = false;  ///< False if grade cannot be computed.
+    float delta_t_s             = 1.0f;   ///< Seconds since previous tick (~1.0).
+};
+
+/**
+ * @brief One cadence bin's accumulated data (spec §5.2).
+ */
+struct StrideBin {
+    float total_distance_m = 0.0f;  ///< Cumulative GPS distance from accepted samples.
+    float total_steps      = 0.0f;  ///< Cumulative step count (float).
+    float sample_count     = 0.0f;  ///< Accepted-sample count (erodes during aging).
+
+    /// Bin is valid once enough steps are accumulated (spec §5.4).
+    bool isValid() const { return total_steps >= Config::kBinValidMinSteps; }
+
+    /// Has any accepted data been added.
+    bool hasData() const { return total_steps > 0.0f; }
+
+    /// Stride length lookup, metres: total_distance_m / (total_steps / 2).
+    /// Returns 0 for an empty bin.
+    float strideLengthM() const
+    {
+        return total_steps > 0.0f ? total_distance_m / (total_steps / 2.0f) : 0.0f;
+    }
+};
+
+/**
+ * @brief Outdoor stride calibrator (spec §1).
+ *
+ * Lifetime maps onto the Running session:
+ *   - load()        at session start            (§6.3)
+ *   - ingestSample() each 1 Hz tick while active (§4, §5)
+ *   - pause()/resume() on run pause / resume     (§4.4)
+ *   - finalise()    at session stop              (§6.4)
+ */
+class OutdoorStrideCalibrator {
+public:
+    /// Default calibration store path, relative to the app root (spec §6.1).
+    static constexpr const char *kDefaultPath = "../SharedData/stride.json";
+
+    /// Current persisted-schema version (spec §6.5).
+    static constexpr int32_t kCurrentVersion = 1;
+
+    /// Maximum accepted store-file size. The store holds 35 small bins (a few
+    /// KB); larger files are treated as corrupt to bound transient heap
+    /// allocation on embedded targets.
+    static constexpr size_t kMaxStoreBytes = 16u * 1024u;
+
+    /**
+     * @brief Construct over a filesystem.
+     * @param fs   Filesystem used for load / save (the app's guarded FS).
+     * @param path Calibration store path; defaults to kDefaultPath.
+     */
+    explicit OutdoorStrideCalibrator(SDK::Interface::IFileSystem &fs,
+                                     const char *path = kDefaultPath);
+
+    ~OutdoorStrideCalibrator();
+
+    // --- Debug trace (spec §9.2) ---------------------------------------------
+
+    /**
+     * @brief Enable a per-tick CSV trace (one row per ingestSample: raw sample,
+     *        each gate's pass/fail, steady-state counter, accept/discard).
+     *
+     * Opens @p path for writing (truncating any existing file) and writes the
+     * header. Off by default; gated by an app config flag. A failed open
+     * silently leaves tracing disabled. See spec §9.2.
+     * @param path Trace file path (e.g. "../SharedData/stride_trace.csv").
+     */
+    void enableTrace(const char *path);
+
+    // --- Session lifecycle ---------------------------------------------------
+
+    /// Load the store into memory (spec §6.3). Safe to call once at start.
+    void load();
+
+    /// Gate, aggregate, or discard one tick (spec §4, §5).
+    void ingestSample(const CalibratorSample &sample);
+
+    /// Stop ingesting and reset the steady-state counter (spec §4.4).
+    void pause();
+
+    /// Resume ingesting; the counter restarts from zero (spec §4.4).
+    void resume();
+
+    /**
+     * @brief Persist the store if >= 1 sample was accepted this session (§6.4).
+     * @return true if the file was written, false if skipped (nothing accepted)
+     *         or on write error.
+     */
+    bool finalise();
+
+    // --- Accessors -----------------------------------------------------------
+
+    /// Number of bins (always Config::kBinCount).
+    static constexpr size_t binCount() { return Config::kBinCount; }
+
+    /// Read one bin (no bounds check; index must be < binCount()).
+    const StrideBin &bin(size_t index) const { return mBins[index]; }
+
+    /// Centre cadence (SPM) of a bin: 82, 86, ..., 218.
+    static float binCentreSpm(size_t index);
+
+    /// Bin index for a cadence value, clamped to [0, kBinCount-1] (spec §5.1).
+    static size_t binIndexForCadence(float cadenceSpm);
+
+    /// Accepted-sample count for the current session (drives the §6.4 write gate).
+    size_t acceptedThisSession() const { return mSessionAccepted; }
+
+    /// Current steady-state counter, seconds (diagnostic / test).
+    float steadySeconds() const { return mSteadySeconds; }
+
+    // --- Phase-2 gate read path (spec §7) ------------------------------------
+
+    /// Count of valid bins (spec §5.4).
+    size_t validBinCount() const;
+
+    /// Total accumulated calibration distance across all bins, metres.
+    float totalCalibrationDistanceM() const;
+
+    /// True when both phase-2 conditions hold (spec §7).
+    bool readyForPhase2() const;
+
+private:
+    /// Reset the steady-state run: counter to zero, reference values cleared.
+    void resetSteadyState();
+
+    /// Add an accepted sample to its bin, applying distance-cap aging (§5.3).
+    void accumulate(const CalibratorSample &sample);
+
+    /// Zero all bins (fresh start).
+    void clearBins();
+
+    /// Parse a previously read JSON buffer into mBins. @return false on failure.
+    bool parseBuffer(const char *data, size_t len);
+
+    /// Back up the current store file to "<path>.bak".
+    void backupCorruptFile();
+
+    /// Per-tick gate outcomes captured for the debug trace (spec §9.2).
+    struct GateTrace {
+        bool gpsValid     = false;
+        bool fixOk        = false;
+        bool speedBounds  = false;
+        bool cadValid     = false;
+        bool cadBounds    = false;
+        bool gradeValid   = false;
+        bool gradeBounds  = false;
+        bool steadyEval   = false;  ///< Were the steady-state gates evaluated this tick.
+        bool speedSteady  = false;
+        bool cadSteady    = false;
+    };
+
+    /// Append one CSV row to the trace file (no-op if tracing disabled).
+    void writeTraceRow(const CalibratorSample &sample, const GateTrace &g,
+                       const char *verdict);
+
+    /// Close the trace file if open.
+    void closeTrace();
+
+    SDK::Interface::IFileSystem &mFs;
+    /// Copy of the store path (the calibrator outlives the ctor argument).
+    char mPath[SDK::Interface::IFileSystem::skMaxPathLen] {};
+
+    StrideBin mBins[Config::kBinCount] {};
+
+    // Steady-state machine (spec §4).
+    float  mSteadySeconds = 0.0f;   ///< Accumulated qualifying seconds.
+    float  mSpeedRef      = 0.0f;   ///< Held speed reference for the band gate.
+    float  mCadenceRef    = 0.0f;   ///< Held cadence reference for the band gate.
+    bool   mRefsSet       = false;  ///< Reference values latched for this run.
+    bool   mPaused        = false;  ///< Ingestion halted between pause/resume.
+
+    size_t mSessionAccepted = 0;    ///< Accepted samples this session (§6.4 gate).
+
+    // Debug trace (spec §9.2); inactive unless enableTrace() succeeds.
+    std::unique_ptr<SDK::Interface::IFile> mTraceFile;
+    uint32_t mTraceRow = 0;
+};
+
+} // namespace SDK::Calibration
+
+#endif /* __OUTDOOR_STRIDE_CALIBRATOR_HPP */

--- a/Libs/Header/SDK/Calibration/StrideMath.hpp
+++ b/Libs/Header/SDK/Calibration/StrideMath.hpp
@@ -1,0 +1,100 @@
+/**
+ ******************************************************************************
+ * @file    StrideMath.hpp
+ * @brief   Stateless SDK-side stride / step-length helpers.
+ *
+ * Holds the implied step-length derivation that previously lived in the kernel
+ * (CadenceEstimator::updateStepLength) — see Outdoor-Data-Collection.md §3.6 and
+ * Treadmill-Specification.md §8.1. Kept header-only and stateless so it is
+ * shared by the FIT record writer (step_length output) and the calibrator's
+ * stride-plausibility gate (§4.3) without duplicating the formula.
+ ******************************************************************************
+ */
+
+#ifndef __STRIDE_MATH_HPP
+#define __STRIDE_MATH_HPP
+
+#include <cmath>
+
+namespace SDK::Calibration
+{
+
+/**
+ * @brief Stateless stride / step-length math.
+ *
+ * Definitions (matching the spec):
+ *   - step length  = distance per single foot strike  = v * 60 / cadence_spm
+ *   - stride length = distance left-to-left (2 steps)  = v * 120 / cadence_spm
+ *
+ * where v is GPS horizontal speed (m/s) and cadence_spm is steps per minute.
+ */
+namespace StrideMath
+{
+
+/// FIT step-length emit gate, metres. Previously kMin/kMaxStepLengthM in the
+/// kernel CadenceEstimatorConfig; moved here as writer policy (spec §3.6.4).
+constexpr float kMinStepLengthM = 0.15f;
+constexpr float kMaxStepLengthM = 2.50f;
+
+/// Result of an implied step-length computation.
+struct StepLength {
+    float meters;  ///< Computed step length, m (defined only when valid).
+    bool  valid;   ///< true when both inputs were valid and the result is in-gate.
+};
+
+/**
+ * @brief Implied step length from speed and cadence, with the FIT emit gate.
+ *
+ * Replaces the removed kernel CadenceEstimator::updateStepLength(): the Running
+ * app calls this at record-write time and gates the result before writing
+ * record.step_length, preserving identical output values (spec §3.6.5).
+ *
+ * @param speedMps     GPS horizontal speed, m/s.
+ * @param speedValid   true when speedMps is a reliable current estimate.
+ * @param cadenceSpm   Cadence, steps per minute.
+ * @param cadenceValid true when cadenceSpm is a reliable current estimate.
+ * @return {meters, valid}. valid is false if either input is invalid, cadence
+ *         is non-positive, or the result falls outside [kMin, kMax]StepLengthM.
+ */
+inline StepLength impliedStepLengthM(float speedMps, bool speedValid,
+                                     float cadenceSpm, bool cadenceValid)
+{
+    if (!speedValid || !cadenceValid || cadenceSpm <= 0.0f) {
+        return {0.0f, false};
+    }
+
+    const float stepM = (speedMps * 60.0f) / cadenceSpm;
+    // Reject non-finite results (e.g. NaN/inf speed): NaN range comparisons are
+    // all false, which would otherwise mark a NaN step length valid and leak it
+    // into record.step_length.
+    if (!std::isfinite(stepM) ||
+        stepM < kMinStepLengthM || stepM > kMaxStepLengthM) {
+        return {stepM, false};
+    }
+    return {stepM, true};
+}
+
+/**
+ * @brief Implied stride length (left-to-left) from speed and cadence.
+ *
+ * Used by the calibrator's post-gate plausibility check (spec §4.3); the caller
+ * supplies the bounds. No internal gating here — this is the raw geometric
+ * value SL_implied = v * 120 / cadence.
+ *
+ * @param speedMps   GPS horizontal speed, m/s.
+ * @param cadenceSpm Cadence, steps per minute (assumed > 0 by the caller).
+ * @return Stride length in metres.
+ */
+inline float impliedStrideLengthM(float speedMps, float cadenceSpm)
+{
+    if (cadenceSpm <= 0.0f) {
+        return 0.0f;  // guard against div-by-zero / inf-NaN for invalid cadence
+    }
+    return (speedMps * 120.0f) / cadenceSpm;
+}
+
+} // namespace StrideMath
+
+} // namespace SDK::Calibration
+
+#endif /* __STRIDE_MATH_HPP */

--- a/Libs/Header/SDK/SensorLayer/DataParsers/SensorDataParserGpsSpeed.hpp
+++ b/Libs/Header/SDK/SensorLayer/DataParsers/SensorDataParserGpsSpeed.hpp
@@ -26,6 +26,8 @@ namespace SDK
          *
          * Expected data layout:
          * - [0] float speed (m/s)
+         * - [1] uint  speed valid (1 = current fix, 0 = acquiring / fix lost)
+         * - [2] uint  dead reckoning (1 = estimated fix, speed unreliable)
          *
          * Validity of each field is checked via corresponding mask bit.
          */
@@ -33,8 +35,10 @@ namespace SDK
         {
         public:
             enum Field : uint8_t {
-                SPEED = 0,  ///< Speed, m/s (float)
-                COUNT       ///< Total number of fields
+                SPEED          = 0,  ///< Speed, m/s (float)
+                SPEED_VALID    = 1,  ///< 1 when the fix is current (uint)
+                DEAD_RECKONING = 2,  ///< 1 when the fix is estimated / DR (uint, §3.5)
+                COUNT                ///< Total number of fields
             };
 
             /**
@@ -62,6 +66,30 @@ namespace SDK
             }
 
             /**
+             * @brief Whether the current speed comes from a live, trustworthy fix.
+             *
+             * Excludes dead-reckoning here so a single call is sufficient for
+             * speed gating; callers need not also check isDeadReckoning(). This
+             * keeps the parser self-consistent regardless of whether a given
+             * publisher already clears SPEED_VALID during DR (§3.5).
+             * @return true if valid (false during acquisition / fix loss / DR)
+             */
+            bool isSpeedValid() const
+            {
+                return isDataValid() && (mData.u[Field::SPEED_VALID] != 0)
+                        && (mData.u[Field::DEAD_RECKONING] == 0);
+            }
+
+            /**
+             * @brief Whether the receiver is dead-reckoning (estimated fix).
+             * @return true if the speed is extrapolated and unreliable (§3.5)
+             */
+            bool isDeadReckoning() const
+            {
+                return isDataValid() && (mData.u[Field::DEAD_RECKONING] != 0);
+            }
+
+            /**
              * @brief Get data timestamp in ms
              * @return Data timestamp in ms (0 if invalid)
              */
@@ -81,7 +109,7 @@ namespace SDK
 
             /**
              * @brief Get total number of expected fields
-             * @return Field count (6)
+             * @return Field count (Field::COUNT = 3: SPEED, SPEED_VALID, DEAD_RECKONING)
              */
             static constexpr uint8_t getFieldsNumber()
             {

--- a/Libs/Header/SDK/SensorLayer/DataParsers/SensorDataParserGrade.hpp
+++ b/Libs/Header/SDK/SensorLayer/DataParsers/SensorDataParserGrade.hpp
@@ -1,0 +1,63 @@
+/**
+ ******************************************************************************
+ * @file    SensorDataParserGrade.hpp
+ * @brief   Parser for GRADE sensor samples (barometric terrain grade).
+ *
+ * See Docs/Treadmill/Outdoor-Data-Collection.md §3.4. GRADE_PCT is only a
+ * reliable estimate when GRADE_VALID is set.
+ ******************************************************************************
+ */
+
+#ifndef __SENSOR_DATA_PARSER_GRADE_HPP
+#define __SENSOR_DATA_PARSER_GRADE_HPP
+
+#include "SDK/SensorLayer/SensorDataView.hpp"
+
+#include <cstdint>
+
+namespace SDK::SensorDataParser
+{
+
+class Grade
+{
+public:
+    enum Field : uint8_t {
+        GRADE_PCT   = 0,  ///< Terrain grade in percent; valid only when GRADE_VALID.
+        GRADE_VALID = 1,  ///< 1 when grade_pct is a reliable current estimate.
+        COUNT
+    };
+
+    explicit Grade(const SDK::Sensor::DataView data) : mData(data) {}
+
+    bool isDataValid() const
+    {
+        return mData.getFieldCount() == Field::COUNT;
+    }
+
+    float getGradePct() const
+    {
+        return isDataValid() ? mData.f[Field::GRADE_PCT] : 0.0f;
+    }
+
+    bool isGradeValid() const
+    {
+        return isDataValid() && (mData.u[Field::GRADE_VALID] != 0);
+    }
+
+    uint32_t getTimestamp() const
+    {
+        return isDataValid() ? mData.getTimestamp() : 0;
+    }
+
+    static constexpr uint8_t getFieldsNumber()
+    {
+        return Field::COUNT;
+    }
+
+private:
+    const SDK::Sensor::DataView mData;
+};
+
+} // namespace SDK::SensorDataParser
+
+#endif /* __SENSOR_DATA_PARSER_GRADE_HPP */

--- a/Libs/Header/SDK/SensorLayer/DataParsers/SensorDataParserRunningCadence.hpp
+++ b/Libs/Header/SDK/SensorLayer/DataParsers/SensorDataParserRunningCadence.hpp
@@ -18,11 +18,13 @@ namespace SDK::SensorDataParser
 class RunningCadence
 {
 public:
+    // Step length is no longer published by the kernel cadence sensor; it is
+    // derived SDK-side at FIT record-write time via SDK::Calibration::StrideMath
+    // (Outdoor-Data-Collection.md §3.6). This is a breaking wire-format change:
+    // Field::COUNT shrank from 4 to 2.
     enum Field : uint8_t {
         CADENCE_SPM        = 0,
         CADENCE_VALID      = 1,
-        STEP_LENGTH_M      = 2,
-        STEP_LENGTH_VALID  = 3,
         COUNT
     };
 
@@ -41,16 +43,6 @@ public:
     bool isCadenceValid() const
     {
         return isDataValid() && (mData.u[Field::CADENCE_VALID] != 0);
-    }
-
-    float getStepLengthM() const
-    {
-        return isDataValid() ? mData.f[Field::STEP_LENGTH_M] : 0.0f;
-    }
-
-    bool isStepLengthValid() const
-    {
-        return isDataValid() && (mData.u[Field::STEP_LENGTH_VALID] != 0);
     }
 
     uint32_t getTimestamp() const

--- a/Libs/Header/SDK/SensorLayer/SensorTypes.hpp
+++ b/Libs/Header/SDK/SensorLayer/SensorTypes.hpp
@@ -47,7 +47,7 @@ namespace SDK::Sensor
         STEP_DETECTOR        = 0x00000050, ///< Step event.
         STEP_COUNTER         = 0x00000051, ///< Step count since boot (monotonic).
         STEP_COUNTER_DAILY   = 0x00000052, ///< Step count for the current day.
-        RUNNING_CADENCE      = 0x00000053, ///< Running cadence + optional GNSS step length.
+        RUNNING_CADENCE      = 0x00000053, ///< Running cadence (steps/min); step length is derived SDK-side.
 
         FLOOR_COUNTER        = 0x00000060, ///< Floor counter since boot (monotonic).
         FLOOR_COUNTER_DAILY  = 0x00000061, ///< Floor counter for the current day.
@@ -120,6 +120,12 @@ namespace SDK::Sensor
          *  @{
          */
         TOUCH_DETECT         = 0x00000140, ///< Touch detection, worn / unworn
+        /** @} */
+
+        /** @name Derived terrain
+         *  @{
+         */
+        GRADE                = 0x00000150, ///< Barometric terrain grade (%) + validity.
         /** @} */
     };
 }

--- a/Libs/Header/SDK/Simulator/Components/Sensors/IMU/ImuRunningCadence.hpp
+++ b/Libs/Header/SDK/Simulator/Components/Sensors/IMU/ImuRunningCadence.hpp
@@ -9,7 +9,6 @@
 #define __IMU_RUNNING_CADENCE_HPP
 
 #include "SDK/Simulator/OS/SwTimer.hpp"
-#include "SDK/Simulator/Components/ISensorsSim/IGps.hpp"
 #include <SDK/Simulator/Components/SensorDriver.hpp>
 #include <cstdint>
 
@@ -38,7 +37,6 @@ private:
 
     void publishSample();
 
-    Interface::IGps& mGps;
     Sensor::Driver   mDriver;
     ::Driver::SwTimer mTimer;
 };

--- a/Libs/Source/Calibration/OutdoorStrideCalibrator.cpp
+++ b/Libs/Source/Calibration/OutdoorStrideCalibrator.cpp
@@ -1,0 +1,527 @@
+/**
+ ******************************************************************************
+ * @file    OutdoorStrideCalibrator.cpp
+ * @brief   Implementation of the outdoor stride calibrator.
+ *
+ * See Docs/Treadmill/Outdoor-Data-Collection.md for the controlling spec.
+ ******************************************************************************
+ */
+
+#include "SDK/Calibration/OutdoorStrideCalibrator.hpp"
+
+#include <cinttypes>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <new>
+
+#include "SDK/Calibration/StrideMath.hpp"
+#include "SDK/JSON/JsonStreamReader.hpp"
+#include "SDK/JSON/JsonStreamWriter.hpp"
+
+namespace SDK::Calibration
+{
+
+OutdoorStrideCalibrator::OutdoorStrideCalibrator(SDK::Interface::IFileSystem &fs,
+                                                 const char *path) :
+    mFs(fs)
+{
+    // Copy the path; it is used across the session (load/finalise/backup) and
+    // must not depend on the caller's argument lifetime.
+    const char *src = (path != nullptr) ? path : kDefaultPath;
+    const int written = std::snprintf(mPath, sizeof(mPath), "%s", src);
+    if (written < 0 || written >= static_cast<int>(sizeof(mPath))) {
+        // Path too long to store safely — fall back to the (short) default so
+        // load/finalise never target a silently-truncated, wrong path.
+        std::snprintf(mPath, sizeof(mPath), "%s", kDefaultPath);
+    }
+}
+
+OutdoorStrideCalibrator::~OutdoorStrideCalibrator()
+{
+    closeTrace();
+}
+
+// --- Bin layout helpers ------------------------------------------------------
+
+float OutdoorStrideCalibrator::binCentreSpm(size_t index)
+{
+    return Config::kBinBaseSpm + Config::kBinWidthSpm * static_cast<float>(index)
+           + Config::kBinWidthSpm / 2.0f;
+}
+
+size_t OutdoorStrideCalibrator::binIndexForCadence(float cadenceSpm)
+{
+    const float rel = (cadenceSpm - Config::kBinBaseSpm) / Config::kBinWidthSpm;
+    if (rel <= 0.0f) {
+        return 0;
+    }
+    const long idx = static_cast<long>(std::floor(rel));
+    if (idx >= static_cast<long>(Config::kBinCount - 1)) {
+        return Config::kBinCount - 1;
+    }
+    return static_cast<size_t>(idx);
+}
+
+void OutdoorStrideCalibrator::clearBins()
+{
+    for (StrideBin &b : mBins) {
+        b = StrideBin {};
+    }
+}
+
+// --- Steady-state machine (spec §4) -----------------------------------------
+
+void OutdoorStrideCalibrator::resetSteadyState()
+{
+    mSteadySeconds = 0.0f;
+    mRefsSet       = false;
+}
+
+void OutdoorStrideCalibrator::ingestSample(const CalibratorSample &s)
+{
+    if (mPaused) {
+        return;
+    }
+
+    // §4.4 stream gap / time discontinuity: a delta_t jump (> MAX_TICK_GAP_S)
+    // OR a non-positive delta_t (a repeated/backward clock, since the app
+    // derives delta_t from UTC timestamps) breaks the consecutive-seconds run.
+    // A non-positive delta_t is especially dangerous: it would shrink
+    // mSteadySeconds and make accumulate() subtract distance/steps. The
+    // discontinuity tick must NOT advance the window or integrate distance; it
+    // only re-anchors the reference values for the next contiguous tick.
+    const bool gapBroke = (s.delta_t_s > Config::kMaxTickGapS) ||
+                          (s.delta_t_s <= 0.0f);
+    if (gapBroke) {
+        resetSteadyState();
+    }
+
+    // Evaluate the non-steady-state gates individually (§4.2) so the debug
+    // trace can report which gate rejected a tick.
+    GateTrace g;
+    g.gpsValid    = s.gps_speed_valid;
+    g.fixOk       = !s.gps_fix_dead_reckoning;
+    g.speedBounds = (s.gps_speed_ms >= Config::kGpsSpeedMinMs &&
+                     s.gps_speed_ms <= Config::kGpsSpeedMaxMs);
+    g.cadValid    = s.cadence_valid;
+    g.cadBounds   = (s.cadence_spm >= Config::kCadenceMinSpm &&
+                     s.cadence_spm <= Config::kCadenceMaxSpm);
+    g.gradeValid  = s.grade_valid;
+    g.gradeBounds = (std::fabs(s.grade_pct) <= Config::kGradeMaxPct);
+
+    const bool nonSteadyPass = g.gpsValid && g.fixOk && g.speedBounds &&
+                               g.cadValid && g.cadBounds &&
+                               g.gradeValid && g.gradeBounds;
+
+    const char *verdict;
+
+    if (!nonSteadyPass) {
+        resetSteadyState();
+        verdict = "discard_gate";
+    } else {
+        // First qualifying tick after a reset latches the reference values
+        // (§4.2). They are > 0 here (speed/cadence bound gates passed).
+        if (!mRefsSet) {
+            mSpeedRef   = s.gps_speed_ms;
+            mCadenceRef = s.cadence_spm;
+            mRefsSet    = true;
+        }
+
+        g.steadyEval  = true;
+        g.speedSteady = std::fabs(s.gps_speed_ms - mSpeedRef) / mSpeedRef
+                            <= Config::kSteadyBandFrac;
+        g.cadSteady   = std::fabs(s.cadence_spm - mCadenceRef) / mCadenceRef
+                            <= Config::kSteadyBandFrac;
+
+        if (!(g.speedSteady && g.cadSteady)) {
+            resetSteadyState();
+            verdict = "discard_steady";
+        } else if (gapBroke) {
+            // Discontinuity: gates pass and refs are now re-anchored, but the
+            // gap tick neither advances the window nor accumulates distance
+            // (§4.4). The next contiguous tick starts the fresh window.
+            verdict = "discard_gap";
+        } else {
+            // All gates pass — advance the counter (§4.1).
+            mSteadySeconds += s.delta_t_s;
+
+            if (mSteadySeconds + 1e-4f < Config::kSteadyStateMinSeconds) {
+                verdict = "qualifying";  // still qualifying, discard for now
+            } else {
+                // §4.3 post-gate stride-plausibility check. A rejection here
+                // does NOT reset the counter (the gates all passed).
+                const float slImplied = StrideMath::impliedStrideLengthM(
+                    s.gps_speed_ms, s.cadence_spm);
+                if (slImplied < Config::kStrideMinM ||
+                    slImplied > Config::kStrideMaxM) {
+                    verdict = "discard_plausibility";
+                } else {
+                    accumulate(s);
+                    ++mSessionAccepted;
+                    verdict = "accept";
+                }
+            }
+        }
+    }
+
+    if (mTraceFile) {
+        writeTraceRow(s, g, verdict);
+    }
+}
+
+void OutdoorStrideCalibrator::pause()
+{
+    mPaused = true;
+    resetSteadyState();
+}
+
+void OutdoorStrideCalibrator::resume()
+{
+    mPaused = false;
+    resetSteadyState();
+}
+
+// --- Bin aggregation (spec §5.3) --------------------------------------------
+
+void OutdoorStrideCalibrator::accumulate(const CalibratorSample &s)
+{
+    const size_t i = binIndexForCadence(s.cadence_spm);
+    StrideBin   &b = mBins[i];
+
+    const float dSample     = s.gps_speed_ms * s.delta_t_s;
+    const float stepsSample = s.cadence_spm * s.delta_t_s / 60.0f;
+
+    // Aging: only when adding this sample would push the bin over the cap.
+    // Scale existing totals so the post-add distance lands exactly at the cap,
+    // yielding a distance-weighted EMA (spec §5.3).
+    if (b.total_distance_m + dSample > Config::kDistanceCapM &&
+        b.total_distance_m > 0.0f) {
+        float scale = (Config::kDistanceCapM - dSample) / b.total_distance_m;
+        if (scale < 0.0f) {
+            // A single tick's distance exceeds the whole cap (pathological —
+            // gap ticks are excluded from accumulation, so dSample stays small).
+            // Discard the old data rather than letting the scale go negative.
+            scale = 0.0f;
+        }
+        b.total_distance_m *= scale;
+        b.total_steps      *= scale;
+        b.sample_count     *= scale;
+    }
+
+    b.total_distance_m += dSample;
+    b.total_steps      += stepsSample;
+    b.sample_count     += 1.0f;
+}
+
+// --- Phase-2 gate read path (spec §7) ---------------------------------------
+
+size_t OutdoorStrideCalibrator::validBinCount() const
+{
+    size_t n = 0;
+    for (const StrideBin &b : mBins) {
+        if (b.isValid()) {
+            ++n;
+        }
+    }
+    return n;
+}
+
+float OutdoorStrideCalibrator::totalCalibrationDistanceM() const
+{
+    float total = 0.0f;
+    for (const StrideBin &b : mBins) {
+        total += b.total_distance_m;
+    }
+    return total;
+}
+
+bool OutdoorStrideCalibrator::readyForPhase2() const
+{
+    return validBinCount() >= Config::kOutdoorLutMinValidBins &&
+           totalCalibrationDistanceM() >= Config::kOutdoorLutMinCalibrationDistanceM;
+}
+
+// --- Persistence (spec §6) --------------------------------------------------
+
+bool OutdoorStrideCalibrator::parseBuffer(const char *data, size_t len)
+{
+    SDK::JsonStreamReader reader(data, len);
+    if (!reader.validate()) {
+        return false;  // malformed → caller backs up
+    }
+
+    int32_t version = 0;
+    if (!reader.get("version", version)) {
+        return false;  // cannot read version → treat as corrupt
+    }
+
+    // version < current with no registered migration → start fresh, no backup
+    // (bins were already cleared by the caller). Equivalent to an empty load.
+    if (version < kCurrentVersion) {
+        return true;
+    }
+
+    // version >= current: load known fields; unknown keys are ignored by the
+    // query reader, giving forward compatibility for newer files (§6.5).
+    size_t arrayLen = 0;
+    if (!reader.getArrayLength("bins", arrayLen)) {
+        return true;  // no bins array → empty store, still valid
+    }
+
+    // Bound the iteration: the schema has exactly kBinCount bins, so a
+    // corrupt-but-valid file claiming a huge array length can't spin the loop.
+    const size_t binLimit = (arrayLen < Config::kBinCount) ? arrayLen
+                                                           : Config::kBinCount;
+    for (size_t k = 0; k < binLimit; ++k) {
+        char query[64];
+
+        float centre = 0.0f;
+        std::snprintf(query, sizeof(query), "bins[%d].centre_spm",
+                      static_cast<int>(k));
+        if (!reader.get(query, centre)) {
+            continue;  // entry without a centre — skip
+        }
+
+        const long idx =
+            std::lround((centre - binCentreSpm(0)) / Config::kBinWidthSpm);
+        if (idx < 0 || idx >= static_cast<long>(Config::kBinCount)) {
+            continue;  // centre outside the known range — ignore
+        }
+        // Accept only exact on-grid centres. An off-grid value (e.g. 83 when the
+        // grid is 80/84/88…) signals a corrupt store; aliasing it into the
+        // nearest bin would silently shift persisted totals into the wrong
+        // cadence bucket and skew LUT/phase-2 readiness, so reject it here.
+        constexpr float kCentreMatchEpsSpm = 0.5f;
+        if (std::fabs(centre - binCentreSpm(static_cast<size_t>(idx))) >
+            kCentreMatchEpsSpm) {
+            continue;
+        }
+        StrideBin &b = mBins[static_cast<size_t>(idx)];
+
+        // Missing keys leave the default (zero) value (backward compatibility).
+        std::snprintf(query, sizeof(query), "bins[%d].total_distance_m",
+                      static_cast<int>(k));
+        reader.get(query, b.total_distance_m);
+        std::snprintf(query, sizeof(query), "bins[%d].total_steps",
+                      static_cast<int>(k));
+        reader.get(query, b.total_steps);
+        std::snprintf(query, sizeof(query), "bins[%d].sample_count",
+                      static_cast<int>(k));
+        reader.get(query, b.sample_count);
+
+        // Reject implausible persisted values (non-finite or negative): a
+        // syntactically valid but corrupt file must not inject bad state that
+        // would skew SL / phase-2 readiness.
+        if (!std::isfinite(b.total_distance_m) || b.total_distance_m < 0.0f ||
+            !std::isfinite(b.total_steps)      || b.total_steps < 0.0f ||
+            !std::isfinite(b.sample_count)     || b.sample_count < 0.0f) {
+            b = StrideBin {};
+        }
+    }
+
+    return true;
+}
+
+void OutdoorStrideCalibrator::backupCorruptFile()
+{
+    char bak[SDK::Interface::IFileSystem::skMaxPathLen] {};
+    const int written = std::snprintf(bak, sizeof(bak), "%s.bak", mPath);
+    if (written > 0 && written < static_cast<int>(sizeof(bak))) {
+        mFs.copy(mPath, bak);
+    }
+}
+
+void OutdoorStrideCalibrator::load()
+{
+    clearBins();
+
+    // The calibrator instance is reused across runs; start each session clean
+    // so the §6.4 write gate (accepted-this-session > 0) is per-session.
+    mSessionAccepted = 0;
+    mPaused          = false;
+    resetSteadyState();
+
+    std::unique_ptr<SDK::Interface::IFile> file = mFs.file(mPath);
+    if (!file || !file->exist()) {
+        return;  // absent → fresh, no backup
+    }
+
+    if (!file->open(false, false)) {
+        return;  // cannot open → fresh, no backup
+    }
+
+    const size_t size = file->size();
+    if (size == 0) {
+        file->close();
+        return;  // empty → fresh, no backup
+    }
+    if (size > kMaxStoreBytes) {
+        // Implausibly large store: treat as corrupt and avoid a large transient
+        // heap allocation. Back it up for inspection and start fresh.
+        file->close();
+        backupCorruptFile();
+        return;  // bins already cleared above
+    }
+
+    char *buffer = new (std::nothrow) char[size];
+    if (buffer == nullptr) {
+        file->close();
+        return;
+    }
+
+    size_t read = 0;
+    const bool readOk = file->read(buffer, size, read) && (read == size);
+    file->close();
+
+    if (!readOk) {
+        delete[] buffer;
+        return;  // read error → fresh, no backup
+    }
+
+    if (!parseBuffer(buffer, size)) {
+        // Malformed JSON: back up and start fresh (§6.3).
+        backupCorruptFile();
+        clearBins();
+    }
+
+    delete[] buffer;
+}
+
+bool OutdoorStrideCalibrator::finalise()
+{
+    // Session is ending — close the debug trace (if any) regardless of outcome.
+    closeTrace();
+
+    // §6.4 write condition: only persist if at least one sample was accepted.
+    if (mSessionAccepted == 0) {
+        return false;
+    }
+
+    // Ensure the SharedData directory exists (FatFs f_open does not create
+    // missing parents). "Already exists" counts as success (§6.1).
+    const char *slash = std::strrchr(mPath, '/');
+    if (slash != nullptr) {
+        char dir[SDK::Interface::IFileSystem::skMaxPathLen] {};
+        std::snprintf(dir, sizeof(dir), "%.*s",
+                      static_cast<int>(slash - mPath), mPath);
+        if (!mFs.mkdir(dir)) {
+            return false;
+        }
+    }
+
+    std::unique_ptr<SDK::Interface::IFile> file = mFs.file(mPath);
+    if (!file || !file->open(true, true)) {
+        return false;
+    }
+
+    SDK::JsonStreamWriter writer(file.get());
+    writer.startMap();
+    writer.add("version", static_cast<int32_t>(kCurrentVersion));
+    writer.startArray("bins");
+    for (size_t i = 0; i < Config::kBinCount; ++i) {
+        writer.startMap();
+        writer.add("centre_spm",
+                   static_cast<int32_t>(std::lround(binCentreSpm(i))));
+        writer.add("total_distance_m", mBins[i].total_distance_m);
+        writer.add("total_steps",      mBins[i].total_steps);
+        writer.add("sample_count",     mBins[i].sample_count);
+        writer.endMap();
+    }
+    writer.endArray();
+    writer.endMap();
+    writer.flush();
+
+    // Fold the final flush/close status into the result: on flash-backed FatFs
+    // the buffered tail may only reach storage at flush()/close(), so a failure
+    // there leaves the persisted store incomplete even when the writer itself
+    // reported no error. Call both unconditionally so close() still runs if
+    // flush() fails.
+    bool ok = !writer.isError();
+    ok = file->flush() && ok;
+    ok = file->close() && ok;
+    return ok;
+}
+
+// --- Debug trace (spec §9.2) ------------------------------------------------
+
+void OutdoorStrideCalibrator::enableTrace(const char *path)
+{
+    closeTrace();
+    if (path == nullptr) {
+        return;
+    }
+
+    // Ensure the parent directory exists (e.g. SharedData). Ignore the result;
+    // the open below is the real success check.
+    const char *slash = std::strrchr(path, '/');
+    if (slash != nullptr) {
+        char dir[SDK::Interface::IFileSystem::skMaxPathLen] {};
+        std::snprintf(dir, sizeof(dir), "%.*s",
+                      static_cast<int>(slash - path), path);
+        mFs.mkdir(dir);
+    }
+
+    std::unique_ptr<SDK::Interface::IFile> file = mFs.file(path);
+    if (!file || !file->open(true, true)) {
+        return;  // leave tracing disabled on failure
+    }
+
+    static const char header[] =
+        "row,gps_speed_ms,gps_speed_valid,gps_fix_dead_reckoning,"
+        "cadence_spm,cadence_valid,grade_pct,grade_valid,delta_t_s,"
+        "g_gps,g_fix,g_speed,g_cad_valid,g_cad_bounds,g_grade_valid,"
+        "g_grade_bounds,g_speed_steady,g_cad_steady,steady_s,verdict\n";
+    size_t bw = 0;
+    file->write(header, sizeof(header) - 1, bw);
+    file->flush();
+
+    mTraceFile = std::move(file);
+    mTraceRow  = 0;
+}
+
+void OutdoorStrideCalibrator::writeTraceRow(const CalibratorSample &s,
+                                            const GateTrace &g,
+                                            const char *verdict)
+{
+    if (!mTraceFile) {
+        return;
+    }
+
+    char line[256];
+    const int n = std::snprintf(
+        line, sizeof(line),
+        "%" PRIu32 ",%.3f,%d,%d,%.2f,%d,%.3f,%d,%.3f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%.3f,%s\n",
+        mTraceRow,
+        static_cast<double>(s.gps_speed_ms), s.gps_speed_valid ? 1 : 0,
+        s.gps_fix_dead_reckoning ? 1 : 0,
+        static_cast<double>(s.cadence_spm), s.cadence_valid ? 1 : 0,
+        static_cast<double>(s.grade_pct), s.grade_valid ? 1 : 0,
+        static_cast<double>(s.delta_t_s),
+        g.gpsValid ? 1 : 0, g.fixOk ? 1 : 0, g.speedBounds ? 1 : 0,
+        g.cadValid ? 1 : 0, g.cadBounds ? 1 : 0, g.gradeValid ? 1 : 0,
+        g.gradeBounds ? 1 : 0, g.speedSteady ? 1 : 0, g.cadSteady ? 1 : 0,
+        static_cast<double>(mSteadySeconds), verdict);
+
+    if (n > 0) {
+        size_t bw = 0;
+        const size_t len = (static_cast<size_t>(n) < sizeof(line))
+                               ? static_cast<size_t>(n)
+                               : sizeof(line) - 1;
+        mTraceFile->write(line, len, bw);
+        mTraceFile->flush();
+    }
+    ++mTraceRow;
+}
+
+void OutdoorStrideCalibrator::closeTrace()
+{
+    if (mTraceFile) {
+        mTraceFile->flush();
+        mTraceFile->close();
+        mTraceFile.reset();
+    }
+}
+
+} // namespace SDK::Calibration

--- a/Libs/Source/Simulator/Components/Sensors/Gps/GpsSpeed.cpp
+++ b/Libs/Source/Simulator/Components/Sensors/Gps/GpsSpeed.cpp
@@ -90,6 +90,11 @@ void GpsSpeed::sensorRefresh()
         auto& sample = mDriver.getDataSample();
         sample.setTimestamp(SDK::Simulator::Mock::System::GetTimeMs());
         sample.f[SDK::SensorDataParser::GpsSpeed::Field::SPEED] = mGps.getSpeed();
+        // The simulator's IGps has no fix-mode/dead-reckoning concept, so a fix
+        // is always a reliable (non-DR) fix here.
+        sample.u[SDK::SensorDataParser::GpsSpeed::Field::SPEED_VALID] =
+            mGps.hasFix() ? 1u : 0u;
+        sample.u[SDK::SensorDataParser::GpsSpeed::Field::DEAD_RECKONING] = 0u;
         mDriver.pushDataSample();
 
         LOG_DEBUG("EXIT\n");

--- a/Libs/Source/Simulator/Components/Sensors/Imu/ImuRunningCadence.cpp
+++ b/Libs/Source/Simulator/Components/Sensors/Imu/ImuRunningCadence.cpp
@@ -12,14 +12,12 @@
 #include "SDK/Simulator/Components/Sensors/IMU/ImuRunningCadence.hpp"
 #include "SDK/SensorLayer/DataParsers/SensorDataParserRunningCadence.hpp"
 #include "SDK/Simulator/Kernel/Mock/System.hpp"
-#include "SDK/Simulator/Components/ComponentSimulator.hpp"
 
 namespace Sensor
 {
 
 ImuRunningCadence::ImuRunningCadence()
-    : mGps(ComponentSimulator::GetInstance().getGps())
-    , mDriver(*this,
+    : mDriver(*this,
               SDK::Sensor::Type::RUNNING_CADENCE,
               SDK::SensorDataParser::RunningCadence::getFieldsNumber(),
               *this)
@@ -37,7 +35,6 @@ float ImuRunningCadence::sdcStart(Sensor::Driver* driver, float period)
     (void)driver;
 
     LOG_INFO("start\n");
-    mGps.enable();
     mTimer.start(mMinPeriodMs);
     return static_cast<float>(mMinPeriodMs);
 }
@@ -48,7 +45,6 @@ void ImuRunningCadence::sdcStop(Sensor::Driver* driver)
 
     LOG_INFO("stop\n");
     mTimer.stop();
-    mGps.disable();
 }
 
 float ImuRunningCadence::sdcUpdatePeriod(Sensor::Driver* driver, float period)
@@ -93,15 +89,9 @@ void ImuRunningCadence::publishSample()
     sample.f[Field::CADENCE_SPM] = mSimCadenceSpm;
     sample.u[Field::CADENCE_VALID] = cadenceValid ? 1u : 0u;
 
-    const float speed = mGps.getSpeed();
-    if (cadenceValid && mGps.hasFix() && speed >= 0.5f && speed <= 8.0f) {
-        const float stepLengthM = speed / (mSimCadenceSpm / 60.0f);
-        sample.f[Field::STEP_LENGTH_M] = stepLengthM;
-        sample.u[Field::STEP_LENGTH_VALID] = 1;
-    } else {
-        sample.f[Field::STEP_LENGTH_M] = 0.0f;
-        sample.u[Field::STEP_LENGTH_VALID] = 0;
-    }
+    // Step length is derived SDK-side from GPS speed + cadence at record-write
+    // time (Outdoor-Data-Collection.md §3.6); the cadence sensor emits cadence
+    // only, so it is no longer published here.
 
     mDriver.pushDataSample();
 }

--- a/cmake/una-sdk.cmake
+++ b/cmake/una-sdk.cmake
@@ -45,6 +45,10 @@ set(UNA_SDK_SOURCES_TRACKMAP
     "$ENV{UNA_SDK}/Libs/Source/TrackMap/TrackMapBuilder.cpp"
 )
 
+set(UNA_SDK_SOURCES_CALIBRATION
+    "$ENV{UNA_SDK}/Libs/Source/Calibration/OutdoorStrideCalibrator.cpp"
+)
+
 # Combined service sources for backward compatibility
 set(UNA_SDK_SOURCES_SERVICE
     "${UNA_SDK_SOURCES_APPSYSTEM}"
@@ -52,6 +56,7 @@ set(UNA_SDK_SOURCES_SERVICE
     "${UNA_SDK_SOURCES_JSON}"
     "${UNA_SDK_SOURCES_SENSOR}"
     "${UNA_SDK_SOURCES_TRACKMAP}"
+    "${UNA_SDK_SOURCES_CALIBRATION}"
 )
 
 set(UNA_SDK_SOURCES_GUI


### PR DESCRIPTION
SDK portion of `Docs/Treadmill/Outdoor-Data-Collection.md` (single squashed commit).

## Changes
- **`OutdoorStrideCalibrator`** (+ `OutdoorStrideCalibConfig`, `StrideMath`): sample-acceptance state machine, distance-cap EMA bin aggregation, post-gate stride plausibility, phase-2 read path, JSON persistence over `IFileSystem` (load/finalise/backup, schema versioning, size/value/path guards), and an optional per-tick CSV debug trace (§9.2) gated by an app settings flag.
- **`SensorDataParserGrade`** + `Sensor::Type::GRADE`.
- **GPS_SPEED parser**: `SPEED_VALID` (reliable fix, excludes dead-reckoning) + `DEAD_RECKONING`; **RunningCadence parser** drops `STEP_LENGTH` (COUNT 4→2).
- **Running app `Service`**: owns the calibrator, subscribes to GRADE, assembles a `CalibratorSample` per 1 Hz tick and drives `load/ingest/pause/resume/finalise`; `record.step_length` derived via `StrideMath`.
- `una-sdk.cmake` Calibration source group; simulator updated.

## Verification
- 90 host unit tests pass (in the una-kernel repo `Tests/Host`).
- Running app builds clean natively on ARM (`RunningService.elf`).

Paired with the **una-kernel** PR (kernel changes + submodule bump). CodeRabbit: 0 actionable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outdoor stride calibration to improve step-length estimates using GPS speed, cadence and terrain grade.
  * Step-length now derived from GPS speed + cadence at record write.

* **Sensors & Simulation**
  * Added terrain grade sensor and richer GPS-speed metadata (validity + dead-reckoning).
  * Simulators now publish cadence-only; step-length is produced by the SDK.

* **Settings**
  * Persistent calibration storage with optional per-session CSV trace and a new toggle to enable tracing.

* **Chores**
  * Repository auto-review configuration added for pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UNAWatch/una-sdk/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->