### PR TITLE
feat(calibration): drop the phase-2 total-distance floor

### DIFF
--- a/Libs/Header/SDK/Calibration/OutdoorStrideCalibConfig.hpp
+++ b/Libs/Header/SDK/Calibration/OutdoorStrideCalibConfig.hpp
@@ -62,11 +62,15 @@ constexpr float kBinValidMinSteps = 200.0f;
 
 // --- Phase-2 gate -------------------------------------------------
 
-/// Valid bins required for the phase-2 gate.
+/// Valid bins required for the phase-2 (fully-calibrated) gate. This is the sole
+/// condition: 8 distinct valid bins, each already requiring kBinValidMinSteps
+/// accepted steps, give both cadence-coverage breadth and per-bin confidence.
+/// There is deliberately no total-distance floor -- it was a weak proxy that, in
+/// practice, almost never bound (a typical cadence range piles far more than the
+/// old 5 km floor into a few bins long before 8 distinct bins validate), and
+/// phase 2 only *starts* the delta LUT learning (it keeps refining afterward),
+/// so the floor added cost without meaningfully protecting calibration quality.
 constexpr size_t kOutdoorLutMinValidBins = 8;
-
-/// Total LUT distance required for the phase-2 gate, metres.
-constexpr float kOutdoorLutMinCalibrationDistanceM = 5000.0f;
 
 // --- Intermediate (outdoor-estimate) gate -------------------------
 

--- a/Libs/Header/SDK/Calibration/StrideLut.hpp
+++ b/Libs/Header/SDK/Calibration/StrideLut.hpp
@@ -126,8 +126,8 @@ public:
     /// Total accumulated calibration distance across all bins, metres.
     float totalCalibrationDistanceM() const;
 
-    /// True when both phase-2 conditions hold (>=8 valid bins and >=5000 m).
-    /// At this point the delta LUT may begin learning.
+    /// True when the phase-2 condition holds (>= kOutdoorLutMinValidBins valid
+    /// bins; no distance floor). At this point the delta LUT may begin learning.
     bool readyForPhase2() const;
 
     /// True once there is enough outdoor data to use the LUT for live

--- a/Libs/Source/Calibration/StrideLut.cpp
+++ b/Libs/Source/Calibration/StrideLut.cpp
@@ -69,8 +69,7 @@ float StrideLut::totalCalibrationDistanceM() const
 
 bool StrideLut::readyForPhase2() const
 {
-    return validBinCount() >= Config::kOutdoorLutMinValidBins &&
-           totalCalibrationDistanceM() >= Config::kOutdoorLutMinCalibrationDistanceM;
+    return validBinCount() >= Config::kOutdoorLutMinValidBins;
 }
 
 bool StrideLut::readyForOutdoorEstimate() const

--- a/Tests/Host/calibration/CadenceStrideModel_test.cpp
+++ b/Tests/Host/calibration/CadenceStrideModel_test.cpp
@@ -92,10 +92,10 @@ TEST(CadenceStrideModel, PhaseUncalibratedWhenNoLut)
     EXPECT_FALSE(m.outdoorLutReady());
 }
 
-TEST(CadenceStrideModel, PhaseCalibratedAtThreshold)
+TEST(CadenceStrideModel, PhaseCalibratedAtFullBinCount)
 {
     SDK::Test::FakeFileSystem fs;
-    // 8 valid bins, 625 m each → 5000 m total (== threshold).
+    // 8 valid bins → full tier (bin count is the sole condition).
     fs.seedFile(kOutPath, makeStoreJson(1, phase2Bins(8, 625.0f)));
     CadenceStrideModel m(fs, kOutPath, kDeltaPath);
     m.startSession(1.75f);
@@ -116,15 +116,17 @@ TEST(CadenceStrideModel, PhaseEstimateBelowFullBinCount)
     EXPECT_FALSE(m.outdoorLutReady());
 }
 
-TEST(CadenceStrideModel, PhaseEstimateBelowFullDistance)
+TEST(CadenceStrideModel, PhaseCalibratedAtFullBinsRegardlessOfDistance)
 {
     SDK::Test::FakeFileSystem fs;
     fs.seedFile(kOutPath, makeStoreJson(1, phase2Bins(8, 500.0f)));  // 4000 m, 8 bins
     CadenceStrideModel m(fs, kOutPath, kDeltaPath);
     m.startSession(1.75f);
-    // 8 valid bins but <5000 m total → estimate, not full.
-    EXPECT_EQ(m.phase(), Phase::OUTDOOR_ESTIMATE);
-    EXPECT_FALSE(m.deltaLearningActive());
+    // 8 valid bins is the sole full-tier condition (no distance floor): even at
+    // 4000 m total this is OUTDOOR_CALIBRATED with the delta LUT learning.
+    EXPECT_EQ(m.phase(), Phase::OUTDOOR_CALIBRATED);
+    EXPECT_TRUE(m.outdoorLutReady());
+    EXPECT_TRUE(m.deltaLearningActive());
 }
 
 TEST(CadenceStrideModel, PhaseEstimateAtOneValidBin)

