### PR TITLE
docs(ifilesystem): specify IDirectory::readNext cursor + reset contract

### DIFF
--- a/Libs/Header/SDK/Interfaces/IFileSystem.hpp
+++ b/Libs/Header/SDK/Interfaces/IFileSystem.hpp
@@ -286,10 +286,29 @@ public:
     virtual bool isOpen() const = 0;
 
     /**
-     * @brief   Reads the next item in the directory.
-     * @param   item: Reference to store the directory item information.
-     * @param   reset: Reset the read position if true.
-     * @retval  'true' if the item was successfully read, 'false' otherwise.
+     * @brief   Reads the next directory entry, advancing the read cursor.
+     *
+     * @details
+     * Cursor-style enumeration: each call returns one entry and advances, so a
+     * caller can iterate the directory with:
+     * @code
+     *     while (dir.readNext(item)) { ... }
+     * @endcode
+     * The loop terminates when the directory is exhausted (return 'false').
+     *
+     * When @p reset is 'true', the cursor is first rewound to the start of the
+     * directory. A reset call does NOT read an entry: @p item is left
+     * unmodified and the return value only reflects whether the rewind
+     * succeeded. The next call with @p reset 'false' returns the first entry.
+     *
+     * @param   item: On a non-reset call, receives the entry. Left unmodified
+     *          on a reset call or when the directory is exhausted.
+     * @param   reset: Rewind the cursor to the first entry before reading.
+     *          Note that a reset call rewinds only and returns without reading.
+     * @retval  'true'  a non-reset call read an entry into @p item, or a reset
+     *          call rewound successfully.
+     * @retval  'false' the directory is exhausted, not open, or the rewind
+     *          failed. @p item is unchanged.
      */
     virtual bool readNext(IFileSystem::ObjectInfo& item, bool reset = false) = 0;
 


### PR DESCRIPTION
Tightens the `IDirectory::readNext` interface documentation so the contract is fully specified for anyone implementing or consuming it from the SDK alone.

### Why

The current doxygen says only:

> Reads the next item in the directory. / Reset the read position if true. / 'true' if the item was successfully read.

That leaves two things undefined that an implementer or caller actually needs:

1. **Is it a cursor or an enumerate-all call?** The intended behavior is one entry per call, advancing each time, returning `false` on exhaustion — the `while (dir.readNext(item))` idiom. The wording doesn't make that explicit.
2. **Does a `reset` call also yield an entry?** Unspecified. The intended behavior is that `reset` is a *pure rewind*: it returns without reading and leaves `item` unmodified, so the next non-reset call returns the first entry.

This ambiguity has already produced a real mock/implementation divergence in the simulator's `Directory::readNext` (see #128). Specifying the contract here closes the gap at the source rather than per-implementation.

### What

Doc-only change to the `readNext` doxygen block:
- documents the one-entry-per-call cursor semantics and the exhaustion signal, with the canonical iteration idiom;
- specifies `reset` as a rewind that does not read an entry and leaves `item` untouched;
- clarifies each `@retval` for both the read and the reset case.

No code or behavioral change.

### Note

One intentionally-documented quirk: a successful `reset` returns `true` even though it doesn't populate `item`. That matches existing behavior and callers, so it's documented as-is. A cleaner API would be a separate `rewind()`/`reset()` method, but that's a larger change and out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for directory enumeration functionality, providing clearer explanations of cursor-style semantics, reset parameter behavior, and method parameters and return values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->