### PR TITLE
feat(apps): pre-activity sensor-status row on Settings/Intervals sub-menus

### DIFF
--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
@@ -4,6 +4,7 @@
 #include <gui_generated/containers/MainMenuLayoutBase.hpp>
 #include <gui/containers/MenuItemConfig.hpp>
 #include <touchgfx/Callback.hpp>
+#include <SDK/GUI/SensorStatusRow.hpp>
 
 /**
  * @brief Standard full-screen menu layout container.
@@ -68,11 +69,22 @@ public:
     void setInfoMsg(TypedTextId msgId);
     void setInfoMsgColor(touchgfx::colortype color);
 
+    // ---- Sensor status row (GPS / external HR) -----------------------------
+    // Shared pre-activity icon bar, occupying the old infoText slot. Hidden by
+    // default; pre-activity menu screens opt in with showSensorRow(true) and
+    // forward live state via setGps()/setHr().
+    void showSensorRow(bool show);
+    void setGps(bool fix);
+    void setHr(uint8_t accessoryState);
+
     // ---- Getters -----------------------------------------------------------
     /** Direct access to navigation buttons (set L1/L2/R1/R2 state). */
     Buttons  &getButtons();
     /** Direct access to the scroll wheel menu (for advanced operations). */
     MainMenu &getMenu();
+
+private:
+    SDK::Gui::SensorStatusRow mSensorRow;
 };
 
 #endif // MAINMENULAYOUT_HPP

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsPresenter.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsPresenter.hpp
@@ -28,6 +28,8 @@ public:
     virtual ~MenuAlertsPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onGpsFix(bool acquired) override;
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
 private:
     MenuAlertsPresenter();

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsView.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsView.hpp
@@ -13,6 +13,8 @@ public:
     virtual void setupScreen();
     virtual void tearDownScreen();
 
+    void setGpsFix(bool state);
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setUnitsImperial(bool isImperial);
     void setDistance(Settings::Alerts::Distance::Id id);
     void setTime(Settings::Alerts::Time::Id id);
@@ -26,6 +28,7 @@ protected:
 
     static const uint16_t kBuffSize = 32;
 
+    bool         mGpsFix        = false;
     bool         mUnitsImperial = false;
     Distance::Id mDistanceId    = Distance::ID_OFF;
     Time::Id     mTimeId        = Time::ID_OFF;

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
@@ -29,6 +29,7 @@ public:
 
     virtual void onIdleTimeout() override { model->exitApp(); }
     virtual void onGpsFix(bool acquired) override;
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
     void savePhoneNotif(bool state);
 

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
@@ -14,6 +14,7 @@ public:
     virtual void tearDownScreen();
 
     void setGpsFix(bool state);
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setPhoneNotif(bool state);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
@@ -1,4 +1,5 @@
 #include <gui/containers/MainMenuLayout.hpp>
+#include <images/BitmapDatabase.hpp>
 
 MainMenuLayout::MainMenuLayout()
 {
@@ -13,6 +14,14 @@ void MainMenuLayout::initialize()
     buttons.setL2(Buttons::NONE);
     buttons.setR1(Buttons::AMBER);
     buttons.setR2(Buttons::WHITE);
+
+    // Pre-activity sensor-status row in the old infoText slot. Hidden until a
+    // screen opts in (value-entry pickers reuse this space, so they don't).
+    add(mSensorRow);
+    mSensorRow.setPosition(0, 52, 240, 24);
+    mSensorRow.setIcons(BITMAP_SENSORGPSDARK_ID, BITMAP_SENSORGPSLIGHT_ID,
+                        BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
+    mSensorRow.setVisible(false);
 }
 
 // ---- Delegated wheel operations --------------------------------------------
@@ -129,6 +138,30 @@ void MainMenuLayout::setInfoMsgColor(touchgfx::colortype color)
 {
     infoText.setColor(color);
     infoText.invalidate();
+}
+
+// ---- Sensor status row -----------------------------------------------------
+
+void MainMenuLayout::showSensorRow(bool show)
+{
+    // The row occupies the old infoText slot; keep them mutually exclusive
+    // so a stray setInfoMsg() can never overlap the sensor icons.
+    if (show) {
+        infoText.setVisible(false);
+        infoText.invalidate();
+    }
+    mSensorRow.setVisible(show);
+    mSensorRow.invalidate();
+}
+
+void MainMenuLayout::setGps(bool fix)
+{
+    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(fix));
+}
+
+void MainMenuLayout::setHr(uint8_t accessoryState)
+{
+    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(accessoryState));
 }
 
 // ---- Getters ---------------------------------------------------------------

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsPresenter.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsPresenter.cpp
@@ -12,9 +12,21 @@ void MenuAlertsPresenter::activate()
     view.setPositionId(model->menu().settings.alerts.get());
     model->resetIdleTimer();
 
+    view.setGpsFix(model->hasGpsFix());
+    view.setAccessoryStatus(model->getAccessoryState(), "");
     view.setUnitsImperial(model->isUnitsImperial());
     view.setDistance(model->getSettings().alertDistanceId);
     view.setTime(model->getSettings().alertTimeId);
+}
+
+void MenuAlertsPresenter::onGpsFix(bool acquired)
+{
+    view.setGpsFix(acquired);
+}
+
+void MenuAlertsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuAlertsPresenter::deactivate()

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsView.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsView.cpp
@@ -16,6 +16,9 @@ void MenuAlertsView::setupScreen()
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
 
+    menuLayout.showSensorRow(true);
+    setGpsFix(mGpsFix);
+
     formatTips();
     menuLayout.invalidate();
 }
@@ -23,6 +26,17 @@ void MenuAlertsView::setupScreen()
 void MenuAlertsView::tearDownScreen()
 {
     MenuAlertsViewBase::tearDownScreen();
+}
+
+void MenuAlertsView::setGpsFix(bool state)
+{
+    mGpsFix = state;
+    menuLayout.setGps(state);
+}
+
+void MenuAlertsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuAlertsView::setUnitsImperial(bool isImperial)

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
@@ -14,6 +14,7 @@ void MenuSettingsPresenter::activate()
     model->resetIdleTimer();
 
     view.setGpsFix(model->hasGpsFix());
+    view.setAccessoryStatus(model->getAccessoryState(), "");
     view.setPhoneNotif(model->getSettings().phoneNotifEn);
 }
 
@@ -25,6 +26,11 @@ void MenuSettingsPresenter::deactivate()
 void MenuSettingsPresenter::onGpsFix(bool acquired)
 {
     view.setGpsFix(acquired);
+}
+
+void MenuSettingsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuSettingsPresenter::savePhoneNotif(bool state)

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
@@ -16,6 +16,7 @@ void MenuSettingsView::setupScreen()
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
 
+    menuLayout.showSensorRow(true);
     setGpsFix(mGpsFix);
 
     menuLayout.invalidate();
