### PR TITLE
feat(treadmill): always offer Calibrate & Save; demographic-gradient extrapolation

### DIFF
--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/trackaction_screen/TrackActionPresenter.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/trackaction_screen/TrackActionPresenter.hpp
@@ -30,8 +30,10 @@ public:
     virtual void onTrackData(const Track::Data& data) override;
 
     void resumeTrack();
-    /// Stop recording and route to Calibrate & Save (eligible) or straight to
-    /// the saved screen (§5.1: offer calibration only for sessions >= 2 km).
+    /// Stop recording and always route to Calibrate & Save (every run, any
+    /// tier); the user corrects the recorded distance/avg speed there, or skips.
+    /// Whether an entered distance also updates the delta LUT is gated
+    /// Service-side (outdoor-calibrated tier + a minimum distance), not here.
     void saveRequested();
 
 private:

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/trackaction_screen/TrackActionPresenter.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/trackaction_screen/TrackActionPresenter.cpp
@@ -40,15 +40,13 @@ void TrackActionPresenter::resumeTrack()
 void TrackActionPresenter::saveRequested()
 {
     // Stop recording. The Service builds the summary at the estimated distance
-    // and, for eligible sessions, waits for the Calibrate & Save decision.
+    // and waits for the Calibrate & Save decision.
     model->saveTrack();
 
-    // Offer Calibrate & Save only for sessions of at least 2 km (§5.1); shorter
-    // ones are finalised immediately by the Service with the estimate. The intro
-    // screen explains the calibration step, then advances to the distance picker.
-    if (model->getTrackData().distance >= 2000.0f) {
-        model->application().gotoTrackCalibrateIntroScreenNoTransition();
-    } else {
-        model->application().gotoTrackSavedScreenNoTransition();
-    }
+    // Always offer Calibrate & Save so the user can correct the recorded
+    // distance (and the avg speed derived from it) on any run. The intro screen
+    // explains the step, then advances to the distance picker; the user can skip
+    // to keep the estimate. Whether the entered distance also updates the delta
+    // LUT is gated Service-side (outdoor-calibrated tier + a minimum distance).
+    model->application().gotoTrackCalibrateIntroScreenNoTransition();
 }

--- a/Examples/Apps/Treadmill/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Header/Service.hpp
@@ -165,10 +165,10 @@ private:
     SDK::Calibration::TreadmillSpeedEstimator mEstimator;
 
     // -- Post-run Calibrate & Save (§5) -----------------------------------
-    /// Offer Calibrate & Save only for sessions of at least this distance.
-    static constexpr float skCalibrateMinDistanceM = 2000.0f;
     /// True between "stop recording" and the GUI's calibrate/skip decision;
-    /// the FIT session is finalised only once this resolves.
+    /// the FIT session is finalised only once this resolves. Calibrate & Save is
+    /// offered on every run; the delta-LUT learning gate (tier + minimum
+    /// distance) lives in CadenceStrideModel::applyPostRunCalibration.
     bool  mAwaitingCalibration = false;
     float mCalibSteps[SDK::Calibration::StrideLut::kBinCount] = {}; ///< S_i snapshot.
     float mCalibDEstimatedM = 0.0f;                                 ///< Pre-correction distance.

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
@@ -948,22 +948,22 @@ void Service::stopTrack(bool discard)
              static_cast<uint32_t>(mTimeCounter.getValueTotal()),
              static_cast<double>(mCalibDEstimatedM));
 
