### PR TITLE
fix(simulator): link ImuRunningCadence and Fit encoder sources

### DIFF
--- a/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -70,6 +70,7 @@ Libs/Source/Simulator/Components/Sensors/HeartRate/SensorHeartRate.cpp\
 Libs/Source/Simulator/Components/Sensors/SensorPressure.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuWristMotion.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuStepCounter.cpp\
+Libs/Source/Simulator/Components/Sensors/Imu/ImuRunningCadence.cpp\
 Libs/Source/Simulator/Components/ComponentSimulator.cpp\
 Libs/Source/Simulator/Components/Simulator/GpsStepCounterSimulator.cpp\
 Libs/Source/Simulator/Components/SensorListener.cpp\

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -69,6 +69,7 @@ Libs/Source/Simulator/Components/Sensors/HeartRate/SensorHeartRate.cpp\
 Libs/Source/Simulator/Components/Sensors/SensorPressure.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuWristMotion.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuStepCounter.cpp\
+Libs/Source/Simulator/Components/Sensors/Imu/ImuRunningCadence.cpp\
 Libs/Source/Simulator/Components/ComponentSimulator.cpp\
 Libs/Source/Simulator/Components/Simulator/GpsStepCounterSimulator.cpp\
 Libs/Source/Simulator/Components/SensorListener.cpp\

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -70,10 +70,14 @@ Libs/Source/Simulator/Components/Sensors/HeartRate/SensorHeartRate.cpp\
 Libs/Source/Simulator/Components/Sensors/SensorPressure.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuWristMotion.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuStepCounter.cpp\
+Libs/Source/Simulator/Components/Sensors/Imu/ImuRunningCadence.cpp\
 Libs/Source/Simulator/Components/ComponentSimulator.cpp\
 Libs/Source/Simulator/Components/Simulator/GpsStepCounterSimulator.cpp\
 Libs/Source/Simulator/Components/SensorListener.cpp\
 Libs/Source/Simulator/Components/SensorDriver.cpp\
+Libs/Source/Fit/FitCrc.cpp\
+Libs/Source/Fit/FitWriter.cpp\
+Libs/Source/Fit/FitRecordCadence.cpp\
 ../../Libs/Sources/ActivitySummarySerializer.cpp\
 ../../Libs/Sources/ActivityWriter.cpp\
 ../../Libs/Sources/Service.cpp\
@@ -93,9 +97,3 @@ all assets: $(filter clean,$(MAKECMDGOALS))
 all clean assets:
 	@$(MAKE) -r -f una/Makefile -s $(MFLAGS) $@ -C "$(application_path)"
 endif
-
-
-# Native SDK::Fit encoder sources
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitCrc.cpp
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitWriter.cpp
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitRecordCadence.cpp

--- a/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -69,10 +69,14 @@ Libs/Source/Simulator/Components/Sensors/HeartRate/SensorHeartRate.cpp\
 Libs/Source/Simulator/Components/Sensors/SensorPressure.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuWristMotion.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuStepCounter.cpp\
+Libs/Source/Simulator/Components/Sensors/Imu/ImuRunningCadence.cpp\
 Libs/Source/Simulator/Components/ComponentSimulator.cpp\
 Libs/Source/Simulator/Components/Simulator/GpsStepCounterSimulator.cpp\
 Libs/Source/Simulator/Components/SensorListener.cpp\
 Libs/Source/Simulator/Components/SensorDriver.cpp\
+Libs/Source/Fit/FitCrc.cpp\
+Libs/Source/Fit/FitWriter.cpp\
+Libs/Source/Fit/FitRecordCadence.cpp\
 ../../Libs/Sources/ActivityWriter.cpp\
 ../../Libs/Sources/Service.cpp\
 ADDITIONAL_SOURCES :=
@@ -90,9 +94,3 @@ all assets: $(filter clean,$(MAKECMDGOALS))
 all clean assets:
 	@$(MAKE) -r -f una/Makefile -s $(MFLAGS) $@ -C "$(application_path)"
 endif
-
-
-# Native SDK::Fit encoder sources
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitCrc.cpp
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitWriter.cpp
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitRecordCadence.cpp

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -70,10 +70,14 @@ Libs/Source/Simulator/Components/Sensors/HeartRate/SensorHeartRate.cpp\
 Libs/Source/Simulator/Components/Sensors/SensorPressure.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuWristMotion.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuStepCounter.cpp\
+Libs/Source/Simulator/Components/Sensors/Imu/ImuRunningCadence.cpp\
 Libs/Source/Simulator/Components/ComponentSimulator.cpp\
 Libs/Source/Simulator/Components/Simulator/GpsStepCounterSimulator.cpp\
 Libs/Source/Simulator/Components/SensorListener.cpp\
 Libs/Source/Simulator/Components/SensorDriver.cpp\
+Libs/Source/Fit/FitCrc.cpp\
+Libs/Source/Fit/FitWriter.cpp\
+Libs/Source/Fit/FitRecordCadence.cpp\
 ../../Libs/Sources/ActivitySummarySerializer.cpp\
 ../../Libs/Sources/ActivityWriter.cpp\
 ../../Libs/Sources/Service.cpp\
@@ -93,9 +97,3 @@ all assets: $(filter clean,$(MAKECMDGOALS))
 all clean assets:
 	@$(MAKE) -r -f una/Makefile -s $(MFLAGS) $@ -C "$(application_path)"
 endif