--- a/Tests/Host/calibration/OutdoorStrideCalibrator_test.cpp
+++ b/Tests/Host/calibration/OutdoorStrideCalibrator_test.cpp
@@ -419,7 +419,7 @@ TEST(OutdoorStrideCalibrator, Phase2GateReady)
     EXPECT_TRUE(c.readyForPhase2());
 }
 
-TEST(OutdoorStrideCalibrator, Phase2GateNotReadyOnDistance)
+TEST(OutdoorStrideCalibrator, Phase2GateReadyAtLowDistance)
 {
     SDK::Test::FakeFileSystem fs;
     std::vector<SeedBin> bins;
@@ -430,8 +430,9 @@ TEST(OutdoorStrideCalibrator, Phase2GateNotReadyOnDistance)
 
     OutdoorStrideCalibrator c(fs, kPath);
     c.load();
+    // 8 valid bins is the sole gate; no distance floor, so 4000 m is ready.
     EXPECT_EQ(c.validBinCount(), 8u);
-    EXPECT_FALSE(c.readyForPhase2());
+    EXPECT_TRUE(c.readyForPhase2());
 }
 
 TEST(OutdoorStrideCalibrator, Phase2GateNotReadyOnBinCount)

--- a/Tests/Host/calibration/StrideLut_test.cpp
+++ b/Tests/Host/calibration/StrideLut_test.cpp
@@ -183,7 +183,7 @@ TEST(StrideLut, Phase2GateReady)
     EXPECT_TRUE(lut.readyForPhase2());
 }
 
-TEST(StrideLut, Phase2GateNotReadyOnDistance)
+TEST(StrideLut, Phase2GateReadyAtLowDistance)
 {
     SDK::Test::FakeFileSystem fs;
     std::vector<SeedBin> bins;
@@ -193,8 +193,10 @@ TEST(StrideLut, Phase2GateNotReadyOnDistance)
     fs.seedFile(kPath, makeStoreJson(1, bins));
     StrideLut lut;
     ASSERT_TRUE(lut.loadFromFile(fs, kPath));
+    // 8 valid bins is the sole gate; there is no distance floor, so 4000 m total
+    // is still ready for phase 2.
     EXPECT_EQ(lut.validBinCount(), 8u);
-    EXPECT_FALSE(lut.readyForPhase2());
+    EXPECT_TRUE(lut.readyForPhase2());
 }
 
 TEST(StrideLut, Phase2GateNotReadyOnBinCount)


### PR DESCRIPTION
## Summary

The treadmill **phase-2 ("fully calibrated") gate** now requires only **≥8 valid bins** (`kOutdoorLutMinValidBins`); the **≥5000 m total-distance** condition is removed.

## Rationale
Each valid bin already requires `kBinValidMinSteps` (200) accepted steps, so 8 valid bins give both cadence-coverage breadth **and** per-bin statistical confidence. The aggregate distance floor was a weak proxy that:
- **almost never bound in practice** — a typical (narrow) cadence range banks far more than 5 km into a few bins long before 8 *distinct* bins validate; and
- guarded the wrong thing — phase 2 only *starts* the delta LUT learning, which keeps refining afterward, so entering it slightly earlier self-corrects.

The intermediate **outdoor-estimate tier** (≥1 valid bin) already personalises the stride before phase 2, further lowering the stakes.

## Changes
- `StrideLut::readyForPhase2()` drops the distance term (sole condition: valid-bin count).
- Remove the now-unused `kOutdoorLutMinCalibrationDistanceM` constant (the `totalCalibrationDistanceM()` accessor is kept for telemetry).
- Tests: the two "not ready on distance" cases (8 valid bins, 4000 m) now assert **ready**; bin-count cases unchanged.

## Verification
- Full host suite green: **120 tests**.

Companion kernel-side spec doc updates (Treadmill-Specification, Cadence-Stride-Estimation, Outdoor-Data-Collection, field-test) land with the kernel submodule bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated outdoor stride calibration to advance to phase-2 learning based solely on valid data point accumulation, removing the previous minimum distance requirement for faster calibration progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->