@@ -29,7 +30,12 @@ void MenuSettingsView::tearDownScreen()
 void MenuSettingsView::setGpsFix(bool state)
 {
     mGpsFix = state;
-    menuLayout.setInfoMsg(state ? T_TEXT_SIGNAL_ACQUIRED : T_TEXT_ACQUIRING_SIGNAL);
+    menuLayout.setGps(state);
+}
+
+void MenuSettingsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuSettingsView::setPhoneNotif(bool state)

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
@@ -4,6 +4,7 @@
 #include <gui_generated/containers/MainMenuLayoutBase.hpp>
 #include <gui/containers/MenuItemConfig.hpp>
 #include <touchgfx/Callback.hpp>
+#include <SDK/GUI/SensorStatusRow.hpp>
 
 /**
  * @brief Standard full-screen menu layout container.
@@ -68,11 +69,22 @@ public:
     void setInfoMsg(TypedTextId msgId);
     void setInfoMsgColor(touchgfx::colortype color);
 
+    // ---- Sensor status row (GPS / external HR) -----------------------------
+    // Shared pre-activity icon bar, occupying the old infoText slot. Hidden by
+    // default; pre-activity menu screens opt in with showSensorRow(true) and
+    // forward live state via setGps()/setHr().
+    void showSensorRow(bool show);
+    void setGps(bool fix);
+    void setHr(uint8_t accessoryState);
+
     // ---- Getters -----------------------------------------------------------
     /** Direct access to navigation buttons (set L1/L2/R1/R2 state). */
     Buttons  &getButtons();
     /** Direct access to the scroll wheel menu (for advanced operations). */
     MainMenu &getMenu();
+
+private:
+    SDK::Gui::SensorStatusRow mSensorRow;
 };
 
 #endif // MAINMENULAYOUT_HPP

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsPresenter.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsPresenter.hpp
@@ -28,6 +28,8 @@ public:
     virtual ~MenuAlertsPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onGpsFix(bool acquired) override;
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
 private:
     MenuAlertsPresenter();

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsView.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsView.hpp
@@ -16,6 +16,8 @@ public:
     void setUnitsImperial(bool isImperial);
     void setDistance(Settings::Alerts::Distance::Id id);
     void setTime(Settings::Alerts::Time::Id id);
+    void setGpsFix(bool state);
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 
@@ -26,6 +28,7 @@ protected:
 
     static const uint16_t kBuffSize = 32;
 
+    bool         mGpsFix        = false;
     bool         mUnitsImperial = false;
     Distance::Id mDistanceId    = Distance::ID_OFF;
     Time::Id     mTimeId        = Time::ID_OFF;

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
@@ -29,6 +29,7 @@ public:
 
     virtual void onIdleTimeout() override { model->exitApp(); }
     virtual void onGpsFix(bool acquired) override;
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
     void savePhoneNotif(bool state);
 

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
@@ -14,6 +14,7 @@ public:
     virtual void tearDownScreen();
 
     void setGpsFix(bool state);
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setPhoneNotif(bool state);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
@@ -1,4 +1,5 @@
 #include <gui/containers/MainMenuLayout.hpp>
+#include <images/BitmapDatabase.hpp>
 
 MainMenuLayout::MainMenuLayout()
 {
@@ -13,6 +14,14 @@ void MainMenuLayout::initialize()
     buttons.setL2(Buttons::NONE);
     buttons.setR1(Buttons::AMBER);
     buttons.setR2(Buttons::WHITE);
+
+    // Pre-activity sensor-status row in the old infoText slot. Hidden until a
+    // screen opts in (value-entry pickers reuse this space, so they don't).
+    add(mSensorRow);
+    mSensorRow.setPosition(0, 52, 240, 24);
+    mSensorRow.setIcons(BITMAP_SENSORGPSDARK_ID, BITMAP_SENSORGPSLIGHT_ID,
+                        BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
+    mSensorRow.setVisible(false);
 }
 
 // ---- Delegated wheel operations --------------------------------------------
@@ -129,6 +138,30 @@ void MainMenuLayout::setInfoMsgColor(touchgfx::colortype color)
 {
     infoText.setColor(color);
     infoText.invalidate();
+}
+
+// ---- Sensor status row -----------------------------------------------------
+
+void MainMenuLayout::showSensorRow(bool show)
+{
+    // The row occupies the old infoText slot; keep them mutually exclusive
+    // so a stray setInfoMsg() can never overlap the sensor icons.
+    if (show) {
+        infoText.setVisible(false);
+        infoText.invalidate();
+    }
+    mSensorRow.setVisible(show);
+    mSensorRow.invalidate();
+}
+
+void MainMenuLayout::setGps(bool fix)
+{
+    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(fix));
+}
+
+void MainMenuLayout::setHr(uint8_t accessoryState)
+{
+    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(accessoryState));
 }
 
 // ---- Getters ---------------------------------------------------------------

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsPresenter.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsPresenter.cpp
@@ -15,9 +15,21 @@ void MenuAlertsPresenter::activate()
     view.setUnitsImperial(model->isUnitsImperial());
     view.setDistance(model->getSettings().alertDistanceId);
     view.setTime(model->getSettings().alertTimeId);
+    view.setGpsFix(model->hasGpsFix());
+    view.setAccessoryStatus(model->getAccessoryState(), "");
 }
 
 void MenuAlertsPresenter::deactivate()
 {
     model->menu().settings.alerts.set(view.getPositionId());
+}
+
+void MenuAlertsPresenter::onGpsFix(bool acquired)
+{
+    view.setGpsFix(acquired);
+}
+
+void MenuAlertsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsView.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsView.cpp
@@ -16,6 +16,9 @@ void MenuAlertsView::setupScreen()
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
 
+    menuLayout.showSensorRow(true);
+    setGpsFix(mGpsFix);
+
     formatTips();
     menuLayout.invalidate();
 }
@@ -23,6 +26,17 @@ void MenuAlertsView::setupScreen()
 void MenuAlertsView::tearDownScreen()
 {
     MenuAlertsViewBase::tearDownScreen();
+}
+
+void MenuAlertsView::setGpsFix(bool state)
+{
+    mGpsFix = state;
+    menuLayout.setGps(state);
+}
+
+void MenuAlertsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuAlertsView::setUnitsImperial(bool isImperial)

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
@@ -14,6 +14,7 @@ void MenuSettingsPresenter::activate()
     model->resetIdleTimer();
 
     view.setGpsFix(model->hasGpsFix());
+    view.setAccessoryStatus(model->getAccessoryState(), "");
     view.setPhoneNotif(model->getSettings().phoneNotifEn);
 }
 
@@ -25,6 +26,11 @@ void MenuSettingsPresenter::deactivate()
 void MenuSettingsPresenter::onGpsFix(bool acquired)
 {
     view.setGpsFix(acquired);
+}
+
+void MenuSettingsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuSettingsPresenter::savePhoneNotif(bool state)

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
@@ -16,6 +16,7 @@ void MenuSettingsView::setupScreen()
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
 