-    // Sessions >= 2 km wait for the GUI's Calibrate & Save decision; shorter
-    // ones finalise immediately with the estimated distance.
-    if (mCalibDEstimatedM >= skCalibrateMinDistanceM) {
-        mAwaitingCalibration = true;
-        LOG_INFO("Awaiting Calibrate & Save (D_est %.1f m)\n",
-                 static_cast<double>(mCalibDEstimatedM));
-    } else {
-        finalizeActivity(0.0f);
-    }
+    // Every session waits for the GUI's Calibrate & Save decision so the user
+    // can correct the recorded distance (and the avg speed derived from it) on
+    // any run. The delta-LUT *learning* is gated separately inside
+    // CadenceStrideModel::applyPostRunCalibration (outdoor-calibrated tier + a
+    // minimum distance); correcting the FIT file is not.
+    mAwaitingCalibration = true;
+    LOG_INFO("Awaiting Calibrate & Save (D_est %.1f m)\n",
+             static_cast<double>(mCalibDEstimatedM));
 }
 
 void Service::finalizeActivity(float distanceActualM)
 {
-    // distanceActualM <= 0 => skip calibration (keep the estimate). In phase 2
-    // an accepted value also nudges the delta LUT (§5.3); in phase 1 it only
-    // rewrites the recorded distance.
+    // distanceActualM <= 0 => skip calibration (keep the estimate). An accepted
+    // value always rewrites the recorded distance; it additionally nudges the
+    // delta LUT only in the outdoor-calibrated tier and above the minimum
+    // distance (§5.3) — applyPostRunCalibration owns that gate.
     const SDK::Calibration::CadenceStrideModel::CalibrationResult res =
         mModel.applyPostRunCalibration(mCalibSteps, mCalibDEstimatedM, distanceActualM);
 

--- a/Libs/Header/SDK/Calibration/CadenceStrideModelConfig.hpp
+++ b/Libs/Header/SDK/Calibration/CadenceStrideModelConfig.hpp
@@ -29,7 +29,9 @@ namespace Config
 // overground plateau, per the speed-research doc), so SL(c) is modelled as a
 // straight line through two population anchors at a reference height, then
 // scaled by the user's height: SL(c,h) = (h / kDemoRefHeightM) * line(c).
-// Anchors are firmware-tunable; gender refinement is still deferred.
+// Anchors are firmware-tunable. The model is unisex by design — a
+// gender-specific stride model is not planned (no robust sex effect at matched
+// running speeds).
 constexpr float kDemoRefHeightM   = 1.75f;    ///< Reference height for the anchors
 constexpr float kDemoCadenceLoSpm = 110.0f;   ///< Walk anchor cadence
 constexpr float kDemoStrideLoM    = 1.51f;    ///<   stride there (~5.0 km/h @ 110 SPM)
@@ -51,6 +53,14 @@ constexpr float kLearningRateEta = 0.4f;
 /// D_actual sanity band as a fraction of D_estimated.
 constexpr float kDActualRatioMin = 0.5f;
 constexpr float kDActualRatioMax = 2.0f;
+
+/// Minimum estimated (pre-correction) session distance, metres, before a
+/// post-run correction may *learn* the delta LUT. The Calibrate & Save screen
+/// is always offered (the user can correct the recorded distance / avg speed on
+/// any run), but delta learning additionally requires the outdoor-calibrated
+/// tier AND this much integrated distance — short runs lack the cadence-bin
+/// coverage to attribute a correction reliably.
+constexpr float kDeltaLearnMinDistanceM = 2000.0f;
 
 // --- Live estimator ----------------------------------------------------------
 

--- a/Libs/Source/Calibration/CadenceStrideModel.cpp
+++ b/Libs/Source/Calibration/CadenceStrideModel.cpp
@@ -126,10 +126,12 @@ float CadenceStrideModel::outdoorStrideLengthM(float cadenceSpm) const
         }
     }
 
-    if (loIdx >= 0 && hiIdx >= 0) {
-        if (loIdx == hiIdx) {
-            return mOutdoor.bin(static_cast<size_t>(loIdx)).strideLengthM();
-        }
+    // Two distinct valid bins bracket c: linear interpolation between their
+    // measured strides. (This is exactly equivalent to the demographic-carrier
+    // form below: SL_demographic is linear in cadence over the interior, so its
+    // contribution cancels between the two endpoints. Kept explicit for clarity
+    // and to keep the well-trodden interior path byte-identical.)
+    if (loIdx >= 0 && hiIdx >= 0 && loIdx != hiIdx) {
         const float cLo = StrideLut::binCentreSpm(static_cast<size_t>(loIdx));
         const float cHi = StrideLut::binCentreSpm(static_cast<size_t>(hiIdx));
         const float slLo = mOutdoor.bin(static_cast<size_t>(loIdx)).strideLengthM();
@@ -140,14 +142,26 @@ float CadenceStrideModel::outdoorStrideLengthM(float cadenceSpm) const
         }
         return slLo + (slHi - slLo) * (cadenceSpm - cLo) / span;
     }
