### PR TITLE
fix(activity): derive lap/session avg speed from distance/time

### DIFF
--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -55,6 +55,7 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\SensorPressure.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuWristMotion.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuStepCounter.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuRunningCadence.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\ComponentSimulator.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Simulator\GpsStepCounterSimulator.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\SensorListener.cpp"/>

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
@@ -978,6 +978,9 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuStepCounter.cpp">
       <Filter>SDK\Libs\Source\Simulator\Components\Sensors\Imu</Filter>
     </ClCompile>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuRunningCadence.cpp">
+      <Filter>SDK\Libs\Source\Simulator\Components\Sensors\Imu</Filter>
+    </ClCompile>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuWristMotion.cpp">
       <Filter>SDK\Libs\Source\Simulator\Components\Sensors\Imu</Filter>
     </ClCompile>

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -34,6 +34,17 @@ static float getPace(float speed, float threshold)
     return (speed > threshold) ? (1.0f / speed) : 0.0f;
 }
 
+// Average speed per the FIT definition: total distance / active timer time.
+// This is NOT the mean of the instantaneous speed samples -- a sample mean
+// drifts away from distance/time because sub-threshold samples are dropped
+// from the average while their seconds still count toward the duration. Using
+// the totals keeps distance, duration and the reported average pace mutually
+// consistent on every lap and session.
+static float speedFromTotals(float distanceM, float activeTimeS)
+{
+    return (activeTimeS > 0.0f) ? (distanceM / activeTimeS) : 0.0f;
+}
+
 } // namespace
 
 Service::Service(SDK::Kernel &kernel)
@@ -621,9 +632,9 @@ void Service::processTrack()
 
     // Speed, m/s
     mTrackData.speed       = mSpeedCounter.getCurrent();
-    mTrackData.avgSpeed    = mSpeedCounter.getAverage();
+    mTrackData.avgSpeed    = speedFromTotals(mTrackData.distance, mTrackData.totalTime);
     mTrackData.maxSpeed    = mSpeedCounter.getMaximum();
-    mTrackData.avgLapSpeed = mSpeedCounter.getLapAverage();
+    mTrackData.avgLapSpeed = speedFromTotals(mTrackData.lapDistance, mTrackData.lapTime);
     mTrackData.maxLapSpeed = mSpeedCounter.getLapMaximum();
 
     // Pace, s/m
