### PR TITLE
fix(treadmill): keep Calibrate & Save prompt up on idle (don't exit the app)

### DIFF
--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/trackcalibrate_screen/TrackCalibratePresenter.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/trackcalibrate_screen/TrackCalibratePresenter.hpp
@@ -28,9 +28,6 @@ public:
     /// Keep the estimated distance (no correction).
     void skipCalibration();
 
-    /// On idle, finalise with the estimate by letting the app stop.
-    virtual void onIdleTimeout() override { model->exitApp(); }
-
 private:
     TrackCalibratePresenter();
 


### PR DESCRIPTION
## Summary

Bug fix: completing a treadmill run and then sitting on the **Calibrate & Save distance-entry screen** exited the app after the screen idle timeout (~30 s of no keypress). Reading the treadmill console and dialing in the distance can take longer than that, so the app closed out from under the user mid-entry.

## Root cause

`TrackCalibratePresenter::onIdleTimeout()` called `model->exitApp()`. The screen idle timer (`kScreenTimeoutSteps`) decrements every tick and, with no keypress, fires `onIdleTimeout()` → app exit. The intro screen (`TrackCalibrateIntroPresenter`) does **not** override `onIdleTimeout`, so it already persists — only the distance picker exited, which is the inconsistency the user hit.

## Fix

Make `TrackCalibratePresenter::onIdleTimeout()` a no-op, so the post-run prompt persists indefinitely with no keypress required (matching the intro screen). The user must explicitly **Save** (R1) or **Skip** (R2). If the kernel force-stops the app, the Service still finalizes the session with the estimate (`finalizeActivity(0)`), so no run data is lost.

One-line change in `TrackCalibratePresenter.hpp` (method body only).

## Test plan

- apps-CI builds the Treadmill `.uapp` (compiles the GUI) — compile gate.
- On-device: complete a run, sit on the distance-entry screen > 30 s → it stays up; Save/Skip still work.

## Notes

- Follows apps-v1.0.1 (una-sdk #153). No JSON/schema changes; no docs impact (idle behavior isn't specced).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified idle timeout behavior during calibration to keep the user on the calibration prompt rather than exiting the app unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->