-    if (loIdx >= 0) {
-        // c above the highest valid bin → flat shelf.
-        return mOutdoor.bin(static_cast<size_t>(loIdx)).strideLengthM();
+
+    // At or beyond the valid-bin span — including the single-valid-bin case,
+    // where every cadence is "outside" the (degenerate) span. Instead of a flat
+    // shelf (which would make the estimate cadence-independent, a downgrade from
+    // the demographic tier), ride the demographic cadence slope shifted to pass
+    // through the nearest valid bin:
+    //
+    //   SL(c) = SL_demographic(c) + (SL_anchor − SL_demographic(c_anchor))
+    //
+    // At c == c_anchor this returns SL_anchor exactly; elsewhere it parallels the
+    // demographic slope. The residual is derived per-session from the (frozen)
+    // user height; nothing about it is persisted to the LUT.
+    const int anchorIdx = (loIdx >= 0) ? loIdx : hiIdx;
+    if (anchorIdx >= 0) {
+        const float cAnchor  = StrideLut::binCentreSpm(static_cast<size_t>(anchorIdx));
+        const float slAnchor = mOutdoor.bin(static_cast<size_t>(anchorIdx)).strideLengthM();
+        return demographicStrideLengthM(cadenceSpm)
+             + (slAnchor - demographicStrideLengthM(cAnchor));
     }
-    if (hiIdx >= 0) {
-        // c below the lowest valid bin → flat shelf.
-        return mOutdoor.bin(static_cast<size_t>(hiIdx)).strideLengthM();
-    }
+
     // No valid bin: cannot happen in phase 2 (gate guarantees >=8). Defensive
     // fallback to the demographic stride.
     return demographicStrideLengthM(cadenceSpm);

--- a/Libs/Source/Calibration/CadenceStrideModel.cpp
+++ b/Libs/Source/Calibration/CadenceStrideModel.cpp
@@ -234,23 +234,28 @@ CadenceStrideModel::CalibrationResult CadenceStrideModel::applyPostRunCalibratio
     CalibrationResult result;
     result.dActualAccepted = accepted;
 
-    // Below the full tier (UNCALIBRATED or OUTDOOR_ESTIMATE): never touch the
-    // delta LUT. Calibrate & Save still corrects the recorded distance (use
-    // D_actual when accepted) — only the delta learning is withheld.
-    if (mPhase != Phase::OUTDOOR_CALIBRATED) {
-        result.distanceForFitM = accepted ? D_actual : D_estimated;
+    // FIT distance is always corrected to D_actual when it passes the sanity
+    // gates, on every run and in every tier — Calibrate & Save lets the user fix
+    // the recorded distance (and the avg speed derived from it) regardless of
+    // calibration state. When rejected/skipped, keep the estimate.
+    result.distanceForFitM = accepted ? D_actual : D_estimated;
+
+    // Delta LUT *learning* is gated more tightly than the distance correction:
+    // it requires an accepted D_actual, the outdoor-calibrated tier, AND at
+    // least kDeltaLearnMinDistanceM of estimated distance. Short runs (or lower
+    // tiers) correct the FIT file but never nudge the LUT — they lack the
+    // cadence-bin coverage to attribute the correction reliably.
+    const bool deltaEligible =
+        accepted && mPhase == Phase::OUTDOOR_CALIBRATED &&
+        std::isfinite(D_estimated) &&
+        D_estimated >= Config::kDeltaLearnMinDistanceM;
+    if (!deltaEligible) {
         result.deltaLutUpdated = false;
         return result;
     }
 
-    // Phase 2, rejected: keep the estimate; leave the delta LUT untouched.
-    if (!accepted) {
-        result.distanceForFitM = D_estimated;
-        result.deltaLutUpdated = false;
-        return result;
-    }
-
-    // Phase 2, accepted: §5.3 weighted update over the used bins.
+    // Outdoor-calibrated, accepted, long enough: §5.3 weighted update over the
+    // used bins.
     const float deltaD = D_actual - D_estimated;
     float q = 0.0f;
     for (size_t i = 0; i < StrideLut::kBinCount; ++i) {
@@ -284,8 +289,7 @@ CadenceStrideModel::CalibrationResult CadenceStrideModel::applyPostRunCalibratio
 
     saveDeltaLut();  // app logs a persist failure; learning already applied.
 
-    result.distanceForFitM = D_actual;
-    result.deltaLutUpdated = true;
+    result.deltaLutUpdated = true;  // distanceForFitM already set to D_actual above
     return result;
 }
 

--- a/Tests/Host/calibration/CadenceStrideModel_test.cpp
+++ b/Tests/Host/calibration/CadenceStrideModel_test.cpp
@@ -153,13 +153,15 @@ TEST(CadenceStrideModel, PhaseEstimateAtOneValidBin)
     EXPECT_TRUE(m.usingOutdoorStride());
     EXPECT_FALSE(m.deltaLearningActive());
 
-    // The personalised outdoor stride is used, NOT the demographic fallback.
-    const float demo = m.demographicStrideLengthM(160.0f);
-    EXPECT_NEAR(m.treadmillStrideLengthM(160.0f), 1.5f, 1e-4f);
-    EXPECT_GT(std::fabs(m.treadmillStrideLengthM(160.0f) - demo), 0.1f);
-    // One bin → flat across all cadences (single-point personalisation).
-    EXPECT_NEAR(m.treadmillStrideLengthM(100.0f),
-                m.treadmillStrideLengthM(200.0f), 1e-4f);
+    // The personalised outdoor stride is used: exact at the bin centre, and
+    // shifted from the pure demographic curve elsewhere (measured 1.5 m at the
+    // centre is above the demographic value there → a positive shift).
+    EXPECT_NEAR(m.treadmillStrideLengthM(82.0f), 1.5f, 1e-4f);
+    EXPECT_GT(m.treadmillStrideLengthM(160.0f), m.demographicStrideLengthM(160.0f));
+    // One bin no longer collapses to a flat stride: it rides the demographic
+    // cadence slope, so it stays cadence-dependent (detail in
+    // OutdoorEstimateSingleBinRidesDemographicSlope).
+    EXPECT_GT(m.treadmillStrideLengthM(200.0f), m.treadmillStrideLengthM(100.0f));
 }
 
 TEST(CadenceStrideModel, PhaseUncalibratedWhenNoValidBin)
@@ -267,9 +269,51 @@ TEST(CadenceStrideModel, OutdoorStrideInterpolationAndShelves)
 
     EXPECT_NEAR(m.outdoorStrideLengthM(98.0f), 1.0f, 1e-4f);   // exact centre
     EXPECT_NEAR(m.outdoorStrideLengthM(118.0f), 1.5f, 1e-4f);  // exact centre
-    EXPECT_NEAR(m.outdoorStrideLengthM(108.0f), 1.25f, 1e-4f); // midpoint interp
-    EXPECT_NEAR(m.outdoorStrideLengthM(82.0f), 1.0f, 1e-4f);   // shelf below lowest
-    EXPECT_NEAR(m.outdoorStrideLengthM(218.0f), 1.5f, 1e-4f);  // shelf above highest
+    EXPECT_NEAR(m.outdoorStrideLengthM(108.0f), 1.25f, 1e-4f); // midpoint interp (interior unchanged)
+
+    // Outside the valid span the estimate is no longer a flat shelf: it rides the
+    // demographic cadence slope, shifted to pass through the nearest valid bin.
+    EXPECT_NEAR(m.outdoorStrideLengthM(82.0f),
+                m.demographicStrideLengthM(82.0f)
+                    + (1.0f - m.demographicStrideLengthM(98.0f)),
+                1e-4f);
+    EXPECT_NEAR(m.outdoorStrideLengthM(218.0f),
+                m.demographicStrideLengthM(218.0f)
+                    + (1.5f - m.demographicStrideLengthM(118.0f)),
+                1e-4f);
+    // Cadence-dependent (lower cadence below the lowest bin → shorter stride),
+    // not the old flat 1.0.
+    EXPECT_LT(m.outdoorStrideLengthM(82.0f), 1.0f);
+}
+
+// A single valid bin must NOT collapse to a flat (cadence-independent) stride:
+// that would be a downgrade from the cadence-dependent demographic tier. The
+// estimate tier rides the demographic slope shifted through the one measured bin.
+TEST(CadenceStrideModel, OutdoorEstimateSingleBinRidesDemographicSlope)
+{
+    SDK::Test::FakeFileSystem fs;
+    // One valid bin at centre 130 (>= 200 steps), SL = 300 / (400/2) = 1.5.
+    fs.seedFile(kOutPath, makeStoreJson(1, {{130.0f, 300.0f, 400.0f, 50.0f}}));
+    CadenceStrideModel m(fs, kOutPath, kDeltaPath);
+    m.startSession(1.75f);
+    ASSERT_EQ(m.phase(), Phase::OUTDOOR_ESTIMATE);
+
+    // Exactly the measured stride at the bin centre.
+    EXPECT_NEAR(m.outdoorStrideLengthM(130.0f), 1.5f, 1e-4f);
+
+    // Cadence-dependent away from the bin: lower → shorter, higher → longer.
+    const float slLo = m.outdoorStrideLengthM(100.0f);
+    const float slHi = m.outdoorStrideLengthM(160.0f);
+    EXPECT_LT(slLo, 1.5f);
+    EXPECT_GT(slHi, 1.5f);
+
+    // It is the demographic curve shifted to pass through the bin (parallel shift).
+    const float shift = 1.5f - m.demographicStrideLengthM(130.0f);
+    EXPECT_NEAR(slLo, m.demographicStrideLengthM(100.0f) + shift, 1e-4f);
+    EXPECT_NEAR(slHi, m.demographicStrideLengthM(160.0f) + shift, 1e-4f);
+    const float dDemo =
+        m.demographicStrideLengthM(160.0f) - m.demographicStrideLengthM(100.0f);
+    EXPECT_NEAR(slHi - slLo, dDemo, 1e-4f);
 }
 
 TEST(CadenceStrideModel, OutdoorStrideFallsBackToDemographicWhenNoValidBin)