+    menuLayout.showSensorRow(true);
     setGpsFix(mGpsFix);
 
     menuLayout.invalidate();
@@ -29,7 +30,12 @@ void MenuSettingsView::tearDownScreen()
 void MenuSettingsView::setGpsFix(bool state)
 {
     mGpsFix = state;
-    menuLayout.setInfoMsg(state ? T_TEXT_SIGNAL_ACQUIRED : T_TEXT_ACQUIRING_SIGNAL);
+    menuLayout.setGps(state);
+}
+
+void MenuSettingsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuSettingsView::setPhoneNotif(bool state)

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
@@ -4,6 +4,7 @@
 #include <gui_generated/containers/MainMenuLayoutBase.hpp>
 #include <gui/containers/MenuItemConfig.hpp>
 #include <touchgfx/Callback.hpp>
+#include <SDK/GUI/SensorStatusRow.hpp>
 
 /**
  * @brief Standard full-screen menu layout container.
@@ -69,11 +70,22 @@ public:
     void setInfoMsg(TypedTextId msgId);
     void setInfoMsgColor(touchgfx::colortype color);
 
+    // ---- Sensor status row (GPS / external HR) -----------------------------
+    // Shared pre-activity icon bar, occupying the old infoText slot. Hidden by
+    // default; pre-activity menu screens opt in with showSensorRow(true) and
+    // forward live state via setGps()/setHr().
+    void showSensorRow(bool show);
+    void setGps(bool fix);
+    void setHr(uint8_t accessoryState);
+
     // ---- Getters -----------------------------------------------------------
     /** Direct access to navigation buttons (set L1/L2/R1/R2 state). */
     Buttons  &getButtons();
     /** Direct access to the scroll wheel menu (for advanced operations). */
     MainMenu &getMenu();
+
+private:
+    SDK::Gui::SensorStatusRow mSensorRow;
 };
 
 #endif // MAINMENULAYOUT_HPP

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsPresenter.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsPresenter.hpp
@@ -28,6 +28,8 @@ public:
     virtual ~MenuAlertsPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onGpsFix(bool acquired) override;
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
 private:
     MenuAlertsPresenter();

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsView.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsView.hpp
@@ -16,6 +16,8 @@ public:
     void setUnitsImperial(bool isImperial);
     void setDistance(Settings::Alerts::Distance::Id id);
     void setTime(Settings::Alerts::Time::Id id);
+    void setGpsFix(bool state);
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 
@@ -26,6 +28,7 @@ protected:
 
     static const uint16_t kBuffSize = 32;
 
+    bool                     mGpsFix        = false;
     bool                     mUnitsImperial = false;
     Distance::Id             mDistanceId    = Distance::ID_OFF;
     Time::Id                 mTimeId        = Time::ID_OFF;

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervals_screen/MenuIntervalsPresenter.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervals_screen/MenuIntervalsPresenter.hpp
@@ -28,6 +28,8 @@ public:
     virtual ~MenuIntervalsPresenter() {}
 
     virtual void onIdleTimeout() override;
+    virtual void onGpsFix(bool acquired) override;
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
     void saveWarmUp(bool enable);
     void saveCoolDown(bool enable);

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervals_screen/MenuIntervalsView.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervals_screen/MenuIntervalsView.hpp
@@ -14,6 +14,9 @@ public:
 
     void setIntervals(const Settings::Intervals & inervals, bool isImperial);
 
+    void setGpsFix(bool state);
+    void setAccessoryStatus(uint8_t state, const char* name);
+
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 
@@ -21,6 +24,9 @@ protected:
     using Menu = App::MenuNav::Root::Intervals;
 
     static const uint16_t kBuffSize = 16;
+
+    bool mGpsFix = false;
+
     touchgfx::Unicode::UnicodeChar mRepeatsTipBuff[kBuffSize] {};
     touchgfx::Unicode::UnicodeChar mRunTipBuff[kBuffSize] {};
     touchgfx::Unicode::UnicodeChar mRestTipBuff[kBuffSize] {};

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrepeats_screen/MenuIntervalsRepeatsPresenter.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrepeats_screen/MenuIntervalsRepeatsPresenter.hpp
@@ -28,6 +28,8 @@ public:
     virtual ~MenuIntervalsRepeatsPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onGpsFix(bool acquired) override;
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
     void saveRepeats(uint8_t repeatsNum);
 

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrepeats_screen/MenuIntervalsRepeatsView.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrepeats_screen/MenuIntervalsRepeatsView.hpp
@@ -16,10 +16,15 @@ public:
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 
+    void setGpsFix(bool state);
+    void setAccessoryStatus(uint8_t state, const char* name);
+
 protected:
     using Menu = App::MenuNav::Root::Intervals::Repeats;
 
     static const uint16_t kBuffSize = 8;
+
+    bool mGpsFix = false;
 
     touchgfx::Unicode::UnicodeChar mMainBuff[kBuffSize] {};
     touchgfx::Unicode::UnicodeChar mItemBuff[kBuffSize] {};

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrest_screen/MenuIntervalsRestPresenter.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrest_screen/MenuIntervalsRestPresenter.hpp
@@ -21,6 +21,8 @@ public:
     virtual ~MenuIntervalsRestPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onGpsFix(bool acquired) override;
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
 private:
     MenuIntervalsRestPresenter();

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrest_screen/MenuIntervalsRestView.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrest_screen/MenuIntervalsRestView.hpp
@@ -18,10 +18,15 @@ public:
 
     void setRestValue(const Settings::Intervals& iv, bool isImperial);
 
+    void setGpsFix(bool state);
+    void setAccessoryStatus(uint8_t state, const char* name);
+
 protected:
     using Menu = App::MenuNav::Root::Intervals::Metric;
 
     static const uint16_t kBuffSize = 16;
+
+    bool mGpsFix = false;
     touchgfx::Unicode::UnicodeChar mTimeTipBuff[kBuffSize] {};
     touchgfx::Unicode::UnicodeChar mDistanceTipBuff[kBuffSize] {};
 

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrun_screen/MenuIntervalsRunPresenter.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrun_screen/MenuIntervalsRunPresenter.hpp
@@ -21,6 +21,8 @@ public:
     virtual ~MenuIntervalsRunPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onGpsFix(bool acquired) override;
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
 private:
     MenuIntervalsRunPresenter();

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrun_screen/MenuIntervalsRunView.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrun_screen/MenuIntervalsRunView.hpp
@@ -18,10 +18,15 @@ public:
 
     void setRunValue(const Settings::Intervals& iv, bool isImperial);
 
+    void setGpsFix(bool state);
+    void setAccessoryStatus(uint8_t state, const char* name);
+
 protected:
     using Menu = App::MenuNav::Root::Intervals::Metric;
 
     static const uint16_t kBuffSize = 16;
