### PR TITLE
feat(simulator): POSIX implementation of the mock FileSystem

### DIFF
--- a/Libs/Header/SDK/Simulator/Kernel/Mock/FileSystem.hpp
+++ b/Libs/Header/SDK/Simulator/Kernel/Mock/FileSystem.hpp
@@ -5,7 +5,11 @@
 #include <fstream>
 #include <string>
 #include <sstream>
+#ifdef _WIN32
 #include <windows.h>
+#else
+#include <dirent.h>
+#endif
 
 #include "SDK/Interfaces/IFileSystem.hpp"
 
@@ -20,7 +24,11 @@ public:
 
     File(const char *prefix, const char *relativePath);
 
-    ~File() = default;
+    ~File() override;
+
+    // Owns a raw handle (fd on POSIX); non-copyable to avoid a double close.
+    File(const File &) = delete;
+    File &operator=(const File &) = delete;
 
 
     virtual void setPath(const char *path) override;
@@ -55,8 +63,12 @@ public:
 
 private:
     std::string path;
+#ifdef _WIN32
     std::fstream file;
     bool isOpenFlag = false;
+#else
+    int fd = -1;   // POSIX file descriptor; -1 when closed
+#endif
     char pathBuffer[SDK::Interface::IFileSystem::skMaxPathLen]; // Buffer to hold the path without prefix
 
     const char *mPathPrefix;
@@ -70,7 +82,11 @@ class Directory : public SDK::Interface::IDirectory {
 public:
     Directory(const char *prefix, const char *relativePath);
 
-    virtual ~Directory() = default;
+    ~Directory() override;
+
+    // Owns a raw handle (DIR* on POSIX); non-copyable to avoid a double close.
+    Directory(const Directory &) = delete;
+    Directory &operator=(const Directory &) = delete;
 
     virtual void setPath(const char *path) override;
 
@@ -94,10 +110,14 @@ public:
 
 private:
     std::string path;
+#ifdef _WIN32
     HANDLE handle;
     WIN32_FIND_DATAA findData;
-    bool isOpenFlag = false;
     bool hasEntry = false; // 'true' when findData holds an entry not yet returned by readNext
+#else
+    DIR *handle = nullptr; // POSIX directory stream; nullptr when closed
+#endif
+    bool isOpenFlag = false;
     char pathBuffer[SDK::Interface::IFileSystem::skMaxPathLen]; // Buffer to hold the path without prefix
 
     const char *mPathPrefix;

--- a/Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp
+++ b/Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp
@@ -144,6 +144,12 @@ bool File::open(bool wMode, bool override)
         flags = O_RDWR | O_CREAT;
     }
 
+    // Release any descriptor from a prior open() so reopening cannot leak it.
+    if (fd >= 0) {
+        ::close(fd);
+        fd = -1;
+    }
+
     fd = ::open(path.c_str(), flags, 0644);
     return fd >= 0;
 #endif
@@ -395,6 +401,10 @@ bool Directory::open()
     isOpenFlag = (handle != INVALID_HANDLE_VALUE);
     hasEntry = isOpenFlag;
 #else
+    // Release any stream from a prior open() so reopening cannot leak it.
+    if (handle != nullptr) {
+        ::closedir(handle);
+    }
     handle = ::opendir(path.c_str());
     isOpenFlag = (handle != nullptr);
 #endif

--- a/Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp
+++ b/Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp
@@ -3,8 +3,16 @@
  * @file    FileSystem.cpp
  * @date    04-04-2025
  * @author  Denys Saienko <denys.saienko@droid-technologies.com>
- * @brief   Mock for IFileSystem interface.
+ * @brief   Mock for IFileSystem interface (Windows + POSIX).
  ******************************************************************************