--- a/Tests/Host/calibration/CadenceStrideModel_test.cpp
+++ b/Tests/Host/calibration/CadenceStrideModel_test.cpp
@@ -383,13 +383,14 @@ TEST(CadenceStrideModel, PostRunPhase2WeightedUpdateIdentityAndPersist)
     m.startSession(1.75f);
     ASSERT_EQ(m.phase(), Phase::OUTDOOR_CALIBRATED);
 
-    // Used bins 0 (centre 82) and 7 (centre 110).
+    // Used bins 0 (centre 82) and 7 (centre 110). Distances are >= the delta
+    // learning floor (kDeltaLearnMinDistanceM = 2000 m) so the LUT actually learns.
     float steps[StrideLut::kBinCount] {};
-    steps[0] = 300.0f;
-    steps[7] = 500.0f;
+    steps[0] = 600.0f;
+    steps[7] = 1000.0f;
 
-    const float dEst = 1000.0f;
-    const float dAct = 1100.0f;  // ratio 1.1, implied mean stride 2.75 → accepted
+    const float dEst = 2000.0f;
+    const float dAct = 2200.0f;  // ratio 1.1, implied mean stride 2.75 → accepted
     auto r = m.applyPostRunCalibration(steps, dEst, dAct);
 
     EXPECT_TRUE(r.dActualAccepted);
