### PR TITLE
fix(treadmill,running): intervals lap button advances the phase on any data face

### DIFF
--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -158,7 +158,12 @@ void TrackView::handleKeyEvent(uint8_t key)
     }
 
     if (key == SDK::GUI::Button::R2) {
-        if (mCurrentFaceId == FaceId::ID_INTERVALS) {
+        // In an intervals workout the lap button advances to the next phase, on
+        // ANY face — laps are phase-driven, not manual. Gate on the workout mode,
+        // not the currently shown face (which the user can scroll away from). When
+        // the workout completes the Service drops intervalsMode, so R2 then records
+        // a manual lap. A free (non-intervals) run always records a manual lap.
+        if (mIntervalsMode) {
             presenter->intervalsNextPhase();
         } else {
             presenter->saveLap();

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -152,7 +152,12 @@ void TrackView::handleKeyEvent(uint8_t key)
     }
 
     if (key == SDK::GUI::Button::R2) {
-        if (mCurrentFaceId == FaceId::ID_INTERVALS) {
+        // In an intervals workout the lap button advances to the next phase, on
+        // ANY face — laps are phase-driven, not manual. Gate on the workout mode,
+        // not the currently shown face (which the user can scroll away from). When
+        // the workout completes the Service drops intervalsMode, so R2 then records
+        // a manual lap. A free (non-intervals) run always records a manual lap.
+        if (mIntervalsMode) {
             presenter->intervalsNextPhase();
         } else {
             presenter->saveLap();


### PR DESCRIPTION
## Summary

In an intervals workout, pressing the **lap button (R2)** while viewing a **data face** (Total / Lap / Status) recorded a manual lap instead of advancing to the next interval phase. It only advanced the phase when the intervals face happened to be on screen — but the user can scroll to any face, so the lap button must advance the phase regardless of which face is shown.

Found on-device in the Treadmill app (v1.1.1); the Running app shares the same `TrackView` pattern and had the identical bug — both are fixed here.

## Fix

Gate R2 on the **workout mode** (`mIntervalsMode`) rather than the **currently shown face** (`mCurrentFaceId == FaceId::ID_INTERVALS`):

```cpp
if (key == SDK::GUI::Button::R2) {
    if (mIntervalsMode) {
        presenter->intervalsNextPhase();   // any face, while the workout is running
    } else {
        presenter->saveLap();              // free run, or after the workout completes
        application().gotoTrackLapScreenNoTransition();
    }
}
```

## Workout-completion behaviour (preserved)

This matches the Service's existing design: on completion it sets `mIntervalsMode = false` (Service comment: *"drop out of intervals mode so … R2 records a lap (not a phase advance)"*), and the workout-completed screen auto-returns to the track screen, which re-activates it and refreshes the view to `mIntervalsMode = false`. So **after the workout completes, R2 records a manual lap** — falling into the same, unchanged manual-lap path a free run uses. A free (non-intervals) run is also unchanged.

## Test plan

- Both **Treadmill** and **Running** app simulators build clean.
- **Treadmill sim, verified live:** started an intervals workout → scrolled from the intervals face to the **Total** data face → pressed **R2** → the **WARM UP → RUN** phase alert appeared (previously it opened the lap-summary screen). Screenshots captured at each step.
- Completion path is the pre-existing manual-lap behaviour (unchanged code), reached once `mIntervalsMode` flips to false.

## Notes

- Follows apps-v1.1.1. No JSON/schema changes; GUI-only (one conditional per app).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * R2 button behavior on the track screen has been updated. The button now responds based on your current workout mode (intervals or standard) rather than the active display view. During interval workouts, it advances to the next phase; otherwise, it records a manual lap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->