+
+    bool mGpsFix = false;
     touchgfx::Unicode::UnicodeChar mTimeTipBuff[kBuffSize] {};
     touchgfx::Unicode::UnicodeChar mDistanceTipBuff[kBuffSize] {};
 

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
@@ -29,6 +29,7 @@ public:
 
     virtual void onIdleTimeout() override { model->exitApp(); }
     virtual void onGpsFix(bool acquired) override;
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
     void savePhoneNotif(bool state);
 

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
@@ -14,6 +14,7 @@ public:
     virtual void tearDownScreen();
 
     void setGpsFix(bool state);
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setPhoneNotif(bool state);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
@@ -1,4 +1,5 @@
 #include <gui/containers/MainMenuLayout.hpp>
+#include <images/BitmapDatabase.hpp>
 
 MainMenuLayout::MainMenuLayout()
 {
@@ -13,6 +14,14 @@ void MainMenuLayout::initialize()
     buttons.setL2(Buttons::NONE);
     buttons.setR1(Buttons::AMBER);
     buttons.setR2(Buttons::WHITE);
+
+    // Pre-activity sensor-status row in the old infoText slot. Hidden until a
+    // screen opts in (value-entry pickers reuse this space, so they don't).
+    add(mSensorRow);
+    mSensorRow.setPosition(0, 52, 240, 24);
+    mSensorRow.setIcons(BITMAP_SENSORGPSDARK_ID, BITMAP_SENSORGPSLIGHT_ID,
+                        BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
+    mSensorRow.setVisible(false);
 }
 
 // ---- Delegated wheel operations --------------------------------------------
@@ -135,6 +144,30 @@ void MainMenuLayout::setInfoMsgColor(touchgfx::colortype color)
 {
     infoText.setColor(color);
     infoText.invalidate();
+}
+
+// ---- Sensor status row -----------------------------------------------------
+
+void MainMenuLayout::showSensorRow(bool show)
+{
+    // The row occupies the old infoText slot; keep them mutually exclusive
+    // so a stray setInfoMsg() can never overlap the sensor icons.
+    if (show) {
+        infoText.setVisible(false);
+        infoText.invalidate();
+    }
+    mSensorRow.setVisible(show);
+    mSensorRow.invalidate();
+}
+
+void MainMenuLayout::setGps(bool fix)
+{
+    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(fix));
+}
+
+void MainMenuLayout::setHr(uint8_t accessoryState)
+{
+    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(accessoryState));
 }
 
 // ---- Getters ---------------------------------------------------------------

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsPresenter.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsPresenter.cpp
@@ -15,9 +15,21 @@ void MenuAlertsPresenter::activate()
     view.setUnitsImperial(model->isUnitsImperial());
     view.setDistance(model->getSettings().alertDistanceId);
     view.setTime(model->getSettings().alertTimeId);
+    view.setGpsFix(model->hasGpsFix());
+    view.setAccessoryStatus(model->getAccessoryState(), "");
 }
 
 void MenuAlertsPresenter::deactivate()
 {
     model->menu().settings.alerts.set(view.getPositionId());
+}
+
+void MenuAlertsPresenter::onGpsFix(bool acquired)
+{
+    view.setGpsFix(acquired);
+}
+
+void MenuAlertsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsView.cpp
@@ -16,6 +16,9 @@ void MenuAlertsView::setupScreen()
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
 
+    menuLayout.showSensorRow(true);
+    setGpsFix(mGpsFix);
+
     formatTips();
     menuLayout.invalidate();
 }
@@ -23,6 +26,17 @@ void MenuAlertsView::setupScreen()
 void MenuAlertsView::tearDownScreen()
 {
     MenuAlertsViewBase::tearDownScreen();
+}
+
+void MenuAlertsView::setGpsFix(bool state)
+{
+    mGpsFix = state;
+    menuLayout.setGps(state);
+}
+
+void MenuAlertsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuAlertsView::setUnitsImperial(bool isImperial)

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervals_screen/MenuIntervalsPresenter.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervals_screen/MenuIntervalsPresenter.cpp
@@ -14,11 +14,23 @@ void MenuIntervalsPresenter::activate()
     model->resetIdleTimer();
 
     view.setIntervals(model->getSettings().intervals, model->isUnitsImperial());
+    view.setGpsFix(model->hasGpsFix());
+    view.setAccessoryStatus(model->getAccessoryState(), "");
 }
 
 void MenuIntervalsPresenter::deactivate()
 {
     model->menu().intervals.set(view.getPositionId());
+}
+
+void MenuIntervalsPresenter::onGpsFix(bool acquired)
+{
+    view.setGpsFix(acquired);
+}
+
+void MenuIntervalsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuIntervalsPresenter::onIdleTimeout()

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervals_screen/MenuIntervalsView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervals_screen/MenuIntervalsView.cpp
@@ -17,12 +17,27 @@ void MenuIntervalsView::setupScreen()
     menuLayout.setUpdateItemCallback(mUpdateItemCb);
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
+
+    menuLayout.showSensorRow(true);
+    setGpsFix(mGpsFix);
+
     menuLayout.invalidate();
 }
 
 void MenuIntervalsView::tearDownScreen()
 {
     MenuIntervalsViewBase::tearDownScreen();
+}
+
+void MenuIntervalsView::setGpsFix(bool state)
+{
+    mGpsFix = state;
+    menuLayout.setGps(state);
+}
+
+void MenuIntervalsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuIntervalsView::setIntervals(const Settings::Intervals& inervals, bool isImperial)

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrepeats_screen/MenuIntervalsRepeatsPresenter.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrepeats_screen/MenuIntervalsRepeatsPresenter.cpp
@@ -11,11 +11,24 @@ void MenuIntervalsRepeatsPresenter::activate()
 {
     view.setPositionId(model->getSettings().intervals.repeatsNum);
     model->resetIdleTimer();
+
+    view.setGpsFix(model->hasGpsFix());
+    view.setAccessoryStatus(model->getAccessoryState(), "");
 }
 
 void MenuIntervalsRepeatsPresenter::deactivate()
 {
     model->menu().intervals.repeats.set(view.getPositionId());
+}
+
+void MenuIntervalsRepeatsPresenter::onGpsFix(bool acquired)
+{
+    view.setGpsFix(acquired);
+}
+
+void MenuIntervalsRepeatsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuIntervalsRepeatsPresenter::saveRepeats(uint8_t repeatsNum)

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrepeats_screen/MenuIntervalsRepeatsView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrepeats_screen/MenuIntervalsRepeatsView.cpp
@@ -16,12 +16,27 @@ void MenuIntervalsRepeatsView::setupScreen()
     menuLayout.setUpdateItemCallback(mUpdateItemCb);
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::kMaxCount);
+
+    menuLayout.showSensorRow(true);
+    setGpsFix(mGpsFix);
+
     menuLayout.invalidate();
 }
 
 void MenuIntervalsRepeatsView::tearDownScreen()
 {
     MenuIntervalsRepeatsViewBase::tearDownScreen();
+}
+
+void MenuIntervalsRepeatsView::setGpsFix(bool state)
+{
+    mGpsFix = state;
+    menuLayout.setGps(state);
+}
+
+void MenuIntervalsRepeatsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuIntervalsRepeatsView::formatItem(touchgfx::Unicode::UnicodeChar* buf, int16_t index)

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrest_screen/MenuIntervalsRestPresenter.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrest_screen/MenuIntervalsRestPresenter.cpp
@@ -25,11 +25,24 @@ void MenuIntervalsRestPresenter::activate()
     view.setRestValue(iv, model->isUnitsImperial());
     view.setPositionId(metricToMenuId(iv.restMetric));
     model->resetIdleTimer();