@@ -419,6 +420,35 @@ TEST(CadenceStrideModel, PostRunPhase2WeightedUpdateIdentityAndPersist)
     reloaded.startSession(1.75f);
     EXPECT_NEAR(reloaded.deltaAt(82.0f), d0, 1e-5f);
     EXPECT_NEAR(reloaded.deltaAt(110.0f), d7, 1e-5f);
+}
+
+// Outdoor-calibrated tier, accepted D_actual, but the session is shorter than
+// the delta-learning distance floor: the recorded distance is still corrected,
+// but the delta LUT must NOT learn or persist.
+TEST(CadenceStrideModel, PostRunCalibratedBelowMinDistanceCorrectsFitButNoDelta)
+{
+    SDK::Test::FakeFileSystem fs;
+    fs.seedFile(kOutPath, makeStoreJson(1, phase2Bins(8, 650.0f)));  // SL = 1.3
+    CadenceStrideModel m(fs, kOutPath, kDeltaPath);
+    m.startSession(1.75f);
+    ASSERT_EQ(m.phase(), Phase::OUTDOOR_CALIBRATED);
+
+    float steps[StrideLut::kBinCount] {};
+    steps[0] = 300.0f;
+    steps[7] = 500.0f;
+
+    // D_estimated below kDeltaLearnMinDistanceM (2000 m). D_actual ratio 1.1,
+    // implied mean stride 2.75 → would be accepted and would normally learn.
+    const float dEst = 1000.0f;
+    const float dAct = 1100.0f;
+    auto r = m.applyPostRunCalibration(steps, dEst, dAct);
+
+    EXPECT_TRUE(r.dActualAccepted);
+    EXPECT_FALSE(r.deltaLutUpdated);
+    EXPECT_FLOAT_EQ(r.distanceForFitM, dAct);   // FIT distance still corrected
+    EXPECT_NEAR(m.deltaAt(82.0f), 0.0f, 1e-6f); // LUT untouched
+    EXPECT_NEAR(m.deltaAt(110.0f), 0.0f, 1e-6f);
+    EXPECT_FALSE(fs.hasFile(kDeltaPath));        // nothing persisted
 }
 
 // --- Post-run gates ----------------------------------------------------------
