### PR TITLE
ci(docs): scope Pages deploy to sdk-v* tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches: [ main, develop ]
-    tags: [ '*' ]
+    tags: [ 'sdk-v*' ]
     paths:
       - 'Docs/**'
       - '.github/workflows/docs.yml'


### PR DESCRIPTION
## Problem

The `Documentation` workflow triggered on **every** tag (`tags: ['*']`). After the una-apps→una-sdk merge, release tags landing here (`sdk-v*`, `apps-v*`) all kick off a Pages deploy, but the `github-pages` environment only allows `main` + `v*` tag policies. Every prefixed release tag therefore failed the `deploy` job:

```
Tag "sdk-v0.1.5-rc1" is not allowed to deploy to github-pages due to environment protection rules.
```

Affected runs: `sdk-v0.1.4`, `apps-v0.1.9-rc1`, `sdk-v0.1.5-rc1`, `apps-v0.1.9-rc2` (build always passed; only deploy was rejected).

## Fix

Scope the tag trigger to **`sdk-v*`** so only SDK releases (including `-rc*` candidates) publish versioned docs. Apps tags no longer trigger a doc build — they only republished the same SDK docs under an apps-named version.

Paired with this, an `sdk-v*` tag policy was added to the `github-pages` environment allowlist so the deploy is permitted.

## Notes
- RC tags intentionally publish docs (e.g. `sdk-v0.1.5-rc1`).
- No change to `main` → `latest` behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation workflow trigger configuration to restrict deployment activation for tag-based events to specific patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->