+
+    view.setGpsFix(model->hasGpsFix());
+    view.setAccessoryStatus(model->getAccessoryState(), "");
 }
 
 void MenuIntervalsRestPresenter::deactivate()
 {
     model->menu().intervals.rest.set(view.getPositionId());
+}
+
+void MenuIntervalsRestPresenter::onGpsFix(bool acquired)
+{
+    view.setGpsFix(acquired);
+}
+
+void MenuIntervalsRestPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuIntervalsRestPresenter::saveOpenRest()

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrest_screen/MenuIntervalsRestView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrest_screen/MenuIntervalsRestView.cpp
@@ -17,12 +17,27 @@ void MenuIntervalsRestView::setupScreen()
     menuLayout.setUpdateItemCallback(mUpdateItemCb);
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
+
+    menuLayout.showSensorRow(true);
+    setGpsFix(mGpsFix);
+
     menuLayout.invalidate();
 }
 
 void MenuIntervalsRestView::tearDownScreen()
 {
     MenuIntervalsRestViewBase::tearDownScreen();
+}
+
+void MenuIntervalsRestView::setGpsFix(bool state)
+{
+    mGpsFix = state;
+    menuLayout.setGps(state);
+}
+
+void MenuIntervalsRestView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuIntervalsRestView::setupItems()

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrun_screen/MenuIntervalsRunPresenter.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrun_screen/MenuIntervalsRunPresenter.cpp
@@ -25,11 +25,24 @@ void MenuIntervalsRunPresenter::activate()
     view.setRunValue(iv, model->isUnitsImperial());
     view.setPositionId(metricToMenuId(iv.runMetric));
     model->resetIdleTimer();
+
+    view.setGpsFix(model->hasGpsFix());
+    view.setAccessoryStatus(model->getAccessoryState(), "");
 }
 
 void MenuIntervalsRunPresenter::deactivate()
 {
     model->menu().intervals.run.set(view.getPositionId());
+}
+
+void MenuIntervalsRunPresenter::onGpsFix(bool acquired)
+{
+    view.setGpsFix(acquired);
+}
+
+void MenuIntervalsRunPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuIntervalsRunPresenter::saveOpenRun()

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrun_screen/MenuIntervalsRunView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrun_screen/MenuIntervalsRunView.cpp
@@ -17,12 +17,27 @@ void MenuIntervalsRunView::setupScreen()
     menuLayout.setUpdateItemCallback(mUpdateItemCb);
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
+
+    menuLayout.showSensorRow(true);
+    setGpsFix(mGpsFix);
+
     menuLayout.invalidate();
 }
 
 void MenuIntervalsRunView::tearDownScreen()
 {
     MenuIntervalsRunViewBase::tearDownScreen();
+}
+
+void MenuIntervalsRunView::setGpsFix(bool state)
+{
+    mGpsFix = state;
+    menuLayout.setGps(state);
+}
+
+void MenuIntervalsRunView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuIntervalsRunView::setupItems()

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
@@ -14,6 +14,7 @@ void MenuSettingsPresenter::activate()
     model->resetIdleTimer();
 
     view.setGpsFix(model->hasGpsFix());
+    view.setAccessoryStatus(model->getAccessoryState(), "");
     view.setPhoneNotif(model->getSettings().phoneNotifEn);
 }
 
@@ -25,6 +26,11 @@ void MenuSettingsPresenter::deactivate()
 void MenuSettingsPresenter::onGpsFix(bool acquired)
 {
     view.setGpsFix(acquired);
+}
+
+void MenuSettingsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuSettingsPresenter::savePhoneNotif(bool state)

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
@@ -16,6 +16,7 @@ void MenuSettingsView::setupScreen()
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
 
+    menuLayout.showSensorRow(true);
     setGpsFix(mGpsFix);
 
     menuLayout.invalidate();
@@ -29,7 +30,12 @@ void MenuSettingsView::tearDownScreen()
 void MenuSettingsView::setGpsFix(bool state)
 {
     mGpsFix = state;
-    menuLayout.setInfoMsg(state ? T_TEXT_SIGNAL_ACQUIRED : T_TEXT_ACQUIRING_SIGNAL);
+    menuLayout.setGps(state);
+}
+
+void MenuSettingsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuSettingsView::setPhoneNotif(bool state)

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
@@ -4,6 +4,7 @@
 #include <gui_generated/containers/MainMenuLayoutBase.hpp>
 #include <gui/containers/MenuItemConfig.hpp>
 #include <touchgfx/Callback.hpp>
+#include <SDK/GUI/SensorStatusRow.hpp>
 
 /**
  * @brief Standard full-screen menu layout container.
@@ -68,11 +69,22 @@ public:
     void setInfoMsg(TypedTextId msgId);
     void setInfoMsgColor(touchgfx::colortype color);
 
+    // ---- Sensor status row (GPS / external HR) -----------------------------
+    // Shared pre-activity icon bar, occupying the old infoText slot. Hidden by
+    // default; pre-activity menu screens opt in with showSensorRow(true) and
+    // forward live state via setGps()/setHr().
+    void showSensorRow(bool show);
+    void setGps(bool fix);
+    void setHr(uint8_t accessoryState);
+
     // ---- Getters -----------------------------------------------------------
     /** Direct access to navigation buttons (set L1/L2/R1/R2 state). */
     Buttons  &getButtons();
     /** Direct access to the scroll wheel menu (for advanced operations). */
     MainMenu &getMenu();
