### PR TITLE
feat(sensor): add SpO2 to the sensor type enum

### DIFF
--- a/Docs/SensorsLayer.md
+++ b/Docs/SensorsLayer.md
@@ -35,6 +35,7 @@ All available sensor types are defined in [`SDK::Sensor::Type`](../Libs/Header/S
 | Motion | GESTURE_RECOGNITION | 0xD0 | Discrete gesture events | No | - |
 | Daily | ACTIVITY | 0xE0 | Active minutes (minutes) | Yes | DURATION (u32 ms) - 1 |
 | Optical | PPG | 0xF0 | Photoplethysmogram | No | - |
+| Optical | SPO2 | 0xF1 | Blood-oxygen saturation (SpO2) | Yes | SATURATION (float %), TRUST_LEVEL (float) - 2 |
 | Optical | ECG | 0x100 | Electrocardiogram | No | - |
 | GPS | GPS_LOCATION | 0x110 | GNSS location | Yes | PRECISION (f m), COORDS_VALID (bool), LAT (f deg), LON (f deg), ALT (f m) - 5 |
 | GPS | GPS_SPEED | 0x111 | GNSS speed | Yes | SPEED (f m/s) - 1 |
@@ -220,6 +221,20 @@ As above, `float bpm = p.getBpm(); float trust = p.getTrustLevel();`
 **Parser**: `SDK::SensorDataParser::Activity`
 
 **Fields**: DURATION (u32 ms)
+
+### SPO2 (0xF1)
+
+**Parser**: `SDK::SensorDataParser::Spo2`
+
+Blood-oxygen saturation derived from the optical PPG path. Delivered as a processed scalar with a trust level, mirroring HEART_RATE.
+
+**Fields**:
+| Index | Name | Type | Unit |
+|-------|------|------|------|
+| 0 | SATURATION | float | % |
+| 1 | TRUST_LEVEL | float | - |
+
+`float spo2 = p.getSaturation(); float trust = p.getTrustLevel();`
 
 ### GPS_LOCATION (0x110)
 

--- a/Docs/SensorsLayer.md
+++ b/Docs/SensorsLayer.md
@@ -229,6 +229,7 @@ As above, `float bpm = p.getBpm(); float trust = p.getTrustLevel();`
 Blood-oxygen saturation derived from the optical PPG path. Delivered as a processed scalar with a trust level, mirroring HEART_RATE.
 
 **Fields**:
+
 | Index | Name | Type | Unit |
 |-------|------|------|------|
 | 0 | SATURATION | float | % |

--- a/Libs/Header/SDK/SensorLayer/DataParsers/SensorDataParserSpo2.hpp
+++ b/Libs/Header/SDK/SensorLayer/DataParsers/SensorDataParserSpo2.hpp
@@ -1,0 +1,104 @@
+/**
+ ******************************************************************************
+ * @file    SensorDataParserSpo2.hpp
+ * @brief   SensorData parser for SPO2 sensor
+ ******************************************************************************
+ */
+
+#ifndef __SENSOR_DATA_PARSER_SPO2_HPP
+#define __SENSOR_DATA_PARSER_SPO2_HPP
+
+#include "SDK/SensorLayer/SensorDataView.hpp"
+
+#include <cstdint>
+
+namespace SDK
+{
+    namespace SensorDataParser
+    {
+        /**
+         * @brief Helper class to parse blood-oxygen saturation (SpO2) sensor data from ISensorData
+         *
+         * SpO2 is derived from the optical PPG path. Like HEART_RATE, it is delivered as a
+         * processed scalar accompanied by a trust level rather than a raw waveform.
+         *
+         * Expected data layout:
+         * - [0] float saturation (percent, typically [70..100])
+         * - [1] float trust level
+         */
+        class Spo2
+        {
+        public:
+            enum Field : uint8_t {
+                SATURATION = 0, ///< Blood-oxygen saturation in percent (float)
+                TRUST_LEVEL,    ///< Trust level (float)
+                COUNT           ///< Total number of fields
+            };
+
+            /**
+             * @brief Construct a new Spo2 parser over given ISensorData
+             * @param view Reference to sensor data containing 2 fields
+             */
+            Spo2(const SDK::Sensor::DataView view) : mData(view) {}
+
+            /**
+             * @brief Check if data is valid (should contain exactly 2 fields)
+             * @return true if valid
+             */
+            bool isDataValid() const
+            {
+                return (mData.getFieldCount() == Field::COUNT);
+            }
+
+            /**
+             * @brief Get blood-oxygen saturation as a percentage
+             * @return Saturation in percent as float (0.f if invalid)
+             */
+            float getSaturation() const
+            {
+                return isDataValid() ? mData.f[Field::SATURATION] : 0.f;
+            }
+
+            /**
+             * @brief Get trust level
+             * @return Trust level
+             */
+            float getTrustLevel() const
+            {
+                return isDataValid() ? mData.f[Field::TRUST_LEVEL] : 0.f;
+            }
+
+            /**
+             * @brief Get data timestamp in ms
+             * @return Data timestamp in ms (0 if invalid)
+             */
+            uint32_t getTimestamp() const
+            {
+                return isDataValid() ? mData.getTimestamp() : 0;
+            }
+
+            /**
+             * @brief Get data timestamp in us
+             * @return Data timestamp in us (0 if invalid)
+             */
+            uint64_t getTimestampUs() const
+            {
+                return isDataValid() ? mData.getTimestampUs() : 0;
+            }
+
+            /**
+             * @brief Get number of expected fields (always 2)
+             */
+            static constexpr uint8_t getFieldsNumber()
+            {
+                return Field::COUNT;
+            }
+
+        private:
+            const SDK::Sensor::DataView mData;
+        }; /* class Spo2 */
+    }; /* namespace SensorDataParser */
+
+} /* namespace SDK */
+
+#endif /* __SENSOR_DATA_PARSER_SPO2_HPP */

--- a/Libs/Header/SDK/SensorLayer/SensorTypes.hpp
+++ b/Libs/Header/SDK/SensorLayer/SensorTypes.hpp
@@ -91,6 +91,7 @@ namespace SDK::Sensor
          *  @{
          */
         PPG                  = 0x000000F0, ///< Photoplethysmogram data.
+        SPO2                 = 0x000000F1, ///< Blood-oxygen saturation (SpO2), derived from the optical PPG path (%).
         ECG                  = 0x00000100, ///< Electrocardiogram data.
         /** @} */
 


### PR DESCRIPTION
The hardware has an optical blood-oxygen sensor, but there's no `SDK::Sensor::Type` value for it, so it can't be referenced through the sensor layer. This is a proposal for how that might look — happy to have you take it in whatever direction fits the SDK. What I'm really after is *some* representation of SpO2 so it can eventually be wired up in the simulator.

What's here:

- **`SPO2 = 0x000000F1`** in `SensorTypes.hpp`. I slotted it one past `PPG` (`0xF0`) in the optical block, since SpO2 comes off the PPG path — mirroring how `HEART_RATE` (`0x41`) sits next to `HEART_BEAT` (`0x40`). The exact value is yours to decide.
- **`SensorDataParserSpo2.hpp`** — SpO2 reads as a processed scalar (saturation % + trust level) rather than a raw waveform, so I modeled the parser on `HeartRate`: `getSaturation()` / `getTrustLevel()` plus the usual validity and timestamp accessors.
- **`SensorsLayer.md`** — table row and a short usage section to match.

Header-only; nothing changes for existing types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an Optical **SPO2** sensor, providing **saturation (%)** and **trust level** measurements.

* **Documentation**
  * Updated the Sensors Layer documentation with the new **SPO2 (0xF1)** sensor type, including field descriptions and example accessor usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->