### PR TITLE
fix(sensor): Gyroscope::getXYZ returns floats, not int32 bits

### DIFF
--- a/Libs/Header/SDK/SensorLayer/DataParsers/SensorDataParserGyroscope.hpp
+++ b/Libs/Header/SDK/SensorLayer/DataParsers/SensorDataParserGyroscope.hpp
@@ -1,6 +1,6 @@
 /**
  ******************************************************************************
- * @file    SensorDataParserAccelerometer.hpp
+ * @file    SensorDataParserGyroscope.hpp
  * @date    23-March-2026
  * @author  Oleksandr Tymoshenko <oleksandr.tymoshenko@droid-technologies.com>
  * @brief   Sensor data parser for GYROSCOPE sensor
@@ -100,9 +100,9 @@ namespace SDK
                     return false;
                 }
 
-                x = mData.i[Field::X];
-                y = mData.i[Field::Y];
-                z = mData.i[Field::Z];
+                x = mData.f[Field::X];
+                y = mData.f[Field::Y];
+                z = mData.f[Field::Z];
 
                 return true;
             }

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(una-sdk-host-tests
     apps/Running/ActivityWriter_test.cpp
     sensorlayer/HeartRateParser_test.cpp
     sensorlayer/HeartRateExParser_test.cpp
+    sensorlayer/GyroscopeParser_test.cpp
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/SettingsSerializer.cpp"
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/Calibration/OutdoorStrideCalibrator.cpp"

--- a/Tests/Host/sensorlayer/GyroscopeParser_test.cpp
+++ b/Tests/Host/sensorlayer/GyroscopeParser_test.cpp
@@ -1,0 +1,88 @@
+/**
+ * Host unit tests for SensorDataParser::Gyroscope — the cooked 3-axis angular
+ * velocity frame (float X/Y/Z). Guards the getXYZ() bulk accessor against
+ * reading the wrong union view: it must return the float values, not the raw
+ * bit pattern reinterpreted through the int32 view.
+ */
+
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "SDK/SensorLayer/SensorData.hpp"
+#include "SDK/SensorLayer/SensorDataView.hpp"
+#include "SDK/SensorLayer/DataParsers/SensorDataParserGyroscope.hpp"
+
+using Gyroscope = SDK::SensorDataParser::Gyroscope;
+
+namespace {
+
+// A SDK::Sensor::Data with room for the 3 gyroscope fields.
+struct GyroData {
+    alignas(SDK::Sensor::Data) uint8_t buf[sizeof(SDK::Sensor::Data) +
+            3 * sizeof(SDK::Sensor::Data::Field)] {};
+    SDK::Sensor::Data* operator->() { return data(); }
+    SDK::Sensor::Data* data() { return reinterpret_cast<SDK::Sensor::Data*>(buf); }
+};
+
+void fill(GyroData& m, float x, float y, float z)
+{
+    m->mValue[Gyroscope::X].f = x;
+    m->mValue[Gyroscope::Y].f = y;
+    m->mValue[Gyroscope::Z].f = z;
+}
+
+} // namespace
+
+// getXYZ() must return the float values that were written. This is the direct
+// regression guard: reading the int32 view instead of the float view turns a
+// stored 1.5f into its bit pattern (1069547520.f), so this fails on the bug.
+TEST(GyroscopeParser, GetXYZReturnsFloatValues)
+{
+    GyroData m;
+    fill(m, 1.5f, -2.25f, 0.125f);
+
+    SDK::Sensor::DataView v(*m.data(), Gyroscope::COUNT);
+    Gyroscope p(v);
+
+    float x = 0.f, y = 0.f, z = 0.f;
+    ASSERT_TRUE(p.getXYZ(x, y, z));
+
+    EXPECT_FLOAT_EQ(x, 1.5f);
+    EXPECT_FLOAT_EQ(y, -2.25f);
+    EXPECT_FLOAT_EQ(z, 0.125f);
+}
+
+// getXYZ() and the scalar getX/getY/getZ() read the same frame, so they must
+// agree. The scalar getters use the float view, so this also fails on the bug.
+TEST(GyroscopeParser, GetXYZMatchesScalarGetters)
+{
+    GyroData m;
+    fill(m, 12.5f, -0.5f, 3.75f);
+
+    SDK::Sensor::DataView v(*m.data(), Gyroscope::COUNT);
+    Gyroscope p(v);
+
+    float x = 0.f, y = 0.f, z = 0.f;
+    ASSERT_TRUE(p.getXYZ(x, y, z));
+
+    EXPECT_FLOAT_EQ(x, p.getX());
+    EXPECT_FLOAT_EQ(y, p.getY());
+    EXPECT_FLOAT_EQ(z, p.getZ());
+}
+
+// A frame whose field count doesn't match the 3-axis layout is rejected, and
+// getXYZ() reports failure.
+TEST(GyroscopeParser, ShortFrameIsInvalid)
+{
+    GyroData m;
+    fill(m, 1.f, 2.f, 3.f);
+
+    SDK::Sensor::DataView v(*m.data(), Gyroscope::COUNT - 1);
+    Gyroscope p(v);
+
+    EXPECT_FALSE(p.isDataValid());
+
+    float x = -1.f, y = -1.f, z = -1.f;
+    EXPECT_FALSE(p.getXYZ(x, y, z));
+}


### PR DESCRIPTION
getXYZ() read the int32 view (mData.i), but the GYROSCOPE frame holds floats and getX/getY/getZ() read the float view (mData.f). So the bulk accessor handed back the raw bit pattern as an int (1.5 became 1069547520) and any caller using it got garbage.

Point getXYZ() at the float view so it matches the scalar getters. Also fix the file header comment, which was copy-pasted from the accelerometer parser.

Add host tests for getXYZ: correct float values, parity with the scalar getters, and rejection of short frames.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected gyroscope readings so X, Y, and Z values are now returned from the proper data source.
  * Improved validation for incomplete sensor frames, so invalid gyroscope data is handled more reliably.

* **Tests**
  * Added host test coverage for gyroscope parsing, including value checks and invalid-data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->