@@ -486,13 +516,14 @@ TEST(CadenceStrideModel, PostRunPhase2PerBinClamp)
     ASSERT_EQ(m.phase(), Phase::OUTDOOR_CALIBRATED);
     ASSERT_NEAR(m.outdoorStrideLengthM(82.0f), 4.8f, 1e-3f);
 
-    // Single used bin 0, S = 200. D_actual = 500 (implied mean stride 5.0 == max,
-    // ratio 500/300 = 1.67 → accepted). Raw δ = 0.8 would push SL→5.6; clamp to
-    // 5.0 back-solves δ = 0.2.
+    // Single used bin 0, S = 2000. D_estimated = 2500 (>= the 2000 m delta floor),
+    // D_actual = 4500 (implied mean stride 4500/1000 = 4.5 ≤ max, ratio 1.8 →
+    // accepted). Raw δ = 2·η·ΔD/S = 0.8 would push SL→5.6; clamp to 5.0
+    // back-solves δ = 0.2.
     float steps[StrideLut::kBinCount] {};
-    steps[0] = 200.0f;
-    auto r = m.applyPostRunCalibration(steps, /*D_estimated=*/300.0f,
-                                       /*D_actual=*/500.0f);
+    steps[0] = 2000.0f;
+    auto r = m.applyPostRunCalibration(steps, /*D_estimated=*/2500.0f,
+                                       /*D_actual=*/4500.0f);
     ASSERT_TRUE(r.dActualAccepted);
     ASSERT_TRUE(r.deltaLutUpdated);
 

--- a/Tests/Host/calibration/TreadmillSpeedEstimator_test.cpp
+++ b/Tests/Host/calibration/TreadmillSpeedEstimator_test.cpp
@@ -262,15 +262,17 @@ TEST(TreadmillSpeedEstimator, EndToEndDeltaConvergesTowardActual)
     TreadmillSpeedEstimator est(m);
     est.startSession();
 
-    // Drive a steady cadence trace (within the valid bins, e.g. 100 spm).
+    // Drive a steady cadence trace (within the valid bins, e.g. 100 spm) long
+    // enough to clear the delta-learning distance floor (kDeltaLearnMinDistanceM
+    // = 2000 m; ~1.08 m/s here → ~2166 m over 2000 s).
     const float cadence = 100.0f;
