### PR TITLE
fix(treadmill): back (R2) on the distance picker returns to the pause menu (Resume/Discard)

### DIFF
--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/trackcalibrate_screen/TrackCalibratePresenter.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/trackcalibrate_screen/TrackCalibratePresenter.hpp
@@ -23,10 +23,8 @@ public:
 
     virtual ~TrackCalibratePresenter() {}
 
-    /// Apply the user-entered actual distance (metres).
+    /// Stop the activity and apply the user-entered actual distance (metres).
     void applyCalibration(float meters);
-    /// Keep the estimated distance (no correction).
-    void skipCalibration();
 
 private:
     TrackCalibratePresenter();

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/trackcalibrate_screen/TrackCalibrateView.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/trackcalibrate_screen/TrackCalibrateView.hpp
@@ -8,7 +8,8 @@
 /**
  * Post-run "Calibrate & Save" distance entry (§5). Uses the shared TwoTonePicker:
  * stage 1 edits the whole part, stage 2 the 0.01-unit fraction. R1 confirms /
- * advances, R2 skips / steps back.
+ * advances; R2 steps back a stage, or (from stage 1) backs out to the pause menu
+ * without saving (the activity stays paused until R1 confirms).
  */
 class TrackCalibrateView : public TrackCalibrateViewBase
 {

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/trackaction_screen/TrackActionPresenter.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/trackaction_screen/TrackActionPresenter.cpp
@@ -39,14 +39,12 @@ void TrackActionPresenter::resumeTrack()
 
 void TrackActionPresenter::saveRequested()
 {
-    // Stop recording. The Service builds the summary at the estimated distance
-    // and waits for the Calibrate & Save decision.
-    model->saveTrack();
-
-    // Always offer Calibrate & Save so the user can correct the recorded
-    // distance (and the avg speed derived from it) on any run. The intro screen
-    // explains the step, then advances to the distance picker; the user can skip
-    // to keep the estimate. Whether the entered distance also updates the delta
-    // LUT is gated Service-side (outdoor-calibrated tier + a minimum distance).
+    // Do NOT stop the activity yet: keep it paused through the Calibrate & Save
+    // intro + distance picker, so R2 (back) on the picker can return to this
+    // pause menu with Resume/Discard still available. The stop + finalise happens
+    // only when the user confirms a distance on the picker
+    // (TrackCalibratePresenter::applyCalibration). Confirming the seeded estimate
+    // keeps the estimate; whether the entered distance also updates the delta LUT
+    // is gated Service-side (outdoor-calibrated tier + a minimum distance).
     model->application().gotoTrackCalibrateIntroScreenNoTransition();
 }

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/trackcalibrate_screen/TrackCalibratePresenter.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/trackcalibrate_screen/TrackCalibratePresenter.cpp
@@ -21,10 +21,9 @@ void TrackCalibratePresenter::deactivate()
 
 void TrackCalibratePresenter::applyCalibration(float meters)
 {
+    // Confirm: stop the activity now (the Service snapshots the session and
+    // builds the summary), then fold in the entered distance. Confirming the
+    // seeded estimate is equivalent to saving without correction (ΔD = 0).
+    model->saveTrack();
     model->trackCalibrate(meters);
-}
-
-void TrackCalibratePresenter::skipCalibration()
-{
-    model->trackCalibrate(0.0f);
 }

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/trackcalibrate_screen/TrackCalibrateView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/trackcalibrate_screen/TrackCalibrateView.cpp
@@ -29,10 +29,11 @@ void TrackCalibrateView::handleKeyEvent(uint8_t key)
             presenter->applyCalibration(mLogic.meters());
             application().gotoTrackSavedScreenNoTransition();
         }
-    } else if (key == SDK::GUI::Button::R2) {     // skip / step back
+    } else if (key == SDK::GUI::Button::R2) {     // back / step back
         if (!mLogic.atFrac()) {
-            presenter->skipCalibration();
-            application().gotoTrackSavedScreenNoTransition();
+            // Back out to the pause menu (Resume / Discard / Save) without
+            // saving — the activity is still only paused, not stopped.
+            application().gotoTrackActionScreenNoTransition();
         } else {
             mLogic.toWhole();
             mLogic.render(picker);


### PR DESCRIPTION
## Summary

On the post-run **Calibrate & Save** distance picker, pressing **back (R2)** used to *skip calibration and save* the activity with the estimate — there was no way back to **Resume / Discard** once you'd chosen Save. (Worse, the activity was already stopped before the picker even appeared, since `saveRequested()` called `trackStop`.)

Now R2 returns to the **paused activity menu** with Resume / Summary / Save / Discard, and the activity stays resumable.

## How

Defer the stop until the user confirms a distance, so the intro + picker run with the activity still **paused**:

- **`TrackActionPresenter::saveRequested()`** no longer stops the track — it just opens the Calibrate & Save intro.
- **R1 (confirm)** stops the activity and folds in the entered distance — `TrackCalibratePresenter::applyCalibration()` now calls `saveTrack()` then `trackCalibrate()`. Confirming the seeded estimate is equivalent to "save without correction" (ΔD = 0), which replaces the old explicit skip.
- **R2 from the whole-number stage** → `gotoTrackActionScreenNoTransition()` (pause menu), track still paused → Resume/Discard work normally.
- **R2 from the fraction stage** → steps back to the whole stage (unchanged).
- The now-unused `skipCalibration()` path is removed.

No button-label change: R2 is already the icon "back" button (`Buttons::WHITE`); only its behavior changes.

## Test plan

- Treadmill MSVC simulator builds clean (before and after rebasing onto latest `main`).
- On-device: pause a run → Save → picker → R2 returns to the pause menu; Resume continues the run, Discard discards; R1 still saves (with or without a distance correction).

## Notes

- Follows apps-v1.0.2. No JSON/schema changes. Idle behavior unchanged (the prompt still persists on idle per the earlier fix).
- Kernel spec §5.1 isn't contradicted (it describes "enter D_actual or skip" at a high level; skip is now "confirm the seeded estimate") — no doc change required, but happy to add a note if you'd like.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calibration workflow to save track data before applying distance adjustments.
  * Updated R2 button behavior during calibration to return to pause screen instead of skipping calibration entirely.

* **Documentation**
  * Clarified button navigation controls (R1/R2) and screen behavior during the calibrate and save workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->