### PR TITLE
docs: add MIT license, third-party notices, and trademark notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 UNA Watch Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -177,3 +177,18 @@ For examples with GUI components like Hiking:
 - Join the community at [UNAWatch/una-sdk](https://github.com/UNAWatch/una-sdk)
 
 For additional support, see the [Community Support](Docs/community-support.md) guide.
+
+## License
+
+UNA Watch Ltd's own source code in this repository is released under the
+**MIT License** — see [`LICENSE`](LICENSE).
+
+Third-party components vendored under `ThirdParty/` (TouchGFX, coreJSON, tinycbor)
+are licensed separately under their own terms and are **not** covered by the MIT
+license — see [`THIRD-PARTY-LICENSES.md`](THIRD-PARTY-LICENSES.md).
+
+## Trademark
+
+"UNA", "UNA Watch", and the UNA logo are trademarks of UNA Watch Ltd. The MIT
+license covers the source code only and grants no rights to the UNA name or
+logos — see [`TRADEMARK.md`](TRADEMARK.md).

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -10,7 +10,7 @@ redistributing.
 
 | Component | Location | License |
 |-----------|----------|---------|
-| TouchGFX | `ThirdParty/touchgfx/` | STMicroelectronics **SLA0048** — see [`ThirdParty/touchgfx/LICENSE.txt`](ThirdParty/touchgfx/LICENSE.txt). Use and redistribution are permitted **only in connection with a microcontroller or microprocessor manufactured by or for STMicroelectronics**, and the component **must not be made subject to any open-source license terms**. TouchGFX itself bundles further third-party code (e.g. the Anti-Grain Geometry rasterizer, libjpeg (Independent JPEG Group), and, for the simulator, SDL2) under their own respective licenses. |
+| TouchGFX | `ThirdParty/touchgfx/` | STMicroelectronics **SLA0048** — see [`ThirdParty/touchgfx/LICENSE.txt`](ThirdParty/touchgfx/LICENSE.txt). Use and redistribution are permitted **only in connection with a microcontroller or microprocessor manufactured by or for STMicroelectronics**, and the component **must not be made subject to any open-source license terms**. Redistribution in source or binary form must retain/reproduce the copyright notice, conditions, and disclaimer (binary form excepted when embedded in an STMicroelectronics device or a software update for one). TouchGFX itself bundles further third-party code (e.g. the Anti-Grain Geometry rasterizer, libjpeg (Independent JPEG Group), and, for the simulator, SDL2) under their own respective licenses. |
 | coreJSON | `ThirdParty/coreJSON/` | **MIT** — see [`ThirdParty/coreJSON/LICENSE`](ThirdParty/coreJSON/LICENSE). |
 | tinycbor | `ThirdParty/tinycbor_version/` | **MIT** — Copyright (C) Intel Corporation; `SPDX-License-Identifier: MIT` (see the header files in that directory). |
 

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -10,7 +10,7 @@ redistributing.
 
 | Component | Location | License |
 |-----------|----------|---------|
-| TouchGFX | `ThirdParty/touchgfx/` | STMicroelectronics **SLA0048** — see [`ThirdParty/touchgfx/LICENSE.txt`](ThirdParty/touchgfx/LICENSE.txt). Use and redistribution are permitted **only in connection with a microcontroller or microprocessor manufactured by or for STMicroelectronics**, and the component **must not be made subject to any open-source license terms**. TouchGFX itself bundles further third-party code (e.g. the Anti-Grain Geometry rasterizer and, for the simulator, SDL2) under their own respective licenses. |
+| TouchGFX | `ThirdParty/touchgfx/` | STMicroelectronics **SLA0048** — see [`ThirdParty/touchgfx/LICENSE.txt`](ThirdParty/touchgfx/LICENSE.txt). Use and redistribution are permitted **only in connection with a microcontroller or microprocessor manufactured by or for STMicroelectronics**, and the component **must not be made subject to any open-source license terms**. TouchGFX itself bundles further third-party code (e.g. the Anti-Grain Geometry rasterizer, libjpeg (Independent JPEG Group), and, for the simulator, SDL2) under their own respective licenses. |
 | coreJSON | `ThirdParty/coreJSON/` | **MIT** — see [`ThirdParty/coreJSON/LICENSE`](ThirdParty/coreJSON/LICENSE). |
 | tinycbor | `ThirdParty/tinycbor_version/` | **MIT** — Copyright (C) Intel Corporation; `SPDX-License-Identifier: MIT` (see the header files in that directory). |
 

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,19 @@
+# Third-Party Licenses
+
+The MIT license in [`LICENSE`](LICENSE) covers **UNA Watch Ltd's own source code**
+in this repository.
+
+The third-party components vendored under `ThirdParty/` are **licensed separately
+under their own terms and are NOT covered by this repository's MIT license**. Each
+component retains its own copyright notices and license file; consult those before
+redistributing.
+
+| Component | Location | License |
+|-----------|----------|---------|
+| TouchGFX | `ThirdParty/touchgfx/` | STMicroelectronics **SLA0048** — see [`ThirdParty/touchgfx/LICENSE.txt`](ThirdParty/touchgfx/LICENSE.txt). Use and redistribution are permitted **only in connection with a microcontroller or microprocessor manufactured by or for STMicroelectronics**, and the component **must not be made subject to any open-source license terms**. TouchGFX itself bundles further third-party code (e.g. the Anti-Grain Geometry rasterizer and, for the simulator, SDL2) under their own respective licenses. |
+| coreJSON | `ThirdParty/coreJSON/` | **MIT** — see [`ThirdParty/coreJSON/LICENSE`](ThirdParty/coreJSON/LICENSE). |
+| tinycbor | `ThirdParty/tinycbor_version/` | **MIT** — Copyright (C) Intel Corporation; `SPDX-License-Identifier: MIT` (see the header files in that directory). |
+
+> Note: because SLA0048 forbids subjecting TouchGFX to open-source terms, the
+> repository's MIT license is scoped to UNA Watch Ltd's own code only and does not
+> extend to anything under `ThirdParty/`.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,15 @@
+# Trademark Notice
+
+"UNA", "UNA Watch", and the UNA logo are trademarks of UNA Watch Ltd.
+
+The [MIT license](LICENSE) for this repository grants rights to the **source
+code only**. It does **not** grant any right to use the UNA Watch Ltd name,
+trademarks, service marks, product names, or logos.
+
+You may make **nominative reference** to UNA — for example, to state that your
+application is "for the UNA Watch" or is "compatible with UNA Watch" — provided
+such use does not imply endorsement, sponsorship, or affiliation by UNA Watch Ltd.
+
+You may **not** use the UNA name or logos to name or brand a forked or derivative
+project, product, or service, or in any way likely to cause confusion as to the
+origin of, or endorsement by, UNA Watch Ltd.


### PR DESCRIPTION
## Summary

Adds the repository's license, third-party attributions, and a trademark notice.

- **`LICENSE`** — UNA Watch Ltd's own SDK source is released under the **MIT License** (chosen to maximise adoption by hobbyist/app developers).
- **`THIRD-PARTY-LICENSES.md`** — documents the separately-licensed vendored components and scopes the MIT grant to UNA's code only:
  - **TouchGFX** — STMicroelectronics SLA0048 (STM32-only; must not be subjected to open-source terms, so the root MIT explicitly does **not** extend to `ThirdParty/`).
  - **coreJSON** — MIT.
  - **tinycbor** — MIT (Intel).
- **`TRADEMARK.md`** — reserves the "UNA"/"UNA Watch" name and logos (MIT has no trademark clause), while permitting nominative use ("for UNA Watch").
- **README** — adds License and Trademark sections.

## Notes
- SPDX per-file headers were intentionally deferred (can be a follow-up); this PR is the root license + notices only.
- The MIT copyright line attributes **UNA Watch Ltd**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clear licensing information for the repository, including MIT terms for the main source code and separate terms for bundled third-party components.
  * Added a trademark notice explaining permitted use of the UNA Watch name and logo.
  * Expanded the README with licensing and trademark guidance, plus references to third-party license details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->