-
-
-# Native SDK::Fit encoder sources
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitCrc.cpp
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitWriter.cpp
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitRecordCadence.cpp

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -72,10 +72,14 @@ Libs/Source/Simulator/Components/Sensors/HeartRate/SensorHeartRate.cpp\
 Libs/Source/Simulator/Components/Sensors/SensorPressure.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuWristMotion.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuStepCounter.cpp\
+Libs/Source/Simulator/Components/Sensors/Imu/ImuRunningCadence.cpp\
 Libs/Source/Simulator/Components/ComponentSimulator.cpp\
 Libs/Source/Simulator/Components/Simulator/GpsStepCounterSimulator.cpp\
 Libs/Source/Simulator/Components/SensorListener.cpp\
 Libs/Source/Simulator/Components/SensorDriver.cpp\
+Libs/Source/Fit/FitCrc.cpp\
+Libs/Source/Fit/FitWriter.cpp\
+Libs/Source/Fit/FitRecordCadence.cpp\
 ../../Libs/Sources/ActivitySummarySerializer.cpp\
 ../../Libs/Sources/ActivityWriter.cpp\
 ../../Libs/Sources/Service.cpp\
@@ -96,9 +100,3 @@ all assets: $(filter clean,$(MAKECMDGOALS))
 all clean assets:
 	@$(MAKE) -r -f una/Makefile -s $(MFLAGS) $@ -C "$(application_path)"
 endif
-
-
-# Native SDK::Fit encoder sources
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitCrc.cpp
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitWriter.cpp
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitRecordCadence.cpp

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -71,10 +71,14 @@ Libs/Source/Simulator/Components/Sensors/HeartRate/SensorHeartRate.cpp\
 Libs/Source/Simulator/Components/Sensors/SensorPressure.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuWristMotion.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuStepCounter.cpp\
+Libs/Source/Simulator/Components/Sensors/Imu/ImuRunningCadence.cpp\
 Libs/Source/Simulator/Components/ComponentSimulator.cpp\
 Libs/Source/Simulator/Components/Simulator/GpsStepCounterSimulator.cpp\
 Libs/Source/Simulator/Components/SensorListener.cpp\
 Libs/Source/Simulator/Components/SensorDriver.cpp\
+Libs/Source/Fit/FitCrc.cpp\
+Libs/Source/Fit/FitWriter.cpp\
+Libs/Source/Fit/FitRecordCadence.cpp\
 ../../Libs/Sources/ActivitySummarySerializer.cpp\
 ../../Libs/Sources/ActivityWriter.cpp\
 ../../Libs/Sources/Service.cpp\
@@ -95,9 +99,3 @@ all assets: $(filter clean,$(MAKECMDGOALS))
 all clean assets:
 	@$(MAKE) -r -f una/Makefile -s $(MFLAGS) $@ -C "$(application_path)"
 endif
-
-
-# Native SDK::Fit encoder sources
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitCrc.cpp
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitWriter.cpp
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitRecordCadence.cpp

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -70,10 +70,14 @@ Libs/Source/Simulator/Components/Sensors/HeartRate/SensorHeartRate.cpp\
 Libs/Source/Simulator/Components/Sensors/SensorPressure.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuWristMotion.cpp\
 Libs/Source/Simulator/Components/Sensors/Imu/ImuStepCounter.cpp\
+Libs/Source/Simulator/Components/Sensors/Imu/ImuRunningCadence.cpp\
 Libs/Source/Simulator/Components/ComponentSimulator.cpp\
 Libs/Source/Simulator/Components/Simulator/GpsStepCounterSimulator.cpp\
 Libs/Source/Simulator/Components/SensorListener.cpp\
 Libs/Source/Simulator/Components/SensorDriver.cpp\
+Libs/Source/Fit/FitCrc.cpp\
+Libs/Source/Fit/FitWriter.cpp\
+Libs/Source/Fit/FitRecordCadence.cpp\
 ../../Libs/Sources/ActivitySummarySerializer.cpp\
 ../../Libs/Sources/ActivityWriter.cpp\
 ../../Libs/Sources/Service.cpp\
@@ -94,9 +98,3 @@ all assets: $(filter clean,$(MAKECMDGOALS))
 all clean assets:
 	@$(MAKE) -r -f una/Makefile -s $(MFLAGS) $@ -C "$(application_path)"
 endif
-
-
-# Native SDK::Fit encoder sources
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitCrc.cpp
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitWriter.cpp
-C_SRCS_FIT += $(SDK_LOC)/Libs/Source/Fit/FitRecordCadence.cpp


### PR DESCRIPTION
The example/tutorial simulator Makefiles built InstanceSensorLayer.cpp, which unconditionally constructs Sensor::ImuRunningCadence, but never listed ImuRunningCadence.cpp in ADDITIONAL_SOURCES_UNA, producing undefined references to its constructor and vtable at link time.

The activity apps also referenced SDK::Fit::FitWriter (via ActivityWriter.cpp) but the Fit encoder sources were appended to a dangling C_SRCS_FIT variable after the Makefile's endif — dead code that used an undefined $(SDK_LOC) and was never compiled or exported.

Add ImuRunningCadence.cpp to every simulator Makefile that compiles InstanceSensorLayer.cpp, and move the three Fit encoder sources (FitCrc, FitWriter, FitRecordCadence) into ADDITIONAL_SOURCES_UNA for the activity apps, removing the dead C_SRCS_FIT block.

Fixes #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulator build coverage so additional sensor and activity-tracking components are included across multiple app examples.
  * Updated several simulator configurations to ensure related features compile and run consistently in the desktop simulator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->