+ *
+ * The POSIX path (the #else branch) is implemented on file descriptors and
+ * dirent rather than std::fstream. The IFile contract exposes a single
+ * read/write position, which maps exactly onto an fd's offset; std::fstream
+ * keeps separate get/put positions and its append mode ignores seek(), so it
+ * cannot honour a seek() + write() after a non-truncating open. The Windows
+ * path retains the original std::fstream implementation, so some behaviour
+ * differs between the two backends (see File::open and Directory::readNext).
  *
  ******************************************************************************
  */
@@ -17,10 +25,19 @@
 
 #include "SDK/Wrappers/StdLibWrappers.h"
 
-#include <vector>
+#include <cstring>
 #include <filesystem>
-#include <string.h>
 #include <sys/stat.h>
+
+#ifdef _WIN32
+#include <vector>
+#else
+#include <cerrno>
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
 
 namespace SDK::Simulator::Mock
 {
@@ -31,12 +48,7 @@ static std::string AddPrefix(const char *prefix, const char *path)
     return std::string(prefix) + path;
 }
 
-// Method to remove prefix from the path
-static std::string RemovePrefix(const char *prefix, std::string path)
-{
-    return path.substr(strlen(prefix));
-}
-
+#ifdef _WIN32
 // Function to convert FILETIME to time_t (UTC)
 static uint32_t FileTimeToUnixTime(const FILETIME &fileTime)
 {
@@ -49,6 +61,7 @@ static uint32_t FileTimeToUnixTime(const FILETIME &fileTime)
     // Convert to seconds by subtracting the difference between epochs
     return static_cast<uint32_t>((time - EPOCH_DIFFERENCE) / 10000000ULL);
 }
+#endif
 
 
 
@@ -58,14 +71,18 @@ File::File(const char *prefix, const char *relativePath)
     setPath(relativePath);
 }
 
+File::~File()
+{
+    close(); // release the handle on destruction (RAII); close() is idempotent
+}
+
 void File::setPath(const char *path)
 {
     this->path = AddPrefix(mPathPrefix, path);
-    
-    // Update pathBuffer whenever the path is set
-    safe_strcpy(pathBuffer, path, sizeof(pathBuffer) - 1);
-}
 