@@ -675,11 +686,15 @@ void Service::processTrack()
 
 void Service::saveLap()
 {
+    const auto  lapTime     = mTimeCounter.getLapValueActive();
+    const float lapDistance = mDistanceCounter.getLapValueActive();
+    const float lapSpeed    = speedFromTotals(lapDistance, static_cast<float>(lapTime));
+
     // Accumulate lap into summary
     mSummary.laps.push_back({
-        mTimeCounter.getLapValueActive(),
-        mDistanceCounter.getLapValueActive(),
-        mSpeedCounter.getLapAverage()
+        lapTime,
+        lapDistance,
+        lapSpeed
     });
 
     // Save lap to the FIT file
@@ -687,12 +702,12 @@ void Service::saveLap()
 
     fitLap.timestamp = mTimeCounter.getCurrent();
     fitLap.timeStart = mTimeCounter.getCurrent() - mTimeCounter.getLapValueTotal();
-    fitLap.duration  = mTimeCounter.getLapValueActive();
+    fitLap.duration  = lapTime;
     fitLap.elapsed   = mTimeCounter.getLapValueTotal();
 
-    fitLap.distance  = mDistanceCounter.getLapValueActive();
+    fitLap.distance  = lapDistance;
 
-    fitLap.speedAvg  = mSpeedCounter.getLapAverage();
+    fitLap.speedAvg  = lapSpeed;
     fitLap.speedMax  = mSpeedCounter.getLapMaximum();
 
     fitLap.hrAvg     = mHrCounter.getLapAverage();
@@ -707,8 +722,8 @@ void Service::saveLap()
 
     LOG_INFO("Lap_%u saved. UTC: %u\n", mTrackData.lapNum, static_cast<uint32_t>(mTimeCounter.getCurrent()));
     LOG_INFO("Time: %u / %u s\n", static_cast<uint32_t>(mTimeCounter.getLapValueActive()), static_cast<uint32_t>(mTimeCounter.getLapValueTotal()));
-    LOG_INFO("Distance: %.3f m\n", mDistanceCounter.getLapValueActive());
-    LOG_INFO("Speed: %.3f / %.3f m/s\n", mSpeedCounter.getLapAverage(), mSpeedCounter.getLapMaximum());
+    LOG_INFO("Distance: %.3f m\n", lapDistance);
+    LOG_INFO("Speed: %.3f / %.3f m/s\n", lapSpeed, mSpeedCounter.getLapMaximum());
     LOG_INFO("Heart rate: %.0f / %.0f bpm\n", mHrCounter.getLapAverage(), mHrCounter.getLapMaximum());
     LOG_INFO("Ascent/Descent: %.1f / %.1f m\n", mAltitudeCounter.getLapAscent(), mAltitudeCounter.getLapDescent());
 
@@ -735,9 +750,9 @@ void Service::buildPartialSummary()
     mSummary.utc       = mTimeCounter.getCurrent();
     mSummary.time      = mTimeCounter.getValueActive();
     mSummary.distance  = mDistanceCounter.getValueActive();
-    mSummary.speedAvg  = mSpeedCounter.getAverage();
+    mSummary.speedAvg  = speedFromTotals(mSummary.distance, mSummary.time);
     mSummary.elevation = mAltitudeCounter.getCurrent();
-    mSummary.paceAvg   = getPace(mSpeedCounter.getAverage(), mSpeedCounter.getMinValid());
+    mSummary.paceAvg   = getPace(mSummary.speedAvg, mSpeedCounter.getMinValid());
     mSummary.hrMax     = mHrCounter.getMaximum();
     mSummary.hrAvg     = mHrCounter.getAverage();
     mSummary.map       = mTrackMapBuilder.build(skMapMaxPoints);
@@ -782,7 +797,7 @@ void Service::stopTrack(bool discard)
 
         fitTrack.distance  = mDistanceCounter.getValueActive();
 
-        fitTrack.speedAvg  = mSpeedCounter.getAverage();
+        fitTrack.speedAvg  = speedFromTotals(fitTrack.distance, fitTrack.duration);
         fitTrack.speedMax  = mSpeedCounter.getMaximum();
 
         fitTrack.hrAvg     = mHrCounter.getAverage();
@@ -802,7 +817,7 @@ void Service::stopTrack(bool discard)
     LOG_INFO("Track stopped. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
     LOG_INFO("Time: %u / %u s\n", static_cast<uint32_t>(mTimeCounter.getValueActive()), static_cast<uint32_t>(mTimeCounter.getValueTotal()));
     LOG_INFO("Distance: %.3f m\n", mDistanceCounter.getValueActive());
-    LOG_INFO("Speed: %.3f / %.3f m/s\n", mSpeedCounter.getAverage(), mSpeedCounter.getMaximum());
+    LOG_INFO("Speed: %.3f / %.3f m/s\n", speedFromTotals(mDistanceCounter.getValueActive(), mTimeCounter.getValueActive()), mSpeedCounter.getMaximum());
     LOG_INFO("Heart rate: %.0f / %.0f bpm\n", mHrCounter.getAverage(), mHrCounter.getMaximum());
     LOG_INFO("Ascent/Descent: %.1f / %.1f m\n", mAltitudeCounter.getAscent(), mAltitudeCounter.getDescent());
 

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -60,6 +60,7 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\SensorPressure.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuWristMotion.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuStepCounter.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuRunningCadence.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\ComponentSimulator.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Simulator\GpsStepCounterSimulator.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\SensorListener.cpp"/>

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
@@ -975,6 +975,9 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuStepCounter.cpp">
       <Filter>SDK\Libs\Source\Simulator\Components\Sensors\Imu</Filter>
     </ClCompile>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuRunningCadence.cpp">
+      <Filter>SDK\Libs\Source\Simulator\Components\Sensors\Imu</Filter>
+    </ClCompile>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuWristMotion.cpp">
       <Filter>SDK\Libs\Source\Simulator\Components\Sensors\Imu</Filter>
     </ClCompile>

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -36,6 +36,17 @@ static float getPace(float speed, float threshold)
     return (speed > threshold) ? (1.0f / speed) : 0.0f;
 }
 
+// Average speed per the FIT definition: total distance / active timer time.
+// This is NOT the mean of the instantaneous speed samples -- a sample mean
+// drifts away from distance/time because sub-threshold samples are dropped
+// from the average while their seconds still count toward the duration. Using
+// the totals keeps distance, duration and the reported average pace mutually
+// consistent on every lap and session.
+static float speedFromTotals(float distanceM, float activeTimeS)
+{
+    return (activeTimeS > 0.0f) ? (distanceM / activeTimeS) : 0.0f;
+}
+
 } // namespace
 
 Service::Service(SDK::Kernel &kernel)