-    for (int i = 0; i < 600; ++i) {
+    for (int i = 0; i < 2000; ++i) {
         est.tick(cadence, true, 1.0f);
     }
     const float dEst = est.distanceM();
-    ASSERT_GT(dEst, 0.0f);
+    ASSERT_GT(dEst, 2000.0f);
 
-    // Console says we actually went 10% further. Within both gates → accepted.
+    // Console says we actually went 10% further. Within all gates → accepted.
     const float dActual = dEst * 1.10f;
     auto r = m.applyPostRunCalibration(est.stepHistogram(), dEst, dActual);
     ASSERT_TRUE(r.dActualAccepted);
@@ -281,7 +283,7 @@ TEST(TreadmillSpeedEstimator, EndToEndDeltaConvergesTowardActual)
     // stride upward), converging toward the actual.
     TreadmillSpeedEstimator est2(m);
     est2.startSession();
-    for (int i = 0; i < 600; ++i) {
+    for (int i = 0; i < 2000; ++i) {
         est2.tick(cadence, true, 1.0f);
     }
     EXPECT_GT(est2.distanceM(), dEst);


### PR DESCRIPTION
## Summary

Two related improvements to the Treadmill post-run calibration and the outdoor stride lookup. SDK-only (calibration lib + Treadmill app + host tests); no JSON schema or file-format changes, so no migration.

### 1. Always offer Calibrate & Save; gate delta learning by tier + distance

Previously the Calibrate & Save screen was shown only for sessions >= 2 km, so shorter runs could not correct the distance / avg speed written to the FIT file. Decouple the two concerns:

- **Always** show Calibrate & Save (every run, every tier). The user corrects the recorded distance; the session `avg_speed` (= `distance / timer_time`) and `max_speed` follow. `TrackActionPresenter::saveRequested` always routes to the intro; `Service::stopTrack` always awaits the decision.
- **Delta-LUT learning** is now gated by BOTH the outdoor-calibrated tier AND a minimum estimated distance (`kDeltaLearnMinDistanceM = 2000 m`), inside `CadenceStrideModel::applyPostRunCalibration`. The FIT-distance correction is applied whenever `D_actual` passes the sanity gates, independent of tier/length.
- Removes the now-unused app-side `skCalibrateMinDistanceM` (the distance floor is the calibration policy's concern, alongside the ratio / implied-stride gates).

### 2. Demographic-gradient extrapolation outside the valid-bin span (no flat shelf)

In the outdoor-estimate tier a single valid bin made `outdoorStrideLengthM()` flat (every cadence shelved to that one bin's stride) — cadence-independent, a downgrade from the cadence-dependent demographic tier it just left. Replace the flat shelf (and the single-bin case) with a demographic carrier:

```
SL(c) = SL_demographic(c) + (SL_anchor - SL_demographic(c_anchor))
```

anchored to the nearest valid bin. At a bin centre it returns the measured stride exactly; elsewhere it parallels the demographic cadence slope, so the estimate is never worse than the demographic model. Because `SL_demographic` is linear in cadence, its contribution **cancels in the interpolation interior** between two valid bins — that path is left byte-identical, so this changes only the single-bin case and the extrapolation tails (which improves tier-3 tails too: a calibrated runner's slow warm-up below their lowest valid bin now gets a cadence-appropriate stride). Nothing is persisted — the residual is computed per session from the frozen user height, so neither `stride.json` nor `treadmill_delta.json` changes.

## Test plan

- `cmake --build build-host` + run: **122 host tests pass** (was 120).
- Added: `PostRunCalibratedBelowMinDistanceCorrectsFitButNoDelta`, `OutdoorEstimateSingleBinRidesDemographicSlope`.
- Updated: the two phase-2 delta tests + the estimator end-to-end test bumped above the 2 km floor; `OutdoorStrideInterpolationAndShelves` shelf assertions and `PhaseEstimateAtOneValidBin` updated to the carrier.
- Interior interpolation verified unchanged; FIT distance / avg-speed consistency unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calibration is now offered for all running sessions, regardless of distance—previously only sessions ≥2 km were eligible.

* **Improvements**
  * Enhanced outdoor stride estimation algorithm for more accurate distance calculations across varying cadence levels.
  * Delta learning refinements now apply only to sessions exceeding 2 km to ensure model quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->