### PR TITLE
docs(config): rename minSdkVersion to minKernelVersion

### DIFF
--- a/Docs/Tutorials/Files/Output/config.json
+++ b/Docs/Tutorials/Files/Output/config.json
@@ -6,7 +6,7 @@
   "icon": "Resources/icon_60x60.png",
   "binary": "Files_0.1.3-16-ed77913-dirty.uapp",
   "appVersion": "0.1.3",
-  "minSdkVersion": "0.1.3",
+  "minKernelVersion": "0.1.3",
   "requiredHardware": [],
   "stravaExport" : false,
   "id": "03AD5A741E38A35F",

--- a/Docs/app-config-json.md
+++ b/Docs/app-config-json.md
@@ -6,6 +6,7 @@
 |----------|-----------------|------------------|------|--------|
 | 1.00    | 07.08.2025      | Creating        |      | [Denys Saienko](https://github.com/sdvsaienko) |
 | 1.01    | 23.03.2025     | Removed mentions about signature file as it is not used |      | [Denys Sobchuk](https://github.com/AvatarSD) |
+| 1.02    | 29.06.2026     | Renamed `minSdkVersion` to `minKernelVersion`: the SDK is statically linked into the `.uapp`, so the runtime requirement is on the kernel firmware version (reported over BLE via the DIS Firmware Revision String, UUID 0x2A26), not the build-time SDK version | | Ross Ryles |
 
 ## Output Package
 
@@ -42,7 +43,7 @@ Simplest `config.json` for [Files](Tutorials/Files/ARCHITECTURE.md) Tutorial
   "icon": "Resources/icon_60x60.png",
   "binary": "Files_0.1.3-16-ed77913-dirty.uapp",
   "appVersion": "0.1.3",
-  "minSdkVersion": "0.1.3",
+  "minKernelVersion": "0.1.3",
   "requiredHardware": [],
   "stravaExport" : false,
   "id": "03AD5A741E38A35F",
@@ -70,7 +71,7 @@ Watch application config example:
   "binary": "running.uapp", // Relative path to the app binary file
   "previews": "assets/previews/", // Relative path to the previews images
   "appVersion": "1.0.3", // Current version of the app
-  "minSdkVersion": "3.0.0", // Minimum supported SDK version required to run the app
+  "minKernelVersion": "3.0.0", // Minimum watch kernel (firmware) version required to run the app. The SDK is statically linked into the .uapp, so this gates against the runtime kernel, not the build-time SDK. The mobile app reads the watch's firmware version from the BLE DIS Firmware Revision String (UUID 0x2A26).
   "requiredHardware": [ // List of hardware features required for the app to function
     "GPS",
     "ACCELEROMETER",


### PR DESCRIPTION
## What

Renames the `minSdkVersion` field in `config.json` to `minKernelVersion` across the docs and examples.

## Why

A compiled `.uapp` **statically links** the SDK, so the SDK version an app was built against is a build-time fact, not a runtime requirement. What the app actually needs *present on the watch* is a kernel that implements a compatible runtime contract (IKIP ABI, message types, sensor layer).

The watch reports its **kernel firmware version** over BLE as the standard **DIS Firmware Revision String (UUID `0x2A26`)** — fed from `BUILD_VERSION` (the kernel `v*` release tag). That is the value a mobile client should compare an app's minimum-version gate against. SDK (`sdk-v*`) and kernel (`v*`) are versioned independently, so comparing `minSdkVersion` against the watch's reported firmware version was comparing two different number spaces.

## Changes

- Rename `minSdkVersion` → `minKernelVersion` in both example configs and the Files tutorial `Output/config.json`
- Clarify the inline comment (gates against runtime kernel firmware version, read via DIS `0x2A26`)
- Add revision-history row 1.02

## ⚠️ Coordination required

`config.json` is store/mobile-side only — nothing in the build pipeline generates or consumes it (`app_packer.py` emits only the `.uapp`). This is therefore a **breaking key rename for the mobile client** that parses `config.json`. The mobile app team is being contacted separately before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples and tutorial files to use `minKernelVersion` instead of `minSdkVersion`.
  * Clarified that the requirement refers to the watch kernel firmware version.
  * Refreshed the revision history to reflect the configuration field rename.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->