@@ -646,9 +657,9 @@ void Service::processTrack()
 
     // Speed, m/s
     mTrackData.speed        = mSpeedCounter.getCurrent();
-    mTrackData.avgSpeed     = mSpeedCounter.getAverage();
+    mTrackData.avgSpeed     = speedFromTotals(mTrackData.distance, mTrackData.totalTime);
     mTrackData.maxSpeed     = mSpeedCounter.getMaximum();
-    mTrackData.avgLapSpeed  = mSpeedCounter.getLapAverage();
+    mTrackData.avgLapSpeed  = speedFromTotals(mTrackData.lapDistance, mTrackData.lapTime);
     mTrackData.maxLapSpeed  = mSpeedCounter.getLapMaximum();
 
     // Pace, s/m
@@ -711,6 +722,10 @@ void Service::processTrack()
 
 void Service::saveLap()
 {
+    const auto  lapTime     = mTimeCounter.getLapValueActive();
+    const float lapDistance = mDistanceCounter.getLapValueActive();
+    const float lapSpeed    = speedFromTotals(lapDistance, static_cast<float>(lapTime));
+
     // Accumulate lap into summary
     mSummary.laps.push_back({
         mTimeCounter.getLapValueActive(),
@@ -723,12 +738,12 @@ void Service::saveLap()
 
     fitLap.timestamp = mTimeCounter.getCurrent();
     fitLap.timeStart = mTimeCounter.getCurrent() - mTimeCounter.getLapValueTotal();
-    fitLap.duration  = mTimeCounter.getLapValueActive();
+    fitLap.duration  = lapTime;
     fitLap.elapsed   = mTimeCounter.getLapValueTotal();
 
-    fitLap.distance  = mDistanceCounter.getLapValueActive();
+    fitLap.distance  = lapDistance;
 
-    fitLap.speedAvg  = mSpeedCounter.getLapAverage();
+    fitLap.speedAvg  = lapSpeed;
     fitLap.speedMax  = mSpeedCounter.getLapMaximum();
 
     fitLap.steps     = mStepCounter.getLapValueActive();
@@ -752,8 +767,8 @@ void Service::saveLap()
 
     LOG_INFO("Lap_%u saved. UTC: %u\n", mTrackData.lapNum, static_cast<uint32_t>(mTimeCounter.getCurrent()));
     LOG_INFO("Time: %u / %u s\n", static_cast<uint32_t>(mTimeCounter.getLapValueActive()), static_cast<uint32_t>(mTimeCounter.getLapValueTotal()));
-    LOG_INFO("Distance: %.3f m\n", mDistanceCounter.getLapValueActive());
-    LOG_INFO("Speed: %.3f / %.3f m/s\n", mSpeedCounter.getLapAverage(), mSpeedCounter.getLapMaximum());
+    LOG_INFO("Distance: %.3f m\n", lapDistance);
+    LOG_INFO("Speed: %.3f / %.3f m/s\n", lapSpeed, mSpeedCounter.getLapMaximum());
     LOG_INFO("Heart rate: %.0f / %.0f bpm\n", mHrCounter.getLapAverage(), mHrCounter.getLapMaximum());
     LOG_INFO("Ascent/Descent: %.1f / %.1f m\n", mAltitudeCounter.getLapAscent(), mAltitudeCounter.getLapDescent());
     LOG_INFO("Steps: %u\n", mStepCounter.getLapValueActive());
@@ -787,10 +802,10 @@ void Service::buildPartialSummary()
     mSummary.utc      = mTimeCounter.getCurrent();
     mSummary.time     = mTimeCounter.getValueActive();
     mSummary.distance = mDistanceCounter.getValueActive();
-    mSummary.speedAvg = mSpeedCounter.getAverage();
+    mSummary.speedAvg = speedFromTotals(mSummary.distance, mSummary.time);
     mSummary.steps    = mStepCounter.getValueActive();
     mSummary.elevation = mAltitudeCounter.getCurrent();
-    mSummary.paceAvg  = getPace(mSpeedCounter.getAverage(), mSpeedCounter.getMinValid());
+    mSummary.paceAvg  = getPace(mSummary.speedAvg, mSpeedCounter.getMinValid());
     mSummary.hrMax    = mHrCounter.getMaximum();
     mSummary.hrAvg    = mHrCounter.getAverage();
     mSummary.map      = mTrackMapBuilder.build(skMapMaxPoints);
@@ -835,7 +850,7 @@ void Service::stopTrack(bool discard)
 
         fitTrack.distance  = mDistanceCounter.getValueActive();
 
-        fitTrack.speedAvg  = mSpeedCounter.getAverage();
+        fitTrack.speedAvg  = speedFromTotals(fitTrack.distance, fitTrack.duration);
         fitTrack.speedMax  = mSpeedCounter.getMaximum();
 
         fitTrack.hrAvg     = mHrCounter.getAverage();
@@ -858,7 +873,7 @@ void Service::stopTrack(bool discard)
     LOG_INFO("Track stopped. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
     LOG_INFO("Time: %u / %u s\n", static_cast<uint32_t>(mTimeCounter.getValueActive()), static_cast<uint32_t>(mTimeCounter.getValueTotal()));
     LOG_INFO("Distance: %.3f m\n", mDistanceCounter.getValueActive());
-    LOG_INFO("Speed: %.3f / %.3f m/s\n", mSpeedCounter.getAverage(), mSpeedCounter.getMaximum());
+    LOG_INFO("Speed: %.3f / %.3f m/s\n", speedFromTotals(mDistanceCounter.getValueActive(), mTimeCounter.getValueActive()), mSpeedCounter.getMaximum());
     LOG_INFO("Heart rate: %.0f / %.0f bpm\n", mHrCounter.getAverage(), mHrCounter.getMaximum());
     LOG_INFO("Ascent/Descent: %.1f / %.1f m\n", mAltitudeCounter.getAscent(), mAltitudeCounter.getDescent());
     LOG_INFO("Steps: %u\n", mStepCounter.getValueActive());

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -728,8 +728,8 @@ void Service::saveLap()
 
     // Accumulate lap into summary
     mSummary.laps.push_back({
-        mTimeCounter.getLapValueActive(),
-        mDistanceCounter.getLapValueActive(),
+        lapTime,
+        lapDistance,
         mStepCounter.getLapValueActive()
     });
 
@@ -756,12 +756,6 @@ void Service::saveLap()
     fitLap.descent   = mAltitudeCounter.getLapDescent();
 
     mActivityWriter.addLap(fitLap);
-
-    LapSummary lapSummary{};
-    lapSummary.duration = mTimeCounter.getLapValueActive();
-    lapSummary.distance = mDistanceCounter.getLapValueActive();
-    lapSummary.steps    = mStepCounter.getLapValueActive();
-    mSummary.laps.push_back(lapSummary);
 
     mTrackData.lapNum++;
 

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -41,6 +41,17 @@ static float getPace(float speed, float threshold)
     return (speed > threshold) ? (1.0f / speed) : 0.0f;
 }
 
+// Average speed per the FIT definition: total distance / active timer time.
+// This is NOT the mean of the instantaneous speed samples -- a sample mean
+// drifts away from distance/time because sub-threshold samples are dropped
+// from the average while their seconds still count toward the duration. Using
+// the totals keeps distance, duration and the reported average pace mutually
+// consistent on every lap and session.
+static float speedFromTotals(float distanceM, float activeTimeS)
+{
+    return (activeTimeS > 0.0f) ? (distanceM / activeTimeS) : 0.0f;
+}
+
 } // namespace
 
 Service::Service(SDK::Kernel &kernel)
@@ -769,9 +780,9 @@ void Service::processTrack()
     // Speed, m/s
     mTrackData.speed = mSpeedCounter.getCurrent();
 
-    mTrackData.avgSpeed    = mSpeedCounter.getAverage();
+    mTrackData.avgSpeed    = speedFromTotals(mTrackData.distance, mTrackData.totalTime);
     mTrackData.maxSpeed    = mSpeedCounter.getMaximum();
-    mTrackData.avgLapSpeed = mSpeedCounter.getLapAverage();
+    mTrackData.avgLapSpeed = speedFromTotals(mTrackData.lapDistance, mTrackData.lapTime);
     mTrackData.maxLapSpeed = mSpeedCounter.getLapMaximum();
 
 
@@ -858,11 +869,15 @@ void Service::processTrack()
 
 void Service::saveLap()
 {
+    const auto  lapTime     = mTimeCounter.getLapValueActive();
+    const float lapDistance = mDistanceCounter.getLapValueActive();
+    const float lapSpeed    = speedFromTotals(lapDistance, static_cast<float>(lapTime));
+
     // Accumulate lap into summary
     mSummary.laps.push_back({
-        mTimeCounter.getLapValueActive(),
-        mDistanceCounter.getLapValueActive(),
-        getPace(mSpeedCounter.getLapAverage(), mSpeedCounter.getMinValid())
+        lapTime,
+        lapDistance,
+        getPace(lapSpeed, mSpeedCounter.getMinValid())
     });
 
     // Save lap to the FIT file
@@ -870,12 +885,12 @@ void Service::saveLap()
 
     fitLap.timestamp = mTimeCounter.getCurrent();
     fitLap.timeStart = mTimeCounter.getCurrent() - mTimeCounter.getLapValueTotal();
-    fitLap.duration  = mTimeCounter.getLapValueActive();
+    fitLap.duration  = lapTime;
     fitLap.elapsed   = mTimeCounter.getLapValueTotal();
 
-    fitLap.distance  = mDistanceCounter.getLapValueActive();
+    fitLap.distance  = lapDistance;
 
-    fitLap.speedAvg  = mSpeedCounter.getLapAverage();
+    fitLap.speedAvg  = lapSpeed;
     fitLap.speedMax  = mSpeedCounter.getLapMaximum();
 
     fitLap.hrAvg     = mHrCounter.getLapAverage();
@@ -894,8 +909,8 @@ void Service::saveLap()
 
     LOG_INFO("Lap_%u saved. UTC: %u\n", mTrackData.lapNum, static_cast<uint32_t>(mTimeCounter.getCurrent()));
     LOG_INFO("Time: %u / %u s\n", static_cast<uint32_t>(mTimeCounter.getLapValueActive()), static_cast<uint32_t>(mTimeCounter.getLapValueTotal()));
-    LOG_INFO("Distance: %.3f m\n", mDistanceCounter.getLapValueActive());
-    LOG_INFO("Speed: %.3f / %.3f m/s\n", mSpeedCounter.getLapAverage(), mSpeedCounter.getLapMaximum());
+    LOG_INFO("Distance: %.3f m\n", lapDistance);
+    LOG_INFO("Speed: %.3f / %.3f m/s\n", lapSpeed, mSpeedCounter.getLapMaximum());
     LOG_INFO("Heart rate: %.0f / %.0f bpm\n", mHrCounter.getLapAverage(), mHrCounter.getLapMaximum());
     LOG_INFO("Ascent/Descent: %.1f / %.1f m\n", mAltitudeCounter.getLapAscent(), mAltitudeCounter.getLapDescent());
 
@@ -922,9 +937,9 @@ void Service::buildPartialSummary()
     mSummary.utc       = mTimeCounter.getCurrent();
     mSummary.time      = mTimeCounter.getValueActive();
     mSummary.distance  = mDistanceCounter.getValueActive();
-    mSummary.speedAvg  = mSpeedCounter.getAverage();
+    mSummary.speedAvg  = speedFromTotals(mSummary.distance, mSummary.time);
     mSummary.elevation = mAltitudeCounter.getCurrent();
-    mSummary.paceAvg   = getPace(mSpeedCounter.getAverage(), mSpeedCounter.getMinValid());
+    mSummary.paceAvg   = getPace(mSummary.speedAvg, mSpeedCounter.getMinValid());
     mSummary.hrMax     = mHrCounter.getMaximum();
     mSummary.hrAvg     = mHrCounter.getAverage();
     mSummary.map       = mTrackMapBuilder.build(skMapMaxPoints);
@@ -969,7 +984,7 @@ void Service::stopTrack(bool discard)
 
         fitTrack.distance  = mDistanceCounter.getValueActive();
 
-        fitTrack.speedAvg  = mSpeedCounter.getAverage();
+        fitTrack.speedAvg  = speedFromTotals(fitTrack.distance, fitTrack.duration);
         fitTrack.speedMax  = mSpeedCounter.getMaximum();
 
         fitTrack.hrAvg     = mHrCounter.getAverage();
@@ -989,7 +1004,7 @@ void Service::stopTrack(bool discard)
     LOG_INFO("Track stopped. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
     LOG_INFO("Time: %u / %u s\n", static_cast<uint32_t>(mTimeCounter.getValueActive()), static_cast<uint32_t>(mTimeCounter.getValueTotal()));
     LOG_INFO("Distance: %.3f m\n", mDistanceCounter.getValueActive());
-    LOG_INFO("Speed: %.3f / %.3f m/s\n", mSpeedCounter.getAverage(), mSpeedCounter.getMaximum());
+    LOG_INFO("Speed: %.3f / %.3f m/s\n", speedFromTotals(mDistanceCounter.getValueActive(), mTimeCounter.getValueActive()), mSpeedCounter.getMaximum());
     LOG_INFO("Heart rate: %.0f / %.0f bpm\n", mHrCounter.getAverage(), mHrCounter.getMaximum());
     LOG_INFO("Ascent/Descent: %.1f / %.1f m\n", mAltitudeCounter.getAscent(), mAltitudeCounter.getDescent());
 

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
@@ -36,6 +36,18 @@ static float getPace(float speed, float threshold)
     return (speed > threshold) ? (1.0f / speed) : 0.0f;
 }
 
+// Average speed per the FIT definition: total distance / active timer time.
+// This is NOT the mean of the instantaneous speed samples -- a sample mean
+// drifts away from distance/time because sub-threshold samples are dropped
+// from the average while their seconds still count toward the duration. Using
+// the totals keeps distance, duration and the reported average pace mutually
+// consistent on every lap and session. (finalizeActivity() already derives the
+// session avg_speed this way; this matches the per-lap and live values to it.)
+static float speedFromTotals(float distanceM, float activeTimeS)
+{
+    return (activeTimeS > 0.0f) ? (distanceM / activeTimeS) : 0.0f;
+}
+
 } // namespace
 
 Service::Service(SDK::Kernel &kernel)
@@ -753,9 +765,9 @@ void Service::processTrack()
     // Speed, m/s
     mTrackData.speed = mSpeedCounter.getCurrent();
 
-    mTrackData.avgSpeed    = mSpeedCounter.getAverage();
+    mTrackData.avgSpeed    = speedFromTotals(mTrackData.distance, mTrackData.totalTime);
     mTrackData.maxSpeed    = mSpeedCounter.getMaximum();
-    mTrackData.avgLapSpeed = mSpeedCounter.getLapAverage();
+    mTrackData.avgLapSpeed = speedFromTotals(mTrackData.lapDistance, mTrackData.lapTime);
     mTrackData.maxLapSpeed = mSpeedCounter.getLapMaximum();
 
 
@@ -821,11 +833,15 @@ void Service::processTrack()
 
 void Service::saveLap()
 {
+    const auto  lapTime     = mTimeCounter.getLapValueActive();
+    const float lapDistance = mDistanceCounter.getLapValueActive();
+    const float lapSpeed    = speedFromTotals(lapDistance, static_cast<float>(lapTime));
+
     // Accumulate lap into summary
     mSummary.laps.push_back({
-        mTimeCounter.getLapValueActive(),
-        mDistanceCounter.getLapValueActive(),
-        getPace(mSpeedCounter.getLapAverage(), mSpeedCounter.getMinValid())
+        lapTime,
+        lapDistance,
+        getPace(lapSpeed, mSpeedCounter.getMinValid())
     });
 
     // Save lap to the FIT file
@@ -833,12 +849,12 @@ void Service::saveLap()
 
     fitLap.timestamp = mTimeCounter.getCurrent();
     fitLap.timeStart = mTimeCounter.getCurrent() - mTimeCounter.getLapValueTotal();
-    fitLap.duration  = mTimeCounter.getLapValueActive();
+    fitLap.duration  = lapTime;
     fitLap.elapsed   = mTimeCounter.getLapValueTotal();
 
-    fitLap.distance  = mDistanceCounter.getLapValueActive();
+    fitLap.distance  = lapDistance;
 
-    fitLap.speedAvg  = mSpeedCounter.getLapAverage();
+    fitLap.speedAvg  = lapSpeed;
     fitLap.speedMax  = mSpeedCounter.getLapMaximum();
 
     fitLap.hrAvg     = mHrCounter.getLapAverage();
@@ -857,8 +873,8 @@ void Service::saveLap()
 
     LOG_INFO("Lap_%u saved. UTC: %u\n", mTrackData.lapNum, static_cast<uint32_t>(mTimeCounter.getCurrent()));
     LOG_INFO("Time: %u / %u s\n", static_cast<uint32_t>(mTimeCounter.getLapValueActive()), static_cast<uint32_t>(mTimeCounter.getLapValueTotal()));
-    LOG_INFO("Distance: %.3f m\n", mDistanceCounter.getLapValueActive());
-    LOG_INFO("Speed: %.3f / %.3f m/s\n", mSpeedCounter.getLapAverage(), mSpeedCounter.getLapMaximum());
+    LOG_INFO("Distance: %.3f m\n", lapDistance);
+    LOG_INFO("Speed: %.3f / %.3f m/s\n", lapSpeed, mSpeedCounter.getLapMaximum());
     LOG_INFO("Heart rate: %.0f / %.0f bpm\n", mHrCounter.getLapAverage(), mHrCounter.getLapMaximum());
     LOG_INFO("Ascent/Descent: %.1f / %.1f m\n", mAltitudeCounter.getLapAscent(), mAltitudeCounter.getLapDescent());
 
@@ -885,9 +901,9 @@ void Service::buildPartialSummary()
     mSummary.utc       = mTimeCounter.getCurrent();
     mSummary.time      = mTimeCounter.getValueActive();
     mSummary.distance  = mDistanceCounter.getValueActive();
-    mSummary.speedAvg  = mSpeedCounter.getAverage();
+    mSummary.speedAvg  = speedFromTotals(mSummary.distance, mSummary.time);
     mSummary.elevation = mAltitudeCounter.getCurrent();
-    mSummary.paceAvg   = getPace(mSpeedCounter.getAverage(), mSpeedCounter.getMinValid());
+    mSummary.paceAvg   = getPace(mSummary.speedAvg, mSpeedCounter.getMinValid());
     mSummary.hrMax     = mHrCounter.getMaximum();
     mSummary.hrAvg     = mHrCounter.getAverage();
     mSummary.map       = mTrackMapBuilder.build(skMapMaxPoints);


### PR DESCRIPTION
## Problem

The lap (and session) average pace stored in the FIT file is wrong: for a 1 km / 1 mi auto-lap the reported average pace does not match the lap duration.

`ActivityWriter` serializes whatever `speedAvg` the service hands it, and its own comments document the FIT definition: `avg_speed = total_distance / total_timer_time`. But the services fed in `VariableCounter::getAverage()` / `getLapAverage()` — the **arithmetic mean of the instantaneous speed samples**. That sample mean drifts away from distance/time because:

1. **Sub-threshold filtering biases it fast.** Samples below `minValid` (0.5 m/s) are excluded from the average, but those seconds still count toward the lap/session duration. Every slow stretch (stop light, turnaround) makes the average read faster than `distance / time`.
2. **Speed and distance are independent.** On GPS apps, distance is GPS displacement while speed is Doppler instantaneous speed — their sample mean need not reconcile with displacement/time.

So `distance` and `duration` were exact, but `avg_speed` was not consistent with them. The on-watch displayed average pace, derived from the same counter, was wrong the same way.

## Fix

Derive lap, session and live average speed as `distance / active-timer-time` (the data the services already track) via a small `speedFromTotals()` helper, so distance, duration and pace always agree.

Applied to **Running, Cycling, Treadmill, and Hiking**. Treadmill's *session* total was already derived this way in `finalizeActivity()`; its per-lap and live values now match it (`max_speed` / per-record data are left as recorded, unchanged).

## Additional fixes folded in

- **Hiking: stop recording every lap twice.** `Hiking::Service::saveLap()` pushed each lap onto `mSummary.laps` twice (a brace-initialised entry *and* an explicit `LapSummary`), so the summary listed double the laps. Removed the redundant push and fed the survivor from the `lapTime`/`lapDistance` locals. (Reported by CodeRabbit on this PR.)
- **Simulator link fix (Cycling & Hiking).** Their `Application.vcxproj` never compiled `ImuRunningCadence.cpp` (constructed by `InstanceSensorLayer`), so the host simulators failed to link; added the missing `ClCompile` (+ the matching `.filters` grouping). Running/Treadmill already had it.

> Note: the broader Running/Treadmill `.vcxproj.filters` drift cleanup is intentionally **not** here — it's a separate cosmetic PR (#157).

## Verification

**Builds:** all four host simulators build and link clean (Debug/x86, VS 2022 MSBuild).

**Behaviour (driven through the actual GUI simulators with scripted button input; values read from the production-written `Activity/summary.json`):**

*Running* — `time:147 s, distance:768.045 m, speed_avg:5.2248 m/s, pace_avg→3:11/km, lap_count:2`
- session: 768.045 / 147 = 5.2247 m/s = `speed_avg`; `pace_avg` = 1/speed = 3:11/km (matched the on-screen AVG PACE)
- lap 1: `pace 0.19384 s/m × dist 624.226 m = 121.0 s = dur` ✓
- lap 2: `pace 0.177581 s/m × dist 140.781 m = 25.0 s = dur` ✓

Each lap's average pace now **exactly equals `lap_duration / lap_distance`** — the behaviour the report asked for.

*Hiking* — `time:57 s, distance:190.762 m, speed_avg:3.34671 m/s, lap_count:2`
- session: 190.762 / 57 = 3.347 m/s = `speed_avg` ✓
- `lap_count:2` with two **distinct** laps `[{31s,99.8m},{25s,85.3m}]` — pre-fix this run would have written **4** duplicated entries, confirming the dedup fix.

## Scope / safety

SDK-app-side only; no kernel change. Net behavioural effect: average pace now equals `lap_time / lap_distance` for distance auto-laps, matching user expectation and the FIT spec, and Hiking no longer double-counts laps.