+
+private:
+    SDK::Gui::SensorStatusRow mSensorRow;
 };
 
 #endif // MAINMENULAYOUT_HPP

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsPresenter.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsPresenter.hpp
@@ -28,6 +28,7 @@ public:
     virtual ~MenuAlertsPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
 private:
     MenuAlertsPresenter();

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsView.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsView.hpp
@@ -13,6 +13,7 @@ public:
     virtual void setupScreen();
     virtual void tearDownScreen();
 
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setUnitsImperial(bool isImperial);
     void setDistance(Settings::Alerts::Distance::Id id);
     void setTime(Settings::Alerts::Time::Id id);

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervals_screen/MenuIntervalsPresenter.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervals_screen/MenuIntervalsPresenter.hpp
@@ -28,6 +28,7 @@ public:
     virtual ~MenuIntervalsPresenter() {}
 
     virtual void onIdleTimeout() override;
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
     void saveWarmUp(bool enable);
     void saveCoolDown(bool enable);

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervals_screen/MenuIntervalsView.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervals_screen/MenuIntervalsView.hpp
@@ -12,6 +12,7 @@ public:
     virtual void setupScreen();
     virtual void tearDownScreen();
 
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setIntervals(const Settings::Intervals & inervals, bool isImperial);
 
     void setPositionId(uint16_t id);

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrepeats_screen/MenuIntervalsRepeatsPresenter.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrepeats_screen/MenuIntervalsRepeatsPresenter.hpp
@@ -28,6 +28,7 @@ public:
     virtual ~MenuIntervalsRepeatsPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
     void saveRepeats(uint8_t repeatsNum);
 

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrepeats_screen/MenuIntervalsRepeatsView.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrepeats_screen/MenuIntervalsRepeatsView.hpp
@@ -13,6 +13,7 @@ public:
     virtual void setupScreen();
     virtual void tearDownScreen();
 
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrest_screen/MenuIntervalsRestPresenter.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrest_screen/MenuIntervalsRestPresenter.hpp
@@ -21,6 +21,7 @@ public:
     virtual ~MenuIntervalsRestPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
 private:
     MenuIntervalsRestPresenter();

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrest_screen/MenuIntervalsRestView.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrest_screen/MenuIntervalsRestView.hpp
@@ -13,6 +13,7 @@ public:
     virtual void setupScreen();
     virtual void tearDownScreen();
 
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrun_screen/MenuIntervalsRunPresenter.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrun_screen/MenuIntervalsRunPresenter.hpp
@@ -21,6 +21,7 @@ public:
     virtual ~MenuIntervalsRunPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
 private:
     MenuIntervalsRunPresenter();

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrun_screen/MenuIntervalsRunView.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menuintervalsrun_screen/MenuIntervalsRunView.hpp
@@ -13,6 +13,7 @@ public:
     virtual void setupScreen();
     virtual void tearDownScreen();
 
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
@@ -28,6 +28,7 @@ public:
     virtual ~MenuSettingsPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
     void savePhoneNotif(bool state);
 

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
@@ -13,6 +13,7 @@ public:
     virtual void setupScreen();
     virtual void tearDownScreen();
 
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setPhoneNotif(bool state);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
@@ -1,4 +1,5 @@
 #include <gui/containers/MainMenuLayout.hpp>
+#include <images/BitmapDatabase.hpp>
 
 MainMenuLayout::MainMenuLayout()
 {
@@ -13,6 +14,15 @@ void MainMenuLayout::initialize()
     buttons.setL2(Buttons::NONE);
     buttons.setR1(Buttons::AMBER);
     buttons.setR2(Buttons::WHITE);
+
+    // Pre-activity sensor-status row in the old infoText slot. Hidden until a
+    // screen opts in (value-entry pickers reuse this space, so they don't).
+    // Treadmill is HR-only: pass BITMAP_INVALID for the two GPS icon slots.
+    add(mSensorRow);
+    mSensorRow.setPosition(0, 52, 240, 24);
+    mSensorRow.setIcons(touchgfx::BITMAP_INVALID, touchgfx::BITMAP_INVALID,
+                        BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
+    mSensorRow.setVisible(false);
 }
 
 // ---- Delegated wheel operations --------------------------------------------
@@ -129,6 +139,30 @@ void MainMenuLayout::setInfoMsgColor(touchgfx::colortype color)
 {
     infoText.setColor(color);
     infoText.invalidate();
+}
+
+// ---- Sensor status row -----------------------------------------------------
+
+void MainMenuLayout::showSensorRow(bool show)
+{
+    // The row occupies the old infoText slot; keep them mutually exclusive
+    // so a stray setInfoMsg() can never overlap the sensor icons.
+    if (show) {
+        infoText.setVisible(false);
+        infoText.invalidate();
+    }
+    mSensorRow.setVisible(show);
+    mSensorRow.invalidate();
+}
+
+void MainMenuLayout::setGps(bool fix)
+{
+    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(fix));
+}
+
+void MainMenuLayout::setHr(uint8_t accessoryState)
+{
+    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(accessoryState));
 }
 
 // ---- Getters ---------------------------------------------------------------

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsPresenter.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsPresenter.cpp
@@ -12,6 +12,7 @@ void MenuAlertsPresenter::activate()
     view.setPositionId(model->menu().settings.alerts.get());
     model->resetIdleTimer();
 
+    view.setAccessoryStatus(model->getAccessoryState(), "");
     view.setUnitsImperial(model->isUnitsImperial());
     view.setDistance(model->getSettings().alertDistanceId);
     view.setTime(model->getSettings().alertTimeId);
@@ -20,4 +21,9 @@ void MenuAlertsPresenter::activate()
 void MenuAlertsPresenter::deactivate()
 {
     model->menu().settings.alerts.set(view.getPositionId());
+}
+
+void MenuAlertsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsView.cpp
@@ -16,6 +16,9 @@ void MenuAlertsView::setupScreen()
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
 
+    // External-HR-only sensor status row (GPS slots are BITMAP_INVALID).
+    menuLayout.showSensorRow(true);
+
     formatTips();
     menuLayout.invalidate();
 }
@@ -23,6 +26,11 @@ void MenuAlertsView::setupScreen()
 void MenuAlertsView::tearDownScreen()
 {
     MenuAlertsViewBase::tearDownScreen();
+}
+
+void MenuAlertsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuAlertsView::setUnitsImperial(bool isImperial)

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervals_screen/MenuIntervalsPresenter.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervals_screen/MenuIntervalsPresenter.cpp
@@ -13,7 +13,13 @@ void MenuIntervalsPresenter::activate()
     model->menu().intervals.resetChildren();
     model->resetIdleTimer();
 
+    view.setAccessoryStatus(model->getAccessoryState(), "");
     view.setIntervals(model->getSettings().intervals, model->isUnitsImperial());
