### PR TITLE
fix(simulator): set isHidden/isSystem in FileSystem::objectInfo

### DIFF
--- a/Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp
+++ b/Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp
@@ -389,6 +389,8 @@ bool FileSystem::objectInfo(const char *path, FileSystem::ObjectInfo &item) cons
     if (hFind == INVALID_HANDLE_VALUE) return false;
     safe_strcpy(item.name, findData.cFileName, sizeof(item.name));
     item.isDir = (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+    item.isHidden = (findData.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0;
+    item.isSystem = (findData.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM) != 0;
     item.size = findData.nFileSizeLow;
     item.utc = FileTimeToUnixTime(findData.ftCreationTime);
     FindClose(hFind);


### PR DESCRIPTION
`objectInfo` never set `item.isHidden` or `item.isSystem`, so callers read uninitialized values. `readNext` already sets both from the `WIN32_FIND_DATA` attributes; `objectInfo` now does the same.

I missed this in #128, noticed now that I was updating everything with all the work that has been done on the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced mock FileSystem implementation to properly simulate hidden and system file attributes, enabling more realistic filesystem behavior during testing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->