+    // Store the caller-facing (prefix-less) path; safe_strcpy always NUL-terminates.
+    safe_strcpy(pathBuffer, path, sizeof(pathBuffer));
+}
 
 const char *File::getPath() const
 {
@@ -74,7 +91,12 @@ const char *File::getPath() const
 
 bool File::exist() const
 {
+#ifdef _WIN32
     return GetFileAttributesA(path.c_str()) != INVALID_FILE_ATTRIBUTES;
+#else
+    struct stat st;
+    return ::stat(path.c_str(), &st) == 0;
+#endif
 }
 
 bool File::rename(const char *newPath)
@@ -90,14 +112,15 @@ bool File::remove()
 size_t File::size() const
 {
     struct stat st;
-    if (stat(path.c_str(), &st) == 0) {
-        return st.st_size;
+    if (::stat(path.c_str(), &st) == 0) {
+        return static_cast<size_t>(st.st_size);
     }
     return 0;
 }
 
 bool File::open(bool wMode, bool override)
 {
+#ifdef _WIN32
     std::ios_base::openmode mode = std::ios::in | std::ios::binary;
     if (wMode) {
         mode = std::ios::out | std::ios::binary | (override ? std::ios::trunc : std::ios::app);
@@ -105,25 +128,59 @@ bool File::open(bool wMode, bool override)
     file.open(path, mode);
     isOpenFlag = file.is_open();
     return isOpenFlag;
+#else
+    // Read      -> read-only.
+    // Write+override -> create/truncate, read+write, position at start.
+    // Write     -> open-or-create WITHOUT truncating, read+write, position at
+    //              start. Deliberately not append: append would ignore lseek and
+    //              break seek()+write() (e.g. patching a header/CRC after a
+    //              streamed write).
+    int flags;
+    if (!wMode) {
+        flags = O_RDONLY;
+    } else if (override) {
+        flags = O_RDWR | O_CREAT | O_TRUNC;
+    } else {
+        flags = O_RDWR | O_CREAT;
+    }
+
+    fd = ::open(path.c_str(), flags, 0644);
+    return fd >= 0;
+#endif
 }
 
 bool File::isOpen() const
 {
+#ifdef _WIN32
     return isOpenFlag;
+#else
+    return fd >= 0;
+#endif
 }
 
 bool File::close()
 {
+#ifdef _WIN32
     if (isOpenFlag) {
         file.close();
         isOpenFlag = false;
         return true;
     }
     return false;
+#else
+    if (fd >= 0) {
+        bool ok = (::close(fd) == 0);
+        fd = -1;
+        return ok;
+    }
+    return false;
+#endif
 }
 
 bool File::read(char *buff, size_t btr, size_t &br)
 {
+    br = 0;
+#ifdef _WIN32
     if (!isOpenFlag) return false;
 
     file.read(buff, btr);
@@ -137,10 +194,27 @@ bool File::read(char *buff, size_t btr, size_t &br)
         return false;  // An error occurred
     }
     return true;
+#else
+    if (fd < 0) return false;
+
+    // Loop over short reads; a partial read at EOF is success (br < btr).
+    while (br < btr) {
+        ssize_t n = ::read(fd, buff + br, btr - br);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (n == 0) break; // EOF
+        br += static_cast<size_t>(n);
+    }
+    return true;
+#endif
 }
 
 bool File::write(const char *buff, size_t btw, size_t &bw)
 {
+    bw = 0;
+#ifdef _WIN32
     if (!isOpenFlag) return false;
 
     // Perform recording
@@ -155,18 +229,41 @@ bool File::write(const char *buff, size_t btw, size_t &bw)
     // If everything is fine, set the number of written bytes
     bw = btw;
     return true;
+#else
+    if (fd < 0) return false;
+
+    // Loop over short writes so a full buffer is committed (or we report failure).
+    while (bw < btw) {
+        ssize_t n = ::write(fd, buff + bw, btw - bw);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (n == 0) {
+            return false; // no progress: cannot complete the write
+        }
+        bw += static_cast<size_t>(n);
+    }
+    return true;
+#endif
 }
 
 bool File::seek(size_t offset)
 {
+#ifdef _WIN32
     if (!isOpenFlag) return false;
     file.seekg(offset);
     file.seekp(offset);
     return !file.fail();
+#else
+    if (fd < 0) return false;
+    return ::lseek(fd, static_cast<off_t>(offset), SEEK_SET) != static_cast<off_t>(-1);
+#endif
 }
 
 bool File::truncate(size_t offset)
 {
+#ifdef _WIN32
     if (!isOpenFlag) return false;
 
     // Close the file before trimming
@@ -195,37 +292,57 @@ bool File::truncate(size_t offset)
 
     isOpenFlag = true; // Set the open file flag
     return true;
+#else
+    if (fd < 0) return false;
+    // ftruncate sets the exact file length; the fd offset is unchanged.
+    return ::ftruncate(fd, static_cast<off_t>(offset)) == 0;
+#endif
 }
 
 bool File::flush()
 {
+#ifdef _WIN32
     if (!isOpenFlag) return false;
     file.flush();
     return !file.fail();
+#else
+    if (fd < 0) return false;
+    return ::fsync(fd) == 0;
+#endif
 }
 
 size_t File::getPosition() const
 {
+#ifdef _WIN32
     if (!isOpenFlag) return 0;
 
     // Since tellg() cannot be called from const, use const_cast
     return static_cast<size_t>(const_cast<std::fstream &>(file).tellg());
+#else
+    if (fd < 0) return 0;
+    off_t pos = ::lseek(fd, 0, SEEK_CUR);
+    return pos < 0 ? 0 : static_cast<size_t>(pos);
+#endif
 }
 
 
 
-Directory::Directory(const char *prefix, const char *relativePath) 
+Directory::Directory(const char *prefix, const char *relativePath)
     : mPathPrefix(prefix)
 {
     setPath(relativePath);
 }
 
+Directory::~Directory()
+{
+    close(); // release the handle on destruction (RAII); close() is idempotent
+}
+
 void Directory::setPath(const char *path)
 {
     this->path = AddPrefix(mPathPrefix, path);
-    // Update pathBuffer whenever the path is set
-    safe_strcpy(pathBuffer, path, sizeof(pathBuffer) - 1);
-    pathBuffer[sizeof(pathBuffer) - 1] = '\0'; // Ensure null-termination
+    // Store the caller-facing (prefix-less) path; safe_strcpy always NUL-terminates.
+    safe_strcpy(pathBuffer, path, sizeof(pathBuffer));
 }
 
 const char *Directory::getPath() const
@@ -235,7 +352,12 @@ const char *Directory::getPath() const
 
 bool Directory::exist() const
 {
+#ifdef _WIN32
     return GetFileAttributesA(path.c_str()) != INVALID_FILE_ATTRIBUTES;
+#else
+    struct stat st;
+    return ::stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
+#endif
 }
 
 bool Directory::rename(const char *newPath)
@@ -250,15 +372,32 @@ bool Directory::remove()
 
 bool Directory::create()
 {
+#ifdef _WIN32
     return CreateDirectoryA(path.c_str(), nullptr) || GetLastError() == ERROR_ALREADY_EXISTS;
+#else
+    if (::mkdir(path.c_str(), 0755) == 0) {
+        return true;
+    }
+    if (errno == EEXIST) {
+        // Only report success if the existing object really is a directory.
+        struct stat st;
+        return ::stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
+    }
+    return false;
+#endif
 }
 
 bool Directory::open()
 {
+#ifdef _WIN32
     std::string searchPath = path + "/*";
     handle = FindFirstFileA(searchPath.c_str(), &findData);
     isOpenFlag = (handle != INVALID_HANDLE_VALUE);
     hasEntry = isOpenFlag;
+#else
+    handle = ::opendir(path.c_str());
+    isOpenFlag = (handle != nullptr);
+#endif
     return isOpenFlag;
 }
 
@@ -271,6 +410,7 @@ bool Directory::readNext(SDK::Interface::IFileSystem::ObjectInfo &item, bool res
 {
     if (!isOpenFlag) return false;
 
+#ifdef _WIN32
     if (reset) {
         FindClose(handle);
         return open();
@@ -288,14 +428,60 @@ bool Directory::readNext(SDK::Interface::IFileSystem::ObjectInfo &item, bool res
     hasEntry = (FindNextFileA(handle, &findData) != 0);
 
     return true;
+#else
+    if (reset) {
+        ::rewinddir(handle);
+        return true; // rewind only; a reset call does not read an entry (per contract)
+    }
+
+    // Skip the "." and ".." pseudo-entries so callers iterate real children only.
+    struct dirent *ent = nullptr;
+    do {
+        ent = ::readdir(handle);
+    } while (ent != nullptr &&
+             (std::strcmp(ent->d_name, ".") == 0 || std::strcmp(ent->d_name, "..") == 0));
+
+    if (ent == nullptr) {
+        return false; // directory exhausted
+    }
+
+    // Populate every field; never leave one uninitialised.
+    safe_strcpy(item.name, ent->d_name, sizeof(item.name));
+    item.isHidden = (ent->d_name[0] == '.');
+    item.isSystem = false;
+
+    struct stat st;
+    const std::string full = path + "/" + ent->d_name;
+    if (::stat(full.c_str(), &st) == 0) {
+        // st_mode is authoritative for isDir (d_type may be DT_UNKNOWN on some
+        // filesystems) and yields a 64-bit size and a timestamp.
+        item.isDir = S_ISDIR(st.st_mode);
+        item.size  = static_cast<size_t>(st.st_size);
+        // POSIX has no portable creation time; st_ctime (inode change time) is
+        // the closest widely-available approximation. Keep the full time_t width.
+        item.utc   = st.st_ctime;
+    } else {
+        // stat failed (e.g. dangling symlink): fall back without inventing data.
+        item.isDir = (ent->d_type == DT_DIR);
+        item.size  = 0;
+        item.utc   = 0;
+    }
+
+    return true;
+#endif
 }
 
 bool Directory::close()
 {
     if (isOpenFlag) {
+#ifdef _WIN32
         FindClose(handle);
-        isOpenFlag = false;
         hasEntry = false;
+#else
+        ::closedir(handle);
+        handle = nullptr;
+#endif
+        isOpenFlag = false;
         return true;
     }
     return false;
@@ -306,7 +492,11 @@ bool Directory::close()
 FileSystem::FileSystem(const char *rootPath)
 {
     mPathPrefix = rootPath;
+#ifdef _WIN32
     CreateDirectoryA(mPathPrefix, nullptr);
+#else
+    ::mkdir(mPathPrefix, 0755);
+#endif
 }
 
 std::string FileSystem::getRootPath()
@@ -318,25 +508,31 @@ std::string FileSystem::getRootPath()
 bool FileSystem::mkdir(const char *path)
 {
     std::string directory(path);
-    std::vector<std::string> directories;
     std::stringstream ss(directory);
     std::string token;
+    std::string currentPath;
 
     while (std::getline(ss, token, '/')) {
-        directories.push_back(token);
-    }
-
-    std::string currentPath;
-    for (const auto &dir : directories) {
+        if (token.empty()) {
+            continue; // tolerate leading, trailing, and duplicate '/'
+        }
         if (!currentPath.empty()) {
             currentPath += "/";
         }
-        currentPath += dir;
-        if (!CreateDirectoryA(AddPrefix(mPathPrefix, currentPath.c_str()).c_str(), nullptr)) {
+        currentPath += token;
+
+        const std::string full = AddPrefix(mPathPrefix, currentPath.c_str());
+#ifdef _WIN32
+        if (!CreateDirectoryA(full.c_str(), nullptr)) {
             if (GetLastError() != ERROR_ALREADY_EXISTS) {
                 return false;
             }
         }
+#else
+        if (::mkdir(full.c_str(), 0755) != 0 && errno != EEXIST) {
+            return false;
+        }
+#endif
     }
 
     return true;
@@ -354,7 +550,12 @@ std::unique_ptr<SDK::Interface::IDirectory> FileSystem::dir(const char *path)
 
 bool  FileSystem::exist(const char *path) const
 {
+#ifdef _WIN32
     return GetFileAttributesA(AddPrefix(mPathPrefix, path).c_str()) != INVALID_FILE_ATTRIBUTES;
+#else
+    struct stat st;
+    return ::stat(AddPrefix(mPathPrefix, path).c_str(), &st) == 0;
+#endif
 }
 
 bool  FileSystem::remove(const char *path)
@@ -378,12 +579,15 @@ bool  FileSystem::copy(const char *oldPath, const char *newPath)
 
     destination << source.rdbuf();
 
-    return true;
+    // An empty source sets failbit on the rdbuf insertion, which is not an error;
+    // only a real I/O failure sets badbit.
+    return !destination.bad() && !source.bad();
 }
 
 
 bool FileSystem::objectInfo(const char *path, FileSystem::ObjectInfo &item) const
 {
+#ifdef _WIN32
     WIN32_FIND_DATAA findData;
     HANDLE hFind = FindFirstFileA(AddPrefix(mPathPrefix, path).c_str(), &findData);
     if (hFind == INVALID_HANDLE_VALUE) return false;
@@ -395,6 +599,29 @@ bool FileSystem::objectInfo(const char *path, FileSystem::ObjectInfo &item) cons
     item.utc = FileTimeToUnixTime(findData.ftCreationTime);
     FindClose(hFind);
     return true;
+#else
+    std::string full = AddPrefix(mPathPrefix, path);
+    struct stat st;
+    if (::stat(full.c_str(), &st) != 0) {
+        return false;
+    }
+
+    // Derive the leaf name from the path; strip trailing slashes first so a
+    // path like "a/b/" yields "b" rather than an empty name.
+    while (full.size() > 1 && full.back() == '/') {
+        full.pop_back();
+    }
+    const size_t pos = full.rfind('/');
+    const std::string name = (pos != std::string::npos) ? full.substr(pos + 1) : full;
+
+    safe_strcpy(item.name, name.c_str(), sizeof(item.name));
+    item.isDir = S_ISDIR(st.st_mode);
+    item.isHidden = (!name.empty() && name[0] == '.');
+    item.isSystem = false;
+    item.size = static_cast<size_t>(st.st_size);
+    item.utc = st.st_ctime; // time_t; keep full width (no uint32 truncation)
+    return true;
+#endif
 }
 
 } /* namespace Simulator */

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(una-sdk-host-tests
     apps/Running/ActivityWriter_test.cpp
     sensorlayer/HeartRateParser_test.cpp
     sensorlayer/HeartRateExParser_test.cpp
+    simulator/FileSystemMock_test.cpp
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/SettingsSerializer.cpp"
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/Calibration/OutdoorStrideCalibrator.cpp"
@@ -61,6 +62,8 @@ add_executable(una-sdk-host-tests
     "${UNA_SDK_ROOT}/Libs/Source/JSON/JsonStreamReader.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/JSON/JsonStreamWriter.cpp"
     "${COREJSON_DIR}/core_json.c"
+    "${UNA_SDK_ROOT}/Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp"
+    "${UNA_SDK_ROOT}/Libs/Source/Wrappers/StdLibWrappers.c"
 )
 # FIT encoding is covered by the SDK::Fit tests (fit/*) and the Running
 # ActivityWriter smoke test (apps/Running/ActivityWriter_test.cpp).

--- a/Tests/Host/simulator/FileSystemMock_test.cpp
+++ b/Tests/Host/simulator/FileSystemMock_test.cpp
@@ -1,0 +1,269 @@
+/**
+ * Host unit tests for the simulator's POSIX Mock::FileSystem.
+ *
+ * The mock is Windows-only elsewhere in the tree, so this suite is POSIX-guarded
+ * and runs on the Linux host-tests CI job (which is where the SDK host tests
+ * already run). The Windows path is covered separately.
+ */
+#ifndef _WIN32
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <sys/resource.h>
+
+#include <gtest/gtest.h>
+
+#include "SDK/Interfaces/IFileSystem.hpp"
+#include "SDK/Simulator/Kernel/Mock/FileSystem.hpp"
+
+using SDK::Simulator::Mock::FileSystem;
+namespace I = SDK::Interface;
+
+namespace {
+
+class MockFileSystemTest : public ::testing::Test {
+protected:
+    std::string root;
+
+    void SetUp() override
+    {
+        const auto *info = ::testing::UnitTest::GetInstance()->current_test_info();
+        const std::filesystem::path dir =
+            std::filesystem::temp_directory_path() /
+            (std::string("una_fsmock_") + info->name());
+        std::error_code ec;
+        std::filesystem::remove_all(dir, ec);
+        std::filesystem::create_directories(dir, ec);
+        root = dir.string() + "/"; // FileSystem builds paths as prefix + path
+    }
+
+    void TearDown() override
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(root, ec);
+    }
+};
+
+// Loop-open a handle without closing it under a lowered fd limit; RAII must
+// reclaim each one, otherwise this exhausts the table and open() fails.
+bool opensWithoutLeaking(const std::function<bool()> &openOnce)
+{
+    struct rlimit orig{};
+    if (::getrlimit(RLIMIT_NOFILE, &orig) != 0) {
+        return true; // cannot probe; don't fail the suite
+    }
+    struct rlimit low = orig;
+    low.rlim_cur = 96;
+    if (::setrlimit(RLIMIT_NOFILE, &low) != 0) {
+        return true; // not permitted to lower; skip the probe
+    }
+
+    bool ok = true;
+    for (int i = 0; i < 1024; ++i) {
+        if (!openOnce()) { ok = false; break; }
+    }
+
+    ::setrlimit(RLIMIT_NOFILE, &orig); // restore before returning/asserting
+    return ok;
+}
+
+} // namespace
+
+TEST_F(MockFileSystemTest, MkdirNestedAndExist)
+{
+    FileSystem fs(root.c_str());
+    EXPECT_TRUE(fs.mkdir("x/y/z"));
+    EXPECT_TRUE(fs.exist("x/y/z"));
+    EXPECT_FALSE(fs.exist("x/y/nope"));
+}
+
+TEST_F(MockFileSystemTest, WriteReadSize)
+{
+    FileSystem fs(root.c_str());
+    auto w = fs.file("data.bin");
+    size_t bw = 0;
+    ASSERT_TRUE(w->open(true, true));
+    ASSERT_TRUE(w->write("hello", 5, bw));
+    EXPECT_EQ(bw, 5u);
+    ASSERT_TRUE(w->close());
+
+    auto r = fs.file("data.bin");
+    EXPECT_EQ(r->size(), 5u);
+    ASSERT_TRUE(r->open(false));
+    char buf[16] = {0};
+    size_t br = 0;
+    ASSERT_TRUE(r->read(buf, sizeof(buf), br));
+    EXPECT_EQ(br, 5u);
+    EXPECT_EQ(std::string(buf, 5), "hello");
+    r->close();
+}
+
+// The single-position contract: seek() then write() overwrites in place; it must
+// NOT append (the fstream append-mode bug this fd rewrite replaces).
+TEST_F(MockFileSystemTest, SeekWriteOverwritesNotAppends)
+{
+    FileSystem fs(root.c_str());
+    { auto f = fs.file("data.bin"); size_t bw = 0;
+      ASSERT_TRUE(f->open(true, true));
+      ASSERT_TRUE(f->write("AAAAAAAAAA", 10, bw));
+      ASSERT_TRUE(f->close()); }
+
+    { auto f = fs.file("data.bin"); size_t bw = 0;
+      ASSERT_TRUE(f->open(true, false)); // write, no override
+      ASSERT_TRUE(f->seek(3));
+      EXPECT_EQ(f->getPosition(), 3u);
+      ASSERT_TRUE(f->write("XYZ", 3, bw));
+      EXPECT_EQ(bw, 3u);
+      ASSERT_TRUE(f->close()); }
+
+    auto f = fs.file("data.bin");
+    EXPECT_EQ(f->size(), 10u); // overwrote in place, did not append
+    ASSERT_TRUE(f->open(false));
+    char buf[16] = {0};
+    size_t br = 0;
+    ASSERT_TRUE(f->read(buf, sizeof(buf), br));
+    EXPECT_EQ(br, 10u);
+    EXPECT_EQ(std::string(buf, 10), "AAAXYZAAAA");
+    f->close();
+}
+
+TEST_F(MockFileSystemTest, Truncate)
+{
+    FileSystem fs(root.c_str());
+    { auto f = fs.file("t.bin"); size_t bw = 0;
+      ASSERT_TRUE(f->open(true, true));
+      ASSERT_TRUE(f->write("ABCDEFGH", 8, bw));
+      ASSERT_TRUE(f->close()); }
+    { auto f = fs.file("t.bin");
+      ASSERT_TRUE(f->open(true, false));
+      EXPECT_TRUE(f->truncate(3));
+      ASSERT_TRUE(f->close()); }
+
+    auto f = fs.file("t.bin");
+    EXPECT_EQ(f->size(), 3u);
+    ASSERT_TRUE(f->open(false));
+    char buf[16] = {0};
+    size_t br = 0;
+    ASSERT_TRUE(f->read(buf, sizeof(buf), br));
+    f->close();
+    EXPECT_EQ(br, 3u);
+    EXPECT_EQ(std::string(buf, 3), "ABC");
+}
+
+// Every ObjectInfo field must be populated; poison the struct first so a
+// left-uninitialized field is caught.
+TEST_F(MockFileSystemTest, ObjectInfoInitializesAllFields)
+{
+    FileSystem fs(root.c_str());
+    { auto f = fs.file("f.txt"); size_t bw = 0; f->open(true, true); f->write("hi", 2, bw); f->close(); }
+
+    I::IFileSystem::ObjectInfo info;
+    std::memset(&info, 0xAB, sizeof(info));
+    ASSERT_TRUE(fs.objectInfo("f.txt", info));
+    EXPECT_STREQ(info.name, "f.txt");
+    EXPECT_FALSE(info.isDir);
+    EXPECT_FALSE(info.isHidden);
+    EXPECT_FALSE(info.isSystem);
+    EXPECT_EQ(info.size, 2u);
+}
+
+TEST_F(MockFileSystemTest, ObjectInfoDirAndTrailingSlash)
+{
+    FileSystem fs(root.c_str());
+    ASSERT_TRUE(fs.mkdir("sub/inner"));
+
+    I::IFileSystem::ObjectInfo a;
+    std::memset(&a, 0xAB, sizeof(a));
+    ASSERT_TRUE(fs.objectInfo("sub/inner", a));
+    EXPECT_TRUE(a.isDir);
+
+    I::IFileSystem::ObjectInfo b;
+    std::memset(&b, 0xAB, sizeof(b));
+    ASSERT_TRUE(fs.objectInfo("sub/inner/", b)); // trailing slash -> leaf "inner"
+    EXPECT_STREQ(b.name, "inner");
+    EXPECT_TRUE(b.isDir);
+}
+
+// readNext is a one-entry-per-call cursor that skips "." and ".."; reset rewinds
+// without reading (the contract rryles pinned in IFileSystem.hpp).
+TEST_F(MockFileSystemTest, DirectoryEnumeration)
+{
+    FileSystem fs(root.c_str());
+    ASSERT_TRUE(fs.mkdir("list"));
+    { auto f = fs.file("list/one.txt"); size_t bw = 0; f->open(true, true); f->write("1", 1, bw); f->close(); }
+    { auto f = fs.file("list/two.txt"); size_t bw = 0; f->open(true, true); f->write("22", 2, bw); f->close(); }
+    ASSERT_TRUE(fs.mkdir("list/sub"));
+
+    auto d = fs.dir("list");
+    ASSERT_TRUE(d->open());
+
+    int files = 0, dirs = 0, dots = 0;
+    I::IFileSystem::ObjectInfo it;
+    for (;;) {
+        std::memset(&it, 0xAB, sizeof(it));
+        if (!d->readNext(it)) break;
+        if (!std::strcmp(it.name, ".") || !std::strcmp(it.name, "..")) {
+            ++dots;
+        } else if (it.isDir) {
+            ++dirs;
+        } else {
+            ++files;
+        }
+    }
+    EXPECT_EQ(dots, 0);
+    EXPECT_EQ(files, 2);
+    EXPECT_EQ(dirs, 1);
+
+    // reset rewinds only (returns true, leaves item alone); next reads re-enumerate.
+    EXPECT_TRUE(d->readNext(it, /*reset=*/true));
+    int again = 0;
+    while (d->readNext(it)) ++again;
+    EXPECT_EQ(again, 3);
+
+    d->close();
+}
+
+TEST_F(MockFileSystemTest, RenameCopyRemove)
+{
+    FileSystem fs(root.c_str());
+    { auto f = fs.file("a.txt"); size_t bw = 0; f->open(true, true); f->write("data", 4, bw); f->close(); }
+
+    EXPECT_TRUE(fs.rename("a.txt", "b.txt"));
+    EXPECT_TRUE(fs.exist("b.txt"));
+    EXPECT_FALSE(fs.exist("a.txt"));
+
+    EXPECT_TRUE(fs.copy("b.txt", "c.txt"));
+    EXPECT_TRUE(fs.exist("c.txt"));
+
+    EXPECT_TRUE(fs.remove("c.txt"));
+    EXPECT_FALSE(fs.exist("c.txt"));
+}
+
+TEST_F(MockFileSystemTest, FileDestructorReleasesFd)
+{
+    FileSystem fs(root.c_str());
+    { auto f = fs.file("seed"); size_t bw = 0; f->open(true, true); f->write("x", 1, bw); f->close(); }
+
+    EXPECT_TRUE(opensWithoutLeaking([&] {
+        auto f = fs.file("seed");
+        return f->open(false); // no close(): rely on ~File()
+    }));
+}
+
+TEST_F(MockFileSystemTest, DirectoryDestructorReleasesHandle)
+{
+    FileSystem fs(root.c_str());
+    ASSERT_TRUE(fs.mkdir("d"));
+
+    EXPECT_TRUE(opensWithoutLeaking([&] {
+        auto dir = fs.dir("d");
+        return dir->open(); // no close(): rely on ~Directory()
+    }));
+}
+
+#endif // !_WIN32

--- a/Tests/Host/simulator/FileSystemMock_test.cpp
+++ b/Tests/Host/simulator/FileSystemMock_test.cpp
@@ -266,4 +266,31 @@ TEST_F(MockFileSystemTest, DirectoryDestructorReleasesHandle)
     }));
 }
 
+// Reopening the same object without an intervening close() must release the
+// previous handle; otherwise each open() leaks a descriptor and the lowered
+// fd limit is exhausted.
+TEST_F(MockFileSystemTest, FileReopenReleasesPreviousFd)
+{
+    FileSystem fs(root.c_str());
+    { auto f = fs.file("seed"); size_t bw = 0; f->open(true, true); f->write("x", 1, bw); f->close(); }
+
+    auto f = fs.file("seed");
+    EXPECT_TRUE(opensWithoutLeaking([&] {
+        return f->open(false); // no close() between iterations: open() must drop the prior fd
+    }));
+    f->close();
+}
+
+TEST_F(MockFileSystemTest, DirectoryReopenReleasesPreviousHandle)
+{
+    FileSystem fs(root.c_str());
+    ASSERT_TRUE(fs.mkdir("d"));
+
+    auto dir = fs.dir("d");
+    EXPECT_TRUE(opensWithoutLeaking([&] {
+        return dir->open(); // no close() between iterations: open() must drop the prior DIR*
+    }));
+    dir->close();
+}
+
 #endif // !_WIN32


### PR DESCRIPTION
Open to hear if this is contentious - the CI is all Linux but obviously the test coverage is Windows-focused because of the TouchGFX tooling. This is, I think, the last notable piece that is upstream-able to support Linux for running the simulator. The builds are not identical, and the Linux will have to stay constrained to a fork, but if we're able to upstream this it's very close to it Just Works on.

Mock::FileSystem was Windows-only (Win32 + FILETIME), so the simulator did not build on Linux. Add a POSIX path in the #else branch without touching the Windows functionality.

No Windows regression: all new logic is confined to the #else path, so the Win32 branches compile as before. The shared changes are limited to an RAII destructor, deleted copy ops, and zero-initializing the read/write counts; on Windows each is either inert (std::fstream already self-closes) or a strict improvement (it closes the previously-leaked Directory HANDLE and prevents a double-close), never a regression.

The POSIX File is built on a raw fd rather than std::fstream: IFile has a single read/write position that matches an fd offset (fstream's separate get/put positions do not), which also avoids the fstream append-mode bug where seek()+write() appended instead of overwriting. It handles EINTR/short I/O, ftruncate, fsync, and closes on destruction. Directory uses opendir/readdir plus stat: isDir via S_ISDIR, all ObjectInfo fields initialized, "." and ".." skipped, rewinddir on reset.

Add Tests/Host coverage, POSIX-guarded so it runs on the existing Linux host-tests CI job: mkdir/write/read/size, seek+overwrite, truncate, objectInfo (poisoned struct and trailing slash), directory enumeration, rename/copy/remove, and fd/DIR* release under a lowered RLIMIT_NOFILE. First automated coverage for this file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/strengthened POSIX behavior for the simulator’s mock filesystem, including nested directory creation and directory enumeration.
  * Improved metadata reporting for files and directories (size, timestamps, and proper trailing-slash handling).
* **Bug Fixes**
  * More reliable file I/O, including correct success checks, robust read/write retry logic, and accurate seek/truncate behavior.
  * Improved resource management by ensuring proper handle cleanup and safe reopen behavior.
* **Tests**
  * Added extensive host-side coverage for core filesystem operations, metadata correctness, enumeration edge cases, and handle-leak/reopen scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->