+}
+
+void MenuIntervalsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuIntervalsPresenter::deactivate()

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervals_screen/MenuIntervalsView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervals_screen/MenuIntervalsView.cpp
@@ -17,12 +17,21 @@ void MenuIntervalsView::setupScreen()
     menuLayout.setUpdateItemCallback(mUpdateItemCb);
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
+
+    // External-HR-only sensor status row (GPS slots are BITMAP_INVALID).
+    menuLayout.showSensorRow(true);
+
     menuLayout.invalidate();
 }
 
 void MenuIntervalsView::tearDownScreen()
 {
     MenuIntervalsViewBase::tearDownScreen();
+}
+
+void MenuIntervalsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuIntervalsView::setIntervals(const Settings::Intervals& inervals, bool isImperial)

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrepeats_screen/MenuIntervalsRepeatsPresenter.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrepeats_screen/MenuIntervalsRepeatsPresenter.cpp
@@ -11,6 +11,13 @@ void MenuIntervalsRepeatsPresenter::activate()
 {
     view.setPositionId(model->getSettings().intervals.repeatsNum);
     model->resetIdleTimer();
+
+    view.setAccessoryStatus(model->getAccessoryState(), "");
+}
+
+void MenuIntervalsRepeatsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuIntervalsRepeatsPresenter::deactivate()

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrepeats_screen/MenuIntervalsRepeatsView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrepeats_screen/MenuIntervalsRepeatsView.cpp
@@ -16,12 +16,21 @@ void MenuIntervalsRepeatsView::setupScreen()
     menuLayout.setUpdateItemCallback(mUpdateItemCb);
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::kMaxCount);
+
+    // External-HR-only sensor status row (GPS slots are BITMAP_INVALID).
+    menuLayout.showSensorRow(true);
+
     menuLayout.invalidate();
 }
 
 void MenuIntervalsRepeatsView::tearDownScreen()
 {
     MenuIntervalsRepeatsViewBase::tearDownScreen();
+}
+
+void MenuIntervalsRepeatsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuIntervalsRepeatsView::formatItem(touchgfx::Unicode::UnicodeChar* buf, int16_t index)

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrest_screen/MenuIntervalsRestPresenter.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrest_screen/MenuIntervalsRestPresenter.cpp
@@ -25,6 +25,13 @@ void MenuIntervalsRestPresenter::activate()
     view.setRestValue(iv, model->isUnitsImperial());
     view.setPositionId(metricToMenuId(iv.restMetric));
     model->resetIdleTimer();
+
+    view.setAccessoryStatus(model->getAccessoryState(), "");
+}
+
+void MenuIntervalsRestPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuIntervalsRestPresenter::deactivate()

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrest_screen/MenuIntervalsRestView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrest_screen/MenuIntervalsRestView.cpp
@@ -17,12 +17,21 @@ void MenuIntervalsRestView::setupScreen()
     menuLayout.setUpdateItemCallback(mUpdateItemCb);
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
+
+    // External-HR-only sensor status row (GPS slots are BITMAP_INVALID).
+    menuLayout.showSensorRow(true);
+
     menuLayout.invalidate();
 }
 
 void MenuIntervalsRestView::tearDownScreen()
 {
     MenuIntervalsRestViewBase::tearDownScreen();
+}
+
+void MenuIntervalsRestView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuIntervalsRestView::setupItems()

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrun_screen/MenuIntervalsRunPresenter.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrun_screen/MenuIntervalsRunPresenter.cpp
@@ -25,6 +25,13 @@ void MenuIntervalsRunPresenter::activate()
     view.setRunValue(iv, model->isUnitsImperial());
     view.setPositionId(metricToMenuId(iv.runMetric));
     model->resetIdleTimer();
+
+    view.setAccessoryStatus(model->getAccessoryState(), "");
+}
+
+void MenuIntervalsRunPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuIntervalsRunPresenter::deactivate()

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrun_screen/MenuIntervalsRunView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menuintervalsrun_screen/MenuIntervalsRunView.cpp
@@ -17,12 +17,21 @@ void MenuIntervalsRunView::setupScreen()
     menuLayout.setUpdateItemCallback(mUpdateItemCb);
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
+
+    // External-HR-only sensor status row (GPS slots are BITMAP_INVALID).
+    menuLayout.showSensorRow(true);
+
     menuLayout.invalidate();
 }
 
 void MenuIntervalsRunView::tearDownScreen()
 {
     MenuIntervalsRunViewBase::tearDownScreen();
+}
+
+void MenuIntervalsRunView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuIntervalsRunView::setupItems()

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
@@ -13,7 +13,13 @@ void MenuSettingsPresenter::activate()
     model->menu().settings.resetChildren();
     model->resetIdleTimer();
 
+    view.setAccessoryStatus(model->getAccessoryState(), "");
     view.setPhoneNotif(model->getSettings().phoneNotifEn);
+}
+
+void MenuSettingsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuSettingsPresenter::deactivate()

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
@@ -16,10 +16,15 @@ void MenuSettingsView::setupScreen()
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
 
-    // Treadmill has no GPS: no acquisition status line.
-    menuLayout.setInfoMsg(TYPED_TEXT_INVALID);
+    // External-HR-only sensor status row (GPS slots are BITMAP_INVALID).
+    menuLayout.showSensorRow(true);
 
     menuLayout.invalidate();
+}
+
+void MenuSettingsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuSettingsView::tearDownScreen()

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
@@ -4,6 +4,7 @@
 #include <gui_generated/containers/MainMenuLayoutBase.hpp>
 #include <gui/containers/MenuItemConfig.hpp>
 #include <touchgfx/Callback.hpp>
+#include <SDK/GUI/SensorStatusRow.hpp>
 
 /**
  * @brief Standard full-screen menu layout container.
@@ -68,11 +69,22 @@ public:
     void setInfoMsg(TypedTextId msgId);
     void setInfoMsgColor(touchgfx::colortype color);
 
+    // ---- Sensor status row (GPS / external HR) -----------------------------
+    // Shared pre-activity icon bar, occupying the old infoText slot. Hidden by
+    // default; pre-activity menu screens opt in with showSensorRow(true) and
+    // forward live state via setGps()/setHr().
+    void showSensorRow(bool show);
+    void setGps(bool fix);
+    void setHr(uint8_t accessoryState);
+
     // ---- Getters -----------------------------------------------------------
     /** Direct access to navigation buttons (set L1/L2/R1/R2 state). */
     Buttons  &getButtons();
     /** Direct access to the scroll wheel menu (for advanced operations). */
     MainMenu &getMenu();
+
+private:
+    SDK::Gui::SensorStatusRow mSensorRow;
 };
 
 #endif // MAINMENULAYOUT_HPP

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsPresenter.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsPresenter.hpp
@@ -28,6 +28,7 @@ public:
     virtual ~MenuAlertsPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
 private:
     MenuAlertsPresenter();

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsView.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/menualerts_screen/MenuAlertsView.hpp
@@ -14,6 +14,7 @@ public:
     virtual void tearDownScreen();
 
     void setTime(Settings::Alerts::Time::Id id);
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
@@ -28,6 +28,7 @@ public:
     virtual ~MenuSettingsPresenter() {}
 
     virtual void onIdleTimeout() override { model->exitApp(); }
+    virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
     void savePhoneNotif(bool state);
 

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
@@ -13,6 +13,7 @@ public:
     virtual void setupScreen();
     virtual void tearDownScreen();
 
+    void setAccessoryStatus(uint8_t state, const char* name);
     void setPhoneNotif(bool state);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
@@ -1,4 +1,5 @@
 #include <gui/containers/MainMenuLayout.hpp>
