### PR TITLE
chore: enforce LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must keep LF line endings so they run on Linux/macOS
+# regardless of a contributor's core.autocrlf setting (a CRLF shebang breaks).
+*.sh text eol=lf


### PR DESCRIPTION
## Problem

Shell scripts under the SDK (`Utilities/Scripts/build-cube/*.sh`, etc.) run inside the Linux CI/Docker build container. The SDK has no `.gitattributes`, so a contributor on `core.autocrlf=true` (the Windows default) checks them out with **CRLF** line terminators. The CRLF shebang then breaks bash:

```
find-cube.sh: line 2: $'\r': command not found
find-cube.sh: line 28: syntax error: unexpected end of file
```

This silently aborts the firmware build (and mangles apt package names like `python-is-python3\r`).

## Fix

Add `*.sh text eol=lf`, mirroring the rule the **kernel repo** already carries, so shell scripts always materialise with LF regardless of any contributor's `core.autocrlf` setting.

`git add --renormalize` reports no content changes — the `.sh` files are already stored as LF; this only pins checkout behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to ensure consistent line ending handling across different development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->