+#include <images/BitmapDatabase.hpp>
 
 MainMenuLayout::MainMenuLayout()
 {
@@ -13,6 +14,15 @@ void MainMenuLayout::initialize()
     buttons.setL2(Buttons::NONE);
     buttons.setR1(Buttons::AMBER);
     buttons.setR2(Buttons::WHITE);
+
+    // Pre-activity sensor-status row in the old infoText slot. Hidden until a
+    // screen opts in (value-entry pickers reuse this space, so they don't).
+    // HR-only app: no GPS icon.
+    add(mSensorRow);
+    mSensorRow.setPosition(0, 52, 240, 24);
+    mSensorRow.setIcons(touchgfx::BITMAP_INVALID, touchgfx::BITMAP_INVALID,
+                        BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
+    mSensorRow.setVisible(false);
 }
 
 // ---- Delegated wheel operations --------------------------------------------
@@ -135,6 +145,30 @@ void MainMenuLayout::setInfoMsgColor(touchgfx::colortype color)
 {
     infoText.setColor(color);
     infoText.invalidate();
+}
+
+// ---- Sensor status row -----------------------------------------------------
+
+void MainMenuLayout::showSensorRow(bool show)
+{
+    // The row occupies the old infoText slot; keep them mutually exclusive
+    // so a stray setInfoMsg() can never overlap the sensor icons.
+    if (show) {
+        infoText.setVisible(false);
+        infoText.invalidate();
+    }
+    mSensorRow.setVisible(show);
+    mSensorRow.invalidate();
+}
+
+void MainMenuLayout::setGps(bool fix)
+{
+    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(fix));
+}
+
+void MainMenuLayout::setHr(uint8_t accessoryState)
+{
+    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(accessoryState));
 }
 
 // ---- Getters ---------------------------------------------------------------

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsPresenter.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsPresenter.cpp
@@ -12,10 +12,16 @@ void MenuAlertsPresenter::activate()
     view.setPositionId(model->menu().settings.alerts.get());
     model->resetIdleTimer();
 
+    view.setAccessoryStatus(model->getAccessoryState(), "");
     view.setTime(model->getSettings().alertTimeId);
 }
 
 void MenuAlertsPresenter::deactivate()
 {
     model->menu().settings.alerts.set(view.getPositionId());
+}
+
+void MenuAlertsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsView.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/menualerts_screen/MenuAlertsView.cpp
@@ -16,6 +16,8 @@ void MenuAlertsView::setupScreen()
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
 
+    menuLayout.showSensorRow(true);
+
     formatTips();
     menuLayout.invalidate();
 }
@@ -23,6 +25,11 @@ void MenuAlertsView::setupScreen()
 void MenuAlertsView::tearDownScreen()
 {
     MenuAlertsViewBase::tearDownScreen();
+}
+
+void MenuAlertsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuAlertsView::setTime(Time::Id id)

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
@@ -13,12 +13,18 @@ void MenuSettingsPresenter::activate()
     model->menu().settings.resetChildren();
     model->resetIdleTimer();
 
+    view.setAccessoryStatus(model->getAccessoryState(), "");
     view.setPhoneNotif(model->getSettings().phoneNotifEn);
 }
 
 void MenuSettingsPresenter::deactivate()
 {
     model->menu().settings.set(view.getPositionId());
+}
+
+void MenuSettingsPresenter::onAccessoryStatus(uint8_t state, const char* name)
+{
+    view.setAccessoryStatus(state, name);
 }
 
 void MenuSettingsPresenter::savePhoneNotif(bool state)

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
@@ -16,12 +16,19 @@ void MenuSettingsView::setupScreen()
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);
     menuLayout.setNumberOfItems(Menu::ID_COUNT);
 
+    menuLayout.showSensorRow(true);
+
     menuLayout.invalidate();
 }
 
 void MenuSettingsView::tearDownScreen()
 {
     MenuSettingsViewBase::tearDownScreen();
+}
+
+void MenuSettingsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
+{
+    menuLayout.setHr(state);
 }
 
 void MenuSettingsView::setPhoneNotif(bool state)


### PR DESCRIPTION
## Problem

The pre-activity GPS/external-HR icon bar (`SDK::Gui::SensorStatusRow`) was only added to each activity app's `MainView`. Every pre-activity **sub-menu** instead used the shared `MainMenuLayout`, whose old status mechanism was a single GPS-only text line — so:

- **Settings** showed the old "Acquiring signal" / "Signal acquired" text (Running/Cycling/Hiking) or nothing.
- **Intervals** menus (and their sub-menus) were **blank** at the top.
- Treadmill was blank in both Settings and Intervals.

## Fix

Add the row to the shared **`MainMenuLayout`** container (code-only, in the old `infoText` slot, hidden by default) with `showSensorRow()`/`setGps()`/`setHr()` passthroughs, then opt it in and live-wire it on the pre-activity **list-menus** of all five apps:

| App | Icons | Row shown on |
|---|---|---|
| Running | GPS+HR | Settings, Alerts, Intervals, Intervals-Run/Rest/Repeats |
| Treadmill | HR-only | Settings, Alerts, Intervals, Intervals-Run/Rest/Repeats |
| Cycling / Hiking | GPS+HR | Settings, Alerts |
| Workout | HR-only | Settings, Alerts |

Each opted-in screen forwards **live** state: the presenter overrides `onGpsFix`/`onAccessoryStatus` and seeds from the model in `activate()`; the view calls `showSensorRow(true)` and passes state through to `menuLayout`. The old GPS-status `setInfoMsg` text is replaced by `setGps()`. Treadmill/Workout are GPS-less at the model level, so they wire HR only (BITMAP_INVALID GPS slots), matching their `MainView`.

**Excluded (row stays hidden):** the numeric value-entry pickers `menutime`/`menudistance` (they reuse the top space for "kilometers"/"Mins. Secs." labels) and Treadmill's post-activity `menucalibration`. The other numeric pickers (run/rest time/distance, *saved) use a different layout and are auto-excluded.

## Validation

- Host simulators build clean for Running, Cycling, Hiking, Treadmill. (Workout's sim hits a pre-existing textconvert/fontconvert prebuild failure unrelated to this C++ change; it's covered by CI `cmake-build`.)
- Visual: Running & Cycling **Settings** now render the icon row where the old text was; Treadmill **Intervals** is wired (HR-only → blank without a strap, consistent with its main screen).
- Adversarial diff review (82 files): all 16 wired screens fully wired (showSensorRow + view methods + presenter overrides + activate seed); `MainMenuLayout` byte-identical across apps except the intended GPS-vs-HR-only icons; no wrongly-wired or missed screens; no lifecycle/double-add issues.
- Code-only change — no TouchGFX regeneration (the `BITMAP_SENSOR*` assets already exist).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sensor status row to the main layout and key screens, showing live GPS fix status and external heart-rate/accessory status.
  * Extended alerts, settings, and interval screens to initialize these indicators when opened.
* **Improvements**
  * Status updates (GPS fix and accessory state) now refresh the on-screen indicators automatically during runtime.
  * Showing the sensor status row now cleanly replaces the prior info-text area to prevent overlap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->