### PR TITLE
feat(fit): crash-safe activity recording — flush + next-boot recovery + save-status (audit #4 SDK half)

### DIFF
--- a/Examples/Apps/Cycling/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/ActivityWriter.hpp
@@ -103,8 +103,12 @@ public:
     void resume(std::time_t timestamp);
     void addRecord(const RecordData& record);
     void addLap(const LapData& lap);
-    /// Finalize the current activity and persist its summary. Returns true only
-    /// if the FIT stream, its finish()/flush/close and the summary all succeed.
+    /// Finalize the current activity. The return value is the FIT-durability
+    /// contract: true iff the FIT stream + its finish()/flush/close succeeded, so
+    /// the .fit is safely on disk (the kernel auto-registers it on close, and
+    /// recoverInterrupted() re-registers after a crash). The auxiliary .json
+    /// summary is best-effort — a summary-only failure is logged but does NOT
+    /// flip the result, so it can never suppress the activity's registration.
     bool stop(const TrackData& track);
     void discard();
 

--- a/Examples/Apps/Cycling/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/ActivityWriter.hpp
@@ -17,6 +17,7 @@
 #include "SDK/Fit/FitProfile.hpp"
 #include "SDK/Fit/FitRecordCadence.hpp"
 #include "SDK/Fit/FitWriter.hpp"
+#include "SDK/Fit/RecordingMarker.hpp"
 
 /**
  * @class ActivityWriter
@@ -102,8 +103,19 @@ public:
     void resume(std::time_t timestamp);
     void addRecord(const RecordData& record);
     void addLap(const LapData& lap);
-    void stop(const TrackData& track);
+    /// Finalize the current activity and persist its summary. Returns true only
+    /// if the FIT stream, its finish()/flush/close and the summary all succeed.
+    bool stop(const TrackData& track);
     void discard();
+
+    /// Finalize an activity that a previous boot left unfinished (power loss /
+    /// crash mid-recording). If the recovery marker exists it names the torn
+    /// .fit and the last record-complete data-end offset; the file is finalized
+    /// via SDK::Fit::FitWriter::recover() and the marker is removed. Returns true
+    /// only when an interrupted activity was recovered into a valid FIT file.
+    /// Safe (returns false, no side effects) when no marker is present. Must run
+    /// before any new activity is started.
+    bool recoverInterrupted();
 
 private:
     /// Local message types (FIT record header, 0-15).
@@ -130,12 +142,17 @@ private:
         DF_HR_EXTERNAL     = 6,
     };
 
+    /// Flush + marker-refresh cadence during recording (seconds of record time).
+    static constexpr std::time_t skFlushIntervalSec = 30;
+
     const SDK::Kernel& mKernel;
     const char*        mPath = nullptr;
 
     std::unique_ptr<SDK::Interface::IFile> mFile = nullptr;
     std::unique_ptr<SDK::Fit::FitWriter>   mFit  = nullptr;
-    uint16_t mLapCounter = 0;
+    SDK::Fit::RecordingMarker              mMarker;   ///< Shared crash-recovery marker.
+    uint16_t    mLapCounter   = 0;
+    std::time_t mLastFlushUtc = 0;   ///< Record timestamp of the last durability flush.
 
     void defineRecordMessages();
     void writeFieldDescription(uint8_t devFieldNum, const char* name,
@@ -143,7 +160,7 @@ private:
     void addMessageEvent(std::time_t t, SDK::Fit::EventType type);
 
     bool createAndOpenFile(std::time_t utc);
-    void saveSummary(const TrackData& track);
+    bool saveSummary(const TrackData& track);
 
     static std::time_t tm2epoch(const struct tm* tm);
     static std::time_t epochToLocal(std::time_t utc);

--- a/Examples/Apps/Cycling/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/ActivityWriter.cpp
@@ -33,21 +33,25 @@ namespace {
 }  // namespace
 
 ActivityWriter::ActivityWriter(const SDK::Kernel& kernel, const char* pathToDir)
-    : mKernel(kernel), mPath(pathToDir)
+    : mKernel(kernel), mPath(pathToDir), mMarker(kernel.fs, pathToDir)
 {
     assert(pathToDir != nullptr);
 }
 
 void ActivityWriter::start(const AppInfo& info)
 {
-    mLapCounter = 0;
+    mLapCounter   = 0;
+    mLastFlushUtc = info.timestamp;
 
     if (!createAndOpenFile(info.timestamp)) {
         return;
     }
 
     mFit = std::make_unique<fit::FitWriter>(*mFile);
-    mFit->begin(/*profileVersion=*/0);
+    const bool begun = mFit->begin(/*profileVersion=*/0);
+    if (!begun) {
+        LOG_ERROR("Failed to write FIT header\n");
+    }
 
     // file_id
     mFit->defineMessage(L_FILE_ID, fit::mesgNum(fit::MesgNum::FileId),
@@ -108,6 +112,16 @@ void ActivityWriter::start(const AppInfo& info)
          fit::field::Activity::LocalTimestamp, fit::field::Activity::NumSessions});
 
     addMessageEvent(info.timestamp, fit::EventType::Start);
+
+    // Header + all definitions are on disk: flush and drop the recovery marker.
+    // getPosition() here is a clean record boundary, so a crash after this point
+    // is recoverable up to at least the header/definitions. Only write the
+    // marker when begin() succeeded: a failed begin() leaves a near-empty/broken
+    // .fit that the recovery marker must not point next boot's recover() at.
+    if (begun) {
+        mFile->flush();
+        mMarker.write(mFile->getPath(), static_cast<uint32_t>(mFile->getPosition()));
+    }
 }
 
 void ActivityWriter::defineRecordMessages()
@@ -219,6 +233,17 @@ void ActivityWriter::addRecord(const RecordData& record)
     d.u8(record.hrSource).u8(record.hrOpticalBpm).u8(record.hrExternalBpm);
 
     d.write();
+
+    // Periodic durability flush: sync to eMMC and advance the marker to this
+    // record boundary so a later crash recovers a record-complete file.
+    if (record.timestamp - mLastFlushUtc >= skFlushIntervalSec) {
+        // Only advance the marker when the flush durably landed; otherwise keep
+        // the previous good offset (never point recover() past non-durable data).
+        if (mFile->flush()) {
+            mMarker.update(static_cast<uint32_t>(mFile->getPosition()));
+            mLastFlushUtc = record.timestamp;
+        }
+    }
 }
 
 void ActivityWriter::addLap(const LapData& lap)
@@ -241,15 +266,24 @@ void ActivityWriter::addLap(const LapData& lap)
         .u8(static_cast<uint8_t>(lap.hrMax))
         .write();
     mLapCounter++;
+
+    // Laps are sparse: flush and advance the marker, but only when the flush
+    // durably landed (else keep the previous good offset).
+    if (mFile->flush()) {
+        mMarker.update(static_cast<uint32_t>(mFile->getPosition()));
+        mLastFlushUtc = lap.timestamp;
+    }
 }
 
-void ActivityWriter::stop(const TrackData& track)
+bool ActivityWriter::stop(const TrackData& track)
 {
     if (!mFit) {
-        return;
+        return false;
     }
 
-    mFit->data(L_SESSION)
+    bool ok = mFit->ok();
+
+    ok = mFit->data(L_SESSION)
         .u32(unixToFitTimestamp(track.timestamp))
         .u32(unixToFitTimestamp(track.timeStart))
         .u32(static_cast<uint32_t>(track.elapsed * 1000))
@@ -265,29 +299,43 @@ void ActivityWriter::stop(const TrackData& track)
         .u8(static_cast<uint8_t>(fit::SubSport::Generic))
         .u8(static_cast<uint8_t>(track.hrAvg))
         .u8(static_cast<uint8_t>(track.hrMax))
-        .write();
+        .write() && ok;
 
-    mFit->data(L_ACTIVITY)
+    ok = mFit->data(L_ACTIVITY)
         .u32(unixToFitTimestamp(track.timestamp))
         .u32(static_cast<uint32_t>(track.duration * 1000))
         .u32(unixToFitTimestamp(epochToLocal(track.timestamp)))
         .u16(1)
-        .write();
+        .write() && ok;
 
-    mFit->finish();
+    const bool finishOk = mFit->finish();
+    if (!finishOk) {
+        LOG_ERROR("Failed to finalize FIT file\n");
+    }
+    ok = finishOk && mFit->ok() && ok;
     mFit.reset();
 
     if (mFile) {
-        mFile->flush();
-        mFile->close();
+        ok = mFile->flush() && ok;
+        ok = mFile->close() && ok;
+    } else {
+        ok = false;
     }
 
-    saveSummary(track);
+    // The .fit is durably finished on disk: drop the recovery marker so the
+    // next boot does not treat this activity as interrupted.
+    if (ok) {
+        mMarker.remove();
+    }
+
+    const bool summaryOk = saveSummary(track);
+    return ok && summaryOk;
 }
 
 void ActivityWriter::discard()
 {
     mFit.reset();
+    mMarker.remove();
     if (!mFile) {
         return;
     }
@@ -305,6 +353,19 @@ void ActivityWriter::addMessageEvent(std::time_t t, fit::EventType type)
         .u8(static_cast<uint8_t>(fit::Event::Timer))
         .u8(static_cast<uint8_t>(type))
         .write();
+}
+
+bool ActivityWriter::recoverInterrupted()
+{
+    // All marker I/O + FitWriter::recover() orchestration lives in the shared
+    // SDK::Fit::RecordingMarker. Recovery needs no sibling .json to register a
+    // recovered activity (the kernel's activity registry tracks .fit files
+    // only), so this is pure wiring.
+    const auto result = mMarker.recover();
+    if (result.recovered) {
+        LOG_INFO("Recovery: finalized interrupted activity [%s]\n", result.path.c_str());
+    }
+    return result.recovered;
 }
 
 bool ActivityWriter::createAndOpenFile(std::time_t utc)
@@ -338,10 +399,10 @@ bool ActivityWriter::createAndOpenFile(std::time_t utc)
     return true;
 }
 
-void ActivityWriter::saveSummary(const TrackData& track)
+bool ActivityWriter::saveSummary(const TrackData& track)
 {
     if (!mFile) {
-        return;
+        return false;
     }
     char buff[256]{};
     size_t nameLen = strlen(mFile->getPath());
@@ -350,8 +411,9 @@ void ActivityWriter::saveSummary(const TrackData& track)
     mFile->setPath(buff);
 
     if (!mFile->open(true, true)) {
+        LOG_ERROR("Failed to open activity summary [%s]\n", buff);
         mFile.reset();
-        return;
+        return false;
     }
 
     SDK::JsonStreamWriter writer(mFile.get());
@@ -364,8 +426,8 @@ void ActivityWriter::saveSummary(const TrackData& track)
     writer.add("activity_type", "cycling");
     writer.endMap();
 
-    mFile->flush();
-    mFile->close();
+    const bool ok = mFile->flush();
+    return mFile->close() && ok;
 }
 
 std::time_t ActivityWriter::tm2epoch(const struct tm* tm)

--- a/Examples/Apps/Cycling/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/ActivityWriter.cpp
@@ -328,8 +328,16 @@ bool ActivityWriter::stop(const TrackData& track)
         mMarker.remove();
     }
 
-    const bool summaryOk = saveSummary(track);
-    return ok && summaryOk;
+    // FIT durability IS the save-success contract: the kernel auto-registers the
+    // .fit the moment its FileGuard::close() fires (and recoverInterrupted()
+    // re-registers after a crash), so once `ok` is true the activity is never
+    // orphaned. The .json summary is auxiliary/best-effort — recovery cannot
+    // rebuild it — so a summary-only failure must NOT suppress registration.
+    // Attempt it, log on failure, but gate the return value on FIT durability.
+    if (!saveSummary(track)) {
+        LOG_ERROR("Activity summary (.json) save failed; FIT is durable and registered\n");
+    }
+    return ok;
 }
 
 void ActivityWriter::discard()

--- a/Examples/Apps/Cycling/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/ActivityWriter.cpp
@@ -116,10 +116,10 @@ void ActivityWriter::start(const AppInfo& info)
     // Header + all definitions are on disk: flush and drop the recovery marker.
     // getPosition() here is a clean record boundary, so a crash after this point
     // is recoverable up to at least the header/definitions. Only write the
-    // marker when begin() succeeded: a failed begin() leaves a near-empty/broken
-    // .fit that the recovery marker must not point next boot's recover() at.
-    if (begun) {
-        mFile->flush();
+    // marker when begin() succeeded AND the initial flush is durable: a failed
+    // begin()/flush leaves a near-empty/broken or non-durable .fit that the
+    // recovery marker must not point next boot's recover() at.
+    if (begun && mFile->flush()) {
         mMarker.write(mFile->getPath(), static_cast<uint32_t>(mFile->getPosition()));
     }
 }
@@ -333,8 +333,11 @@ bool ActivityWriter::stop(const TrackData& track)
     // re-registers after a crash), so once `ok` is true the activity is never
     // orphaned. The .json summary is auxiliary/best-effort — recovery cannot
     // rebuild it — so a summary-only failure must NOT suppress registration.
-    // Attempt it, log on failure, but gate the return value on FIT durability.
-    if (!saveSummary(track)) {
+    // Attempt it ONLY when the FIT is durable (ok): with ok == false the marker
+    // is kept for next-boot recovery / the FIT is invalid, so a .json sidecar
+    // would misrepresent a non-durable activity. Log on failure; the return
+    // value is gated on FIT durability regardless.
+    if (ok && !saveSummary(track)) {
         LOG_ERROR("Activity summary (.json) save failed; FIT is durable and registered\n");
     }
     return ok;

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -101,6 +101,13 @@ void Service::run()
         LOG_WARNING("Failed to load activity summary\n");
     }
 
+    // Recover any activity a previous boot left unfinished (power loss /
+    // crash mid-recording), before any new track can start.
+    if (mActivityWriter.recoverInterrupted()) {
+        LOG_INFO("Recovered an interrupted activity\n");
+        notifyNewActivity();
+    }
+
     SDK::Timer guiInitTimeout(TIMER_SECONDS(5));
     guiInitTimeout.start();
 
@@ -868,9 +875,13 @@ void Service::stopTrack(bool discard)
         fitTrack.ascent    = mAltitudeCounter.getAscent();
         fitTrack.descent   = mAltitudeCounter.getDescent();
 
-        mActivityWriter.stop(fitTrack);
-
-        notifyNewActivity();
+        if (mActivityWriter.stop(fitTrack)) {
+            notifyNewActivity();
+        } else {
+            LOG_ERROR("activity save failed\n");
+            // Do NOT notify: the .fit is left unfinished, so the crash-recovery
+            // marker (if any) stays for the next boot to finalize.
+        }
     } else {
         mActivityWriter.discard();
     }

--- a/Examples/Apps/HRMonitor/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/HRMonitor/Software/Libs/Header/ActivityWriter.hpp
@@ -16,6 +16,7 @@
 #include "SDK/Kernel/Kernel.hpp"
 #include "SDK/Fit/FitProfile.hpp"
 #include "SDK/Fit/FitWriter.hpp"
+#include "SDK/Fit/RecordingMarker.hpp"
 
 /**
  * @class ActivityWriter
@@ -66,8 +67,19 @@ public:
     void start(const AppInfo& info);
     void addRecord(const RecordData& record);
     void addLap(const LapData& lap);
-    void stop(const TrackData& track);
+    /// Finalize the current activity. Returns true only if the FIT stream and
+    /// its finish()/flush/close all succeed.
+    bool stop(const TrackData& track);
     void discard();
+
+    /// Finalize an activity that a previous boot left unfinished (power loss /
+    /// crash mid-recording). If the recovery marker exists it names the torn
+    /// .fit and the last record-complete data-end offset; the file is finalized
+    /// via SDK::Fit::FitWriter::recover() and the marker is removed. Returns true
+    /// only when an interrupted activity was recovered into a valid FIT file.
+    /// Safe (returns false, no side effects) when no marker is present. Must run
+    /// before any new activity is started.
+    bool recoverInterrupted();
 
 private:
     /// Local message types (FIT record header, 0-15).
@@ -87,12 +99,17 @@ private:
         DF_HR_TRUST_LEVEL = 0,
     };
 
+    /// Flush + marker-refresh cadence during recording (seconds of record time).
+    static constexpr std::time_t skFlushIntervalSec = 30;
+
     const SDK::Kernel& mKernel;
     const char*        mPath = nullptr;
 
     std::unique_ptr<SDK::Interface::IFile> mFile = nullptr;
     std::unique_ptr<SDK::Fit::FitWriter>   mFit  = nullptr;
-    uint16_t mLapCounter = 0;
+    SDK::Fit::RecordingMarker              mMarker;   ///< Shared crash-recovery marker.
+    uint16_t    mLapCounter   = 0;
+    std::time_t mLastFlushUtc = 0;   ///< Record timestamp of the last durability flush.
 
     void writeFieldDescription(uint8_t devFieldNum, const char* name,
                                const char* units, SDK::Fit::BaseType baseType);

--- a/Examples/Apps/HRMonitor/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/HRMonitor/Software/Libs/Sources/ActivityWriter.cpp
@@ -100,10 +100,10 @@ void ActivityWriter::start(const AppInfo& info)
     // Header + all definitions are on disk: flush and drop the recovery marker.
     // getPosition() here is a clean record boundary, so a crash after this point
     // is recoverable up to at least the header/definitions. Only write the
-    // marker when begin() succeeded: a failed begin() leaves a near-empty/broken
-    // .fit that the recovery marker must not point next boot's recover() at.
-    if (begun) {
-        mFile->flush();
+    // marker when begin() succeeded AND the initial flush is durable: a failed
+    // begin()/flush leaves a near-empty/broken or non-durable .fit that the
+    // recovery marker must not point next boot's recover() at.
+    if (begun && mFile->flush()) {
         mMarker.write(mFile->getPath(), static_cast<uint32_t>(mFile->getPosition()));
     }
 }

--- a/Examples/Apps/HRMonitor/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/HRMonitor/Software/Libs/Sources/ActivityWriter.cpp
@@ -20,21 +20,25 @@ namespace fit = SDK::Fit;
 using DevFieldDef = fit::FitWriter::DevField;
 
 ActivityWriter::ActivityWriter(const SDK::Kernel& kernel, const char* pathToDir)
-    : mKernel(kernel), mPath(pathToDir)
+    : mKernel(kernel), mPath(pathToDir), mMarker(kernel.fs, pathToDir)
 {
     assert(pathToDir != nullptr);
 }
 
 void ActivityWriter::start(const AppInfo& info)
 {
-    mLapCounter = 0;
+    mLapCounter   = 0;
+    mLastFlushUtc = info.timestamp;
 
     if (!createAndOpenFile(info.timestamp)) {
         return;
     }
 
     mFit = std::make_unique<fit::FitWriter>(*mFile);
-    mFit->begin(/*profileVersion=*/0);
+    const bool begun = mFit->begin(/*profileVersion=*/0);
+    if (!begun) {
+        LOG_ERROR("Failed to write FIT header\n");
+    }
 
     // file_id
     mFit->defineMessage(L_FILE_ID, fit::mesgNum(fit::MesgNum::FileId),
@@ -92,6 +96,16 @@ void ActivityWriter::start(const AppInfo& info)
          fit::field::Activity::LocalTimestamp, fit::field::Activity::NumSessions});
 
     addMessageEvent(info.timestamp, fit::EventType::Start);
+
+    // Header + all definitions are on disk: flush and drop the recovery marker.
+    // getPosition() here is a clean record boundary, so a crash after this point
+    // is recoverable up to at least the header/definitions. Only write the
+    // marker when begin() succeeded: a failed begin() leaves a near-empty/broken
+    // .fit that the recovery marker must not point next boot's recover() at.
+    if (begun) {
+        mFile->flush();
+        mMarker.write(mFile->getPath(), static_cast<uint32_t>(mFile->getPosition()));
+    }
 }
 
 void ActivityWriter::writeFieldDescription(uint8_t devFieldNum, const char* name,
@@ -127,6 +141,17 @@ void ActivityWriter::addRecord(const RecordData& record)
         .u8(record.heartRate)
         .u8(record.trustLevel)  // developer field hr_trust_level
         .write();
+
+    // Periodic durability flush: sync to eMMC and advance the marker to this
+    // record boundary so a later crash recovers a record-complete file.
+    if (record.timestamp - mLastFlushUtc >= skFlushIntervalSec) {
+        // Only advance the marker when the flush durably landed; otherwise keep
+        // the previous good offset (never point recover() past non-durable data).
+        if (mFile->flush()) {
+            mMarker.update(static_cast<uint32_t>(mFile->getPosition()));
+            mLastFlushUtc = record.timestamp;
+        }
+    }
 }
 
 void ActivityWriter::addLap(const LapData& lap)
@@ -144,18 +169,27 @@ void ActivityWriter::addLap(const LapData& lap)
         .u8(lap.hrMax)
         .write();
     mLapCounter++;
+
+    // Laps are sparse: flush and advance the marker, but only when the flush
+    // durably landed (else keep the previous good offset).
+    if (mFile->flush()) {
+        mMarker.update(static_cast<uint32_t>(mFile->getPosition()));
+        mLastFlushUtc = lap.timestamp;
+    }
 }
 
-void ActivityWriter::stop(const TrackData& track)
+bool ActivityWriter::stop(const TrackData& track)
 {
     if (!mFit) {
-        return;
+        return false;
     }
 
     // STOP event
     addMessageEvent(track.timestamp, fit::EventType::Stop);
 
-    mFit->data(L_SESSION)
+    bool ok = mFit->ok();
+
+    ok = mFit->data(L_SESSION)
         .u32(unixToFitTimestamp(track.timestamp))
         .u32(unixToFitTimestamp(track.timeStart))
         .u32(static_cast<uint32_t>(track.elapsed * 1000))
@@ -166,28 +200,43 @@ void ActivityWriter::stop(const TrackData& track)
         .u8(static_cast<uint8_t>(fit::SubSport::Generic))
         .u8(track.hrAvg)
         .u8(track.hrMax)
-        .write();
+        .write() && ok;
 
-    mFit->data(L_ACTIVITY)
+    ok = mFit->data(L_ACTIVITY)
         .u32(unixToFitTimestamp(track.timestamp))
         .u32(static_cast<uint32_t>(track.duration * 1000))
         .u32(unixToFitTimestamp(epochToLocal(track.timestamp)))
         .u16(1)
-        .write();
+        .write() && ok;
 
-    mFit->finish();
+    const bool finishOk = mFit->finish();
+    if (!finishOk) {
+        LOG_ERROR("Failed to finalize FIT file\n");
+    }
+    ok = finishOk && mFit->ok() && ok;
     mFit.reset();
 
     if (mFile) {
-        mFile->flush();
-        mFile->close();
+        ok = mFile->flush() && ok;
+        ok = mFile->close() && ok;
         mFile.reset();
+    } else {
+        ok = false;
     }
+
+    // The .fit is durably finished on disk: drop the recovery marker so the
+    // next boot does not treat this activity as interrupted.
+    if (ok) {
+        mMarker.remove();
+    }
+
+    return ok;
 }
 
 void ActivityWriter::discard()
 {
     mFit.reset();
+    mMarker.remove();
     if (!mFile) {
         return;
     }
@@ -205,6 +254,19 @@ void ActivityWriter::addMessageEvent(std::time_t t, fit::EventType type)
         .u8(static_cast<uint8_t>(fit::Event::Timer))
         .u8(static_cast<uint8_t>(type))
         .write();
+}
+
+bool ActivityWriter::recoverInterrupted()
+{
+    // All marker I/O + FitWriter::recover() orchestration lives in the shared
+    // SDK::Fit::RecordingMarker. Recovery needs no sibling .json to register a
+    // recovered activity (the kernel's activity registry tracks .fit files
+    // only), so this is pure wiring.
+    const auto result = mMarker.recover();
+    if (result.recovered) {
+        LOG_INFO("Recovery: finalized interrupted activity [%s]\n", result.path.c_str());
+    }
+    return result.recovered;
 }
 
 bool ActivityWriter::createAndOpenFile(std::time_t utc)

--- a/Examples/Apps/HRMonitor/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/HRMonitor/Software/Libs/Sources/Service.cpp
@@ -34,6 +34,21 @@ void Service::run()
 
     mSensorHr.connect();
 
+    // Recover any activity a previous boot left unfinished (power loss / crash
+    // mid-recording), before this run's own recording overwrites the marker.
+    //
+    // Known limitation: unlike the other activity apps, HRMonitor has NO
+    // activity-registration path -- it never sends CommandAppNewActivity, not
+    // even when a normally-completed session ends. Every HRMonitor .fit (both
+    // normal and recovered) is instead picked up by the kernel's boot-time
+    // activity scan. A recovered file is therefore registered on the NEXT boot's
+    // scan rather than immediately, i.e. recovery is one reboot late -- which is
+    // consistent with HRMonitor's normal (never-notified) behaviour, so no
+    // notify is wired here.
+    if (mActivityWriter.recoverInterrupted()) {
+        LOG_INFO("Recovered an interrupted activity\n");
+    }
+
     ActivityWriter::AppInfo info{};
     info.timestamp  = std::time(nullptr);
     info.appVersion = SDK::ParseVersion(BUILD_VERSION).u32;
@@ -137,7 +152,9 @@ void Service::run()
     fitTrack.elapsed   = utc - startTime;
     fitTrack.hrAvg     = static_cast<uint8_t>(hrAvgCount > 0 ? hrAvgSum / hrAvgCount : 0);
     fitTrack.hrMax     = static_cast<uint8_t>(hrMax);
-    mActivityWriter.stop(fitTrack);
+    if (!mActivityWriter.stop(fitTrack)) {
+        LOG_ERROR("activity save failed\n");
+    }
 
     mSensorHr.disconnect();
 

--- a/Examples/Apps/Hiking/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/ActivityWriter.hpp
@@ -107,8 +107,12 @@ public:
     void resume(std::time_t timestamp);
     void addRecord(const RecordData& record);
     void addLap(const LapData& lap);
-    /// Finalize the current activity and persist its summary. Returns true only
-    /// if the FIT stream, its finish()/flush/close and the summary all succeed.
+    /// Finalize the current activity. The return value is the FIT-durability
+    /// contract: true iff the FIT stream + its finish()/flush/close succeeded, so
+    /// the .fit is safely on disk (the kernel auto-registers it on close, and
+    /// recoverInterrupted() re-registers after a crash). The auxiliary .json
+    /// summary is best-effort — a summary-only failure is logged but does NOT
+    /// flip the result, so it can never suppress the activity's registration.
     bool stop(const TrackData& track);
     void discard();
 

--- a/Examples/Apps/Hiking/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/ActivityWriter.hpp
@@ -17,6 +17,7 @@
 #include "SDK/Fit/FitProfile.hpp"
 #include "SDK/Fit/FitRecordCadence.hpp"
 #include "SDK/Fit/FitWriter.hpp"
+#include "SDK/Fit/RecordingMarker.hpp"
 
 /**
  * @class ActivityWriter
@@ -106,8 +107,19 @@ public:
     void resume(std::time_t timestamp);
     void addRecord(const RecordData& record);
     void addLap(const LapData& lap);
-    void stop(const TrackData& track);
+    /// Finalize the current activity and persist its summary. Returns true only
+    /// if the FIT stream, its finish()/flush/close and the summary all succeed.
+    bool stop(const TrackData& track);
     void discard();
+
+    /// Finalize an activity that a previous boot left unfinished (power loss /
+    /// crash mid-recording). If the recovery marker exists it names the torn
+    /// .fit and the last record-complete data-end offset; the file is finalized
+    /// via SDK::Fit::FitWriter::recover() and the marker is removed. Returns true
+    /// only when an interrupted activity was recovered into a valid FIT file.
+    /// Safe (returns false, no side effects) when no marker is present. Must run
+    /// before any new activity is started.
+    bool recoverInterrupted();
 
 private:
     /// Local message types (FIT record header, 0-15).
@@ -136,12 +148,17 @@ private:
         DF_HR_EXTERNAL     = 6,
     };
 
+    /// Flush + marker-refresh cadence during recording (seconds of record time).
+    static constexpr std::time_t skFlushIntervalSec = 30;
+
     const SDK::Kernel& mKernel;
     const char*        mPath = nullptr;
 
     std::unique_ptr<SDK::Interface::IFile> mFile = nullptr;
     std::unique_ptr<SDK::Fit::FitWriter>   mFit  = nullptr;
-    uint16_t mLapCounter = 0;
+    SDK::Fit::RecordingMarker              mMarker;   ///< Shared crash-recovery marker.
+    uint16_t    mLapCounter   = 0;
+    std::time_t mLastFlushUtc = 0;   ///< Record timestamp of the last durability flush.
 
     void defineRecordMessages();
     void writeFieldDescription(uint8_t devFieldNum, const char* name,
@@ -149,7 +166,7 @@ private:
     void addMessageEvent(std::time_t t, SDK::Fit::EventType type);
 
     bool createAndOpenFile(std::time_t utc);
-    void saveSummary(const TrackData& track);
+    bool saveSummary(const TrackData& track);
 
     static std::time_t tm2epoch(const struct tm* tm);
     static std::time_t epochToLocal(std::time_t utc);

--- a/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
@@ -342,8 +342,16 @@ bool ActivityWriter::stop(const TrackData& track)
         mMarker.remove();
     }
 
-    const bool summaryOk = saveSummary(track);
-    return ok && summaryOk;
+    // FIT durability IS the save-success contract: the kernel auto-registers the
+    // .fit the moment its FileGuard::close() fires (and recoverInterrupted()
+    // re-registers after a crash), so once `ok` is true the activity is never
+    // orphaned. The .json summary is auxiliary/best-effort — recovery cannot
+    // rebuild it — so a summary-only failure must NOT suppress registration.
+    // Attempt it, log on failure, but gate the return value on FIT durability.
+    if (!saveSummary(track)) {
+        LOG_ERROR("Activity summary (.json) save failed; FIT is durable and registered\n");
+    }
+    return ok;
 }
 
 void ActivityWriter::discard()

--- a/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
@@ -124,10 +124,10 @@ void ActivityWriter::start(const AppInfo& info)
     // Header + all definitions are on disk: flush and drop the recovery marker.
     // getPosition() here is a clean record boundary, so a crash after this point
     // is recoverable up to at least the header/definitions. Only write the
-    // marker when begin() succeeded: a failed begin() leaves a near-empty/broken
-    // .fit that the recovery marker must not point next boot's recover() at.
-    if (begun) {
-        mFile->flush();
+    // marker when begin() succeeded AND the initial flush is durable: a failed
+    // begin()/flush leaves a near-empty/broken or non-durable .fit that the
+    // recovery marker must not point next boot's recover() at.
+    if (begun && mFile->flush()) {
         mMarker.write(mFile->getPath(), static_cast<uint32_t>(mFile->getPosition()));
     }
 }
@@ -347,8 +347,11 @@ bool ActivityWriter::stop(const TrackData& track)
     // re-registers after a crash), so once `ok` is true the activity is never
     // orphaned. The .json summary is auxiliary/best-effort — recovery cannot
     // rebuild it — so a summary-only failure must NOT suppress registration.
-    // Attempt it, log on failure, but gate the return value on FIT durability.
-    if (!saveSummary(track)) {
+    // Attempt it ONLY when the FIT is durable (ok): with ok == false the marker
+    // is kept for next-boot recovery / the FIT is invalid, so a .json sidecar
+    // would misrepresent a non-durable activity. Log on failure; the return
+    // value is gated on FIT durability regardless.
+    if (ok && !saveSummary(track)) {
         LOG_ERROR("Activity summary (.json) save failed; FIT is durable and registered\n");
     }
     return ok;

--- a/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
@@ -33,21 +33,25 @@ namespace {
 }  // namespace
 
 ActivityWriter::ActivityWriter(const SDK::Kernel& kernel, const char* pathToDir)
-    : mKernel(kernel), mPath(pathToDir)
+    : mKernel(kernel), mPath(pathToDir), mMarker(kernel.fs, pathToDir)
 {
     assert(pathToDir != nullptr);
 }
 
 void ActivityWriter::start(const AppInfo& info)
 {
-    mLapCounter = 0;
+    mLapCounter   = 0;
+    mLastFlushUtc = info.timestamp;
 
     if (!createAndOpenFile(info.timestamp)) {
         return;
     }
 
     mFit = std::make_unique<fit::FitWriter>(*mFile);
-    mFit->begin(/*profileVersion=*/0);
+    const bool begun = mFit->begin(/*profileVersion=*/0);
+    if (!begun) {
+        LOG_ERROR("Failed to write FIT header\n");
+    }
 
     // file_id
     mFit->defineMessage(L_FILE_ID, fit::mesgNum(fit::MesgNum::FileId),
@@ -116,6 +120,16 @@ void ActivityWriter::start(const AppInfo& info)
          fit::field::Activity::LocalTimestamp, fit::field::Activity::NumSessions});
 
     addMessageEvent(info.timestamp, fit::EventType::Start);
+
+    // Header + all definitions are on disk: flush and drop the recovery marker.
+    // getPosition() here is a clean record boundary, so a crash after this point
+    // is recoverable up to at least the header/definitions. Only write the
+    // marker when begin() succeeded: a failed begin() leaves a near-empty/broken
+    // .fit that the recovery marker must not point next boot's recover() at.
+    if (begun) {
+        mFile->flush();
+        mMarker.write(mFile->getPath(), static_cast<uint32_t>(mFile->getPosition()));
+    }
 }
 
 void ActivityWriter::defineRecordMessages()
@@ -227,6 +241,17 @@ void ActivityWriter::addRecord(const RecordData& record)
     d.u8(record.hrSource).u8(record.hrOpticalBpm).u8(record.hrExternalBpm);
 
     d.write();
+
+    // Periodic durability flush: sync to eMMC and advance the marker to this
+    // record boundary so a later crash recovers a record-complete file.
+    if (record.timestamp - mLastFlushUtc >= skFlushIntervalSec) {
+        // Only advance the marker when the flush durably landed; otherwise keep
+        // the previous good offset (never point recover() past non-durable data).
+        if (mFile->flush()) {
+            mMarker.update(static_cast<uint32_t>(mFile->getPosition()));
+            mLastFlushUtc = record.timestamp;
+        }
+    }
 }
 
 void ActivityWriter::addLap(const LapData& lap)
@@ -252,15 +277,24 @@ void ActivityWriter::addLap(const LapData& lap)
         .u32(lap.floors)
         .write();
     mLapCounter++;
+
+    // Laps are sparse: flush and advance the marker, but only when the flush
+    // durably landed (else keep the previous good offset).
+    if (mFile->flush()) {
+        mMarker.update(static_cast<uint32_t>(mFile->getPosition()));
+        mLastFlushUtc = lap.timestamp;
+    }
 }
 
-void ActivityWriter::stop(const TrackData& track)
+bool ActivityWriter::stop(const TrackData& track)
 {
     if (!mFit) {
-        return;
+        return false;
     }
 
-    mFit->data(L_SESSION)
+    bool ok = mFit->ok();
+
+    ok = mFit->data(L_SESSION)
         .u32(unixToFitTimestamp(track.timestamp))
         .u32(unixToFitTimestamp(track.timeStart))
         .u32(static_cast<uint32_t>(track.elapsed * 1000))
@@ -279,29 +313,43 @@ void ActivityWriter::stop(const TrackData& track)
         // developer fields: steps, floors
         .u32(track.steps)
         .u32(track.floors)
-        .write();
+        .write() && ok;
 
-    mFit->data(L_ACTIVITY)
+    ok = mFit->data(L_ACTIVITY)
         .u32(unixToFitTimestamp(track.timestamp))
         .u32(static_cast<uint32_t>(track.duration * 1000))
         .u32(unixToFitTimestamp(epochToLocal(track.timestamp)))
         .u16(1)
-        .write();
+        .write() && ok;
 
-    mFit->finish();
+    const bool finishOk = mFit->finish();
+    if (!finishOk) {
+        LOG_ERROR("Failed to finalize FIT file\n");
+    }
+    ok = finishOk && mFit->ok() && ok;
     mFit.reset();
 
     if (mFile) {
-        mFile->flush();
-        mFile->close();
+        ok = mFile->flush() && ok;
+        ok = mFile->close() && ok;
+    } else {
+        ok = false;
     }
 
-    saveSummary(track);
+    // The .fit is durably finished on disk: drop the recovery marker so the
+    // next boot does not treat this activity as interrupted.
+    if (ok) {
+        mMarker.remove();
+    }
+
+    const bool summaryOk = saveSummary(track);
+    return ok && summaryOk;
 }
 
 void ActivityWriter::discard()
 {
     mFit.reset();
+    mMarker.remove();
     if (!mFile) {
         return;
     }
@@ -319,6 +367,19 @@ void ActivityWriter::addMessageEvent(std::time_t t, fit::EventType type)
         .u8(static_cast<uint8_t>(fit::Event::Timer))
         .u8(static_cast<uint8_t>(type))
         .write();
+}
+
+bool ActivityWriter::recoverInterrupted()
+{
+    // All marker I/O + FitWriter::recover() orchestration lives in the shared
+    // SDK::Fit::RecordingMarker. Recovery needs no sibling .json to register a
+    // recovered activity (the kernel's activity registry tracks .fit files
+    // only), so this is pure wiring.
+    const auto result = mMarker.recover();
+    if (result.recovered) {
+        LOG_INFO("Recovery: finalized interrupted activity [%s]\n", result.path.c_str());
+    }
+    return result.recovered;
 }
 
 bool ActivityWriter::createAndOpenFile(std::time_t utc)
@@ -352,10 +413,10 @@ bool ActivityWriter::createAndOpenFile(std::time_t utc)
     return true;
 }
 
-void ActivityWriter::saveSummary(const TrackData& track)
+bool ActivityWriter::saveSummary(const TrackData& track)
 {
     if (!mFile) {
-        return;
+        return false;
     }
     char buff[256]{};
     size_t nameLen = strlen(mFile->getPath());
@@ -364,8 +425,9 @@ void ActivityWriter::saveSummary(const TrackData& track)
     mFile->setPath(buff);
 
     if (!mFile->open(true, true)) {
+        LOG_ERROR("Failed to open activity summary [%s]\n", buff);
         mFile.reset();
-        return;
+        return false;
     }
 
     SDK::JsonStreamWriter writer(mFile.get());
@@ -378,8 +440,8 @@ void ActivityWriter::saveSummary(const TrackData& track)
     writer.add("activity_type", "hiking");
     writer.endMap();
 
-    mFile->flush();
-    mFile->close();
+    const bool ok = mFile->flush();
+    return mFile->close() && ok;
 }
 
 std::time_t ActivityWriter::tm2epoch(const struct tm* tm)

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -107,6 +107,13 @@ void Service::run()
         LOG_WARNING("Failed to load activity summary\n");
     }
 
+    // Recover any activity a previous boot left unfinished (power loss /
+    // crash mid-recording), before any new track can start.
+    if (mActivityWriter.recoverInterrupted()) {
+        LOG_INFO("Recovered an interrupted activity\n");
+        notifyNewActivity();
+    }
+
     SDK::Timer guiInitTimeout(TIMER_SECONDS(5));
     guiInitTimeout.start();
 
@@ -918,9 +925,13 @@ void Service::stopTrack(bool discard)
         fitTrack.steps     = mStepCounter.getValueActive();
         fitTrack.floors    = mFloorCounter.getValueActive();
 
-        mActivityWriter.stop(fitTrack);
-
-        notifyNewActivity();
+        if (mActivityWriter.stop(fitTrack)) {
+            notifyNewActivity();
+        } else {
+            LOG_ERROR("activity save failed\n");
+            // Do NOT notify: the .fit is left unfinished, so the crash-recovery
+            // marker (if any) stays for the next boot to finalize.
+        }
     } else {
         mActivityWriter.discard();
     }

--- a/Examples/Apps/Running/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/ActivityWriter.hpp
@@ -125,8 +125,12 @@ public:
     void addLap(const LapData& lap);
     /// Emit the workout + workout_step messages describing a structured workout.
     void addWorkout(const char* name, const WorkoutStepData* steps, uint8_t count);
-    /// Finalize the current activity and persist its summary. Returns true only
-    /// if the FIT stream, its finish()/flush/close and the summary all succeed.
+    /// Finalize the current activity. The return value is the FIT-durability
+    /// contract: true iff the FIT stream + its finish()/flush/close succeeded, so
+    /// the .fit is safely on disk (the kernel auto-registers it on close, and
+    /// recoverInterrupted() re-registers after a crash). The auxiliary .json
+    /// summary is best-effort — a summary-only failure is logged but does NOT
+    /// flip the result, so it can never suppress the activity's registration.
     bool stop(const TrackData& track);
     void discard();
 

--- a/Examples/Apps/Running/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/ActivityWriter.hpp
@@ -17,6 +17,7 @@
 #include "SDK/Fit/FitProfile.hpp"
 #include "SDK/Fit/FitRecordCadence.hpp"
 #include "SDK/Fit/FitWriter.hpp"
+#include "SDK/Fit/RecordingMarker.hpp"
 
 /**
  * @class ActivityWriter
@@ -124,8 +125,19 @@ public:
     void addLap(const LapData& lap);
     /// Emit the workout + workout_step messages describing a structured workout.
     void addWorkout(const char* name, const WorkoutStepData* steps, uint8_t count);
-    void stop(const TrackData& track);
+    /// Finalize the current activity and persist its summary. Returns true only
+    /// if the FIT stream, its finish()/flush/close and the summary all succeed.
+    bool stop(const TrackData& track);
     void discard();
+
+    /// Finalize an activity that a previous boot left unfinished (power loss /
+    /// crash mid-recording). If the recovery marker exists it names the torn
+    /// .fit and the last record-complete data-end offset; the file is finalized
+    /// via SDK::Fit::FitWriter::recover() and the marker is removed. Returns true
+    /// only when an interrupted activity was recovered into a valid FIT file.
+    /// Safe (returns false, no side effects) when no marker is present. Must run
+    /// before any new activity is started.
+    bool recoverInterrupted();
 
 private:
     /// Local message types (FIT record header, 0-15).
@@ -154,12 +166,17 @@ private:
         DF_HR_EXTERNAL     = 6,
     };
 
+    /// Flush + marker-refresh cadence during recording (seconds of record time).
+    static constexpr std::time_t skFlushIntervalSec = 30;
+
     const SDK::Kernel& mKernel;
     const char*        mPath = nullptr;
 
     std::unique_ptr<SDK::Interface::IFile> mFile = nullptr;
     std::unique_ptr<SDK::Fit::FitWriter>   mFit  = nullptr;
-    uint16_t mLapCounter = 0;
+    SDK::Fit::RecordingMarker              mMarker;   ///< Shared crash-recovery marker.
+    uint16_t    mLapCounter   = 0;
+    std::time_t mLastFlushUtc = 0;   ///< Record timestamp of the last durability flush.
 
     void defineRecordMessages();
     void writeFieldDescription(uint8_t devFieldNum, const char* name,
@@ -167,7 +184,7 @@ private:
     void addMessageEvent(std::time_t t, SDK::Fit::EventType type);
 
     bool createAndOpenFile(std::time_t utc);
-    void saveSummary(const TrackData& track);
+    bool saveSummary(const TrackData& track);
 
     static std::time_t tm2epoch(const struct tm* tm);
     static std::time_t epochToLocal(std::time_t utc);

--- a/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp
@@ -36,21 +36,25 @@ namespace {
 }  // namespace
 
 ActivityWriter::ActivityWriter(const SDK::Kernel& kernel, const char* pathToDir)
-    : mKernel(kernel), mPath(pathToDir)
+    : mKernel(kernel), mPath(pathToDir), mMarker(kernel.fs, pathToDir)
 {
     assert(pathToDir != nullptr);
 }
 
 void ActivityWriter::start(const AppInfo& info)
 {
-    mLapCounter = 0;
+    mLapCounter   = 0;
+    mLastFlushUtc = info.timestamp;
 
     if (!createAndOpenFile(info.timestamp)) {
         return;
     }
 
     mFit = std::make_unique<fit::FitWriter>(*mFile);
-    mFit->begin(/*profileVersion=*/0);
+    const bool begun = mFit->begin(/*profileVersion=*/0);
+    if (!begun) {
+        LOG_ERROR("Failed to write FIT header\n");
+    }
 
     // file_id
     mFit->defineMessage(L_FILE_ID, fit::mesgNum(fit::MesgNum::FileId),
@@ -112,6 +116,16 @@ void ActivityWriter::start(const AppInfo& info)
          fit::field::Activity::LocalTimestamp, fit::field::Activity::NumSessions});
 
     addMessageEvent(info.timestamp, fit::EventType::Start);
+
+    // Header + all definitions are on disk: flush and drop the recovery marker.
+    // getPosition() here is a clean record boundary, so a crash after this point
+    // is recoverable up to at least the header/definitions. Only write the
+    // marker when begin() succeeded: a failed begin() leaves a near-empty/broken
+    // .fit that the recovery marker must not point next boot's recover() at.
+    if (begun) {
+        mFile->flush();
+        mMarker.write(mFile->getPath(), static_cast<uint32_t>(mFile->getPosition()));
+    }
 }
 
 void ActivityWriter::defineRecordMessages()
@@ -239,6 +253,17 @@ void ActivityWriter::addRecord(const RecordData& record)
     d.u8(record.hrSource).u8(record.hrOpticalBpm).u8(record.hrExternalBpm);
 
     d.write();
+
+    // Periodic durability flush: sync to eMMC and advance the marker to this
+    // record boundary so a later crash recovers a record-complete file.
+    if (record.timestamp - mLastFlushUtc >= skFlushIntervalSec) {
+        // Only advance the marker when the flush durably landed; otherwise keep
+        // the previous good offset (never point recover() past non-durable data).
+        if (mFile->flush()) {
+            mMarker.update(static_cast<uint32_t>(mFile->getPosition()));
+            mLastFlushUtc = record.timestamp;
+        }
+    }
 }
 
 void ActivityWriter::addLap(const LapData& lap)
@@ -262,6 +287,13 @@ void ActivityWriter::addLap(const LapData& lap)
         .u16(lap.wktStepIndex)
         .write();
     mLapCounter++;
+
+    // Laps are sparse: flush and advance the marker, but only when the flush
+    // durably landed (else keep the previous good offset).
+    if (mFile->flush()) {
+        mMarker.update(static_cast<uint32_t>(mFile->getPosition()));
+        mLastFlushUtc = lap.timestamp;
+    }
 }
 
 void ActivityWriter::addWorkout(const char* name, const WorkoutStepData* steps, uint8_t count)
@@ -302,13 +334,15 @@ void ActivityWriter::addWorkout(const char* name, const WorkoutStepData* steps, 
     }
 }
 
-void ActivityWriter::stop(const TrackData& track)
+bool ActivityWriter::stop(const TrackData& track)
 {
     if (!mFit) {
-        return;
+        return false;
     }
 
-    mFit->data(L_SESSION)
+    bool ok = mFit->ok();
+
+    ok = mFit->data(L_SESSION)
         .u32(unixToFitTimestamp(track.timestamp))
         .u32(unixToFitTimestamp(track.timeStart))
         .u32(static_cast<uint32_t>(track.elapsed * 1000))
@@ -324,29 +358,43 @@ void ActivityWriter::stop(const TrackData& track)
         .u8(static_cast<uint8_t>(fit::SubSport::Generic))
         .u8(static_cast<uint8_t>(track.hrAvg))
         .u8(static_cast<uint8_t>(track.hrMax))
-        .write();
+        .write() && ok;
 
-    mFit->data(L_ACTIVITY)
+    ok = mFit->data(L_ACTIVITY)
         .u32(unixToFitTimestamp(track.timestamp))
         .u32(static_cast<uint32_t>(track.duration * 1000))
         .u32(unixToFitTimestamp(epochToLocal(track.timestamp)))
         .u16(1)
-        .write();
+        .write() && ok;
 
-    mFit->finish();
+    const bool finishOk = mFit->finish();
+    if (!finishOk) {
+        LOG_ERROR("Failed to finalize FIT file\n");
+    }
+    ok = finishOk && mFit->ok() && ok;
     mFit.reset();
 
     if (mFile) {
-        mFile->flush();
-        mFile->close();
+        ok = mFile->flush() && ok;
+        ok = mFile->close() && ok;
+    } else {
+        ok = false;
     }
 
-    saveSummary(track);
+    // The .fit is durably finished on disk: drop the recovery marker so the
+    // next boot does not treat this activity as interrupted.
+    if (ok) {
+        mMarker.remove();
+    }
+
+    const bool summaryOk = saveSummary(track);
+    return ok && summaryOk;
 }
 
 void ActivityWriter::discard()
 {
     mFit.reset();
+    mMarker.remove();
     if (!mFile) {
         return;
     }
@@ -364,6 +412,19 @@ void ActivityWriter::addMessageEvent(std::time_t t, fit::EventType type)
         .u8(static_cast<uint8_t>(fit::Event::Timer))
         .u8(static_cast<uint8_t>(type))
         .write();
+}
+
+bool ActivityWriter::recoverInterrupted()
+{
+    // All marker I/O + FitWriter::recover() orchestration lives in the shared
+    // SDK::Fit::RecordingMarker. Running needs no sibling .json to register a
+    // recovered activity (the kernel's activity registry tracks .fit files
+    // only), so this is pure wiring.
+    const auto result = mMarker.recover();
+    if (result.recovered) {
+        LOG_INFO("Recovery: finalized interrupted activity [%s]\n", result.path.c_str());
+    }
+    return result.recovered;
 }
 
 bool ActivityWriter::createAndOpenFile(std::time_t utc)
@@ -397,10 +458,10 @@ bool ActivityWriter::createAndOpenFile(std::time_t utc)
     return true;
 }
 
-void ActivityWriter::saveSummary(const TrackData& track)
+bool ActivityWriter::saveSummary(const TrackData& track)
 {
     if (!mFile) {
-        return;
+        return false;
     }
     char buff[256]{};
     size_t nameLen = strlen(mFile->getPath());
@@ -409,8 +470,9 @@ void ActivityWriter::saveSummary(const TrackData& track)
     mFile->setPath(buff);
 
     if (!mFile->open(true, true)) {
+        LOG_ERROR("Failed to open activity summary [%s]\n", buff);
         mFile.reset();
-        return;
+        return false;
     }
 
     SDK::JsonStreamWriter writer(mFile.get());
@@ -423,8 +485,8 @@ void ActivityWriter::saveSummary(const TrackData& track)
     writer.add("activity_type", "running");
     writer.endMap();
 
-    mFile->flush();
-    mFile->close();
+    const bool ok = mFile->flush();
+    return mFile->close() && ok;
 }
 
 std::time_t ActivityWriter::tm2epoch(const struct tm* tm)

--- a/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp
@@ -387,8 +387,16 @@ bool ActivityWriter::stop(const TrackData& track)
         mMarker.remove();
     }
 
-    const bool summaryOk = saveSummary(track);
-    return ok && summaryOk;
+    // FIT durability IS the save-success contract: the kernel auto-registers the
+    // .fit the moment its FileGuard::close() fires (and recoverInterrupted()
+    // re-registers after a crash), so once `ok` is true the activity is never
+    // orphaned. The .json summary is auxiliary/best-effort — recovery cannot
+    // rebuild it — so a summary-only failure must NOT suppress registration.
+    // Attempt it, log on failure, but gate the return value on FIT durability.
+    if (!saveSummary(track)) {
+        LOG_ERROR("Activity summary (.json) save failed; FIT is durable and registered\n");
+    }
+    return ok;
 }
 
 void ActivityWriter::discard()

--- a/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp
@@ -120,10 +120,10 @@ void ActivityWriter::start(const AppInfo& info)
     // Header + all definitions are on disk: flush and drop the recovery marker.
     // getPosition() here is a clean record boundary, so a crash after this point
     // is recoverable up to at least the header/definitions. Only write the
-    // marker when begin() succeeded: a failed begin() leaves a near-empty/broken
-    // .fit that the recovery marker must not point next boot's recover() at.
-    if (begun) {
-        mFile->flush();
+    // marker when begin() succeeded AND the initial flush is durable: a failed
+    // begin()/flush leaves a near-empty/broken or non-durable .fit that the
+    // recovery marker must not point next boot's recover() at.
+    if (begun && mFile->flush()) {
         mMarker.write(mFile->getPath(), static_cast<uint32_t>(mFile->getPosition()));
     }
 }
@@ -392,8 +392,11 @@ bool ActivityWriter::stop(const TrackData& track)
     // re-registers after a crash), so once `ok` is true the activity is never
     // orphaned. The .json summary is auxiliary/best-effort — recovery cannot
     // rebuild it — so a summary-only failure must NOT suppress registration.
-    // Attempt it, log on failure, but gate the return value on FIT durability.
-    if (!saveSummary(track)) {
+    // Attempt it ONLY when the FIT is durable (ok): with ok == false the marker
+    // is kept for next-boot recovery / the FIT is invalid, so a .json sidecar
+    // would misrepresent a non-durable activity. Log on failure; the return
+    // value is gated on FIT durability regardless.
+    if (ok && !saveSummary(track)) {
         LOG_ERROR("Activity summary (.json) save failed; FIT is durable and registered\n");
     }
     return ok;

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -120,6 +120,13 @@ void Service::run()
         LOG_WARNING("Failed to load activity summary\n");
     }
 
+    // Recover any activity a previous boot left unfinished (power loss /
+    // crash mid-recording), before any new track can start.
+    if (mActivityWriter.recoverInterrupted()) {
+        LOG_INFO("Recovered an interrupted activity\n");
+        notifyNewActivity();
+    }
+
     SDK::Timer guiInitTimeout(TIMER_SECONDS(5));
     guiInitTimeout.start();
 
@@ -1055,9 +1062,13 @@ void Service::stopTrack(bool discard)
         fitTrack.ascent    = mAltitudeCounter.getAscent();
         fitTrack.descent   = mAltitudeCounter.getDescent();
 
-        mActivityWriter.stop(fitTrack);
-
-        notifyNewActivity();
+        if (mActivityWriter.stop(fitTrack)) {
+            notifyNewActivity();
+        } else {
+            LOG_ERROR("activity save failed\n");
+            // Do NOT notify: the .fit is left unfinished, so the crash-recovery
+            // marker (if any) stays for the next boot to finalize.
+        }
     } else {
         mActivityWriter.discard();
     }

--- a/Examples/Apps/Treadmill/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Header/ActivityWriter.hpp
@@ -17,6 +17,7 @@
 #include "SDK/Fit/FitProfile.hpp"
 #include "SDK/Fit/FitRecordCadence.hpp"
 #include "SDK/Fit/FitWriter.hpp"
+#include "SDK/Fit/RecordingMarker.hpp"
 
 /**
  * @class ActivityWriter
@@ -121,8 +122,19 @@ public:
     void addLap(const LapData& lap);
     /// Emit the workout + workout_step messages describing a structured workout.
     void addWorkout(const char* name, const WorkoutStepData* steps, uint8_t count);
-    void stop(const TrackData& track);
+    /// Finalize the current activity and persist its summary. Returns true only
+    /// if the FIT stream, its finish()/flush/close and the summary all succeed.
+    bool stop(const TrackData& track);
     void discard();
+
+    /// Finalize an activity that a previous boot left unfinished (power loss /
+    /// crash mid-recording). If the recovery marker exists it names the torn
+    /// .fit and the last record-complete data-end offset; the file is finalized
+    /// via SDK::Fit::FitWriter::recover() and the marker is removed. Returns true
+    /// only when an interrupted activity was recovered into a valid FIT file.
+    /// Safe (returns false, no side effects) when no marker is present. Must run
+    /// before any new activity is started.
+    bool recoverInterrupted();
 
 private:
     /// Local message types (FIT record header, 0-15).
@@ -150,12 +162,17 @@ private:
         DF_HR_EXTERNAL     = 6,
     };
 
+    /// Flush + marker-refresh cadence during recording (seconds of record time).
+    static constexpr std::time_t skFlushIntervalSec = 30;
+
     const SDK::Kernel& mKernel;
     const char*        mPath = nullptr;
 
     std::unique_ptr<SDK::Interface::IFile> mFile = nullptr;
     std::unique_ptr<SDK::Fit::FitWriter>   mFit  = nullptr;
-    uint16_t mLapCounter = 0;
+    SDK::Fit::RecordingMarker              mMarker;   ///< Shared crash-recovery marker.
+    uint16_t    mLapCounter   = 0;
+    std::time_t mLastFlushUtc = 0;   ///< Record timestamp of the last durability flush.
 
     void defineRecordMessages();
     void writeFieldDescription(uint8_t devFieldNum, const char* name,
@@ -163,7 +180,7 @@ private:
     void addMessageEvent(std::time_t t, SDK::Fit::EventType type);
 
     bool createAndOpenFile(std::time_t utc);
-    void saveSummary(const TrackData& track);
+    bool saveSummary(const TrackData& track);
 
     static std::time_t tm2epoch(const struct tm* tm);
     static std::time_t epochToLocal(std::time_t utc);

--- a/Examples/Apps/Treadmill/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Header/ActivityWriter.hpp
@@ -122,8 +122,12 @@ public:
     void addLap(const LapData& lap);
     /// Emit the workout + workout_step messages describing a structured workout.
     void addWorkout(const char* name, const WorkoutStepData* steps, uint8_t count);
-    /// Finalize the current activity and persist its summary. Returns true only
-    /// if the FIT stream, its finish()/flush/close and the summary all succeed.
+    /// Finalize the current activity. The return value is the FIT-durability
+    /// contract: true iff the FIT stream + its finish()/flush/close succeeded, so
+    /// the .fit is safely on disk (the kernel auto-registers it on close, and
+    /// recoverInterrupted() re-registers after a crash). The auxiliary .json
+    /// summary is best-effort — a summary-only failure is logged but does NOT
+    /// flip the result, so it can never suppress the activity's registration.
     bool stop(const TrackData& track);
     void discard();
 

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/ActivityWriter.cpp
@@ -124,10 +124,10 @@ void ActivityWriter::start(const AppInfo& info)
     // Header + all definitions are on disk: flush and drop the recovery marker.
     // getPosition() here is a clean record boundary, so a crash after this point
     // is recoverable up to at least the header/definitions. Only write the
-    // marker when begin() succeeded: a failed begin() leaves a near-empty/broken
-    // .fit that the recovery marker must not point next boot's recover() at.
-    if (begun) {
-        mFile->flush();
+    // marker when begin() succeeded AND the initial flush is durable: a failed
+    // begin()/flush leaves a near-empty/broken or non-durable .fit that the
+    // recovery marker must not point next boot's recover() at.
+    if (begun && mFile->flush()) {
         mMarker.write(mFile->getPath(), static_cast<uint32_t>(mFile->getPosition()));
     }
 }
@@ -373,8 +373,11 @@ bool ActivityWriter::stop(const TrackData& track)
     // re-registers after a crash), so once `ok` is true the activity is never
     // orphaned. The .json summary is auxiliary/best-effort — recovery cannot
     // rebuild it — so a summary-only failure must NOT suppress registration.
-    // Attempt it, log on failure, but gate the return value on FIT durability.
-    if (!saveSummary(track)) {
+    // Attempt it ONLY when the FIT is durable (ok): with ok == false the marker
+    // is kept for next-boot recovery / the FIT is invalid, so a .json sidecar
+    // would misrepresent a non-durable activity. Log on failure; the return
+    // value is gated on FIT durability regardless.
+    if (ok && !saveSummary(track)) {
         LOG_ERROR("Activity summary (.json) save failed; FIT is durable and registered\n");
     }
     return ok;

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/ActivityWriter.cpp
@@ -368,8 +368,16 @@ bool ActivityWriter::stop(const TrackData& track)
         mMarker.remove();
     }
 
-    const bool summaryOk = saveSummary(track);
-    return ok && summaryOk;
+    // FIT durability IS the save-success contract: the kernel auto-registers the
+    // .fit the moment its FileGuard::close() fires (and recoverInterrupted()
+    // re-registers after a crash), so once `ok` is true the activity is never
+    // orphaned. The .json summary is auxiliary/best-effort — recovery cannot
+    // rebuild it — so a summary-only failure must NOT suppress registration.
+    // Attempt it, log on failure, but gate the return value on FIT durability.
+    if (!saveSummary(track)) {
+        LOG_ERROR("Activity summary (.json) save failed; FIT is durable and registered\n");
+    }
+    return ok;
 }
 
 void ActivityWriter::discard()

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/ActivityWriter.cpp
@@ -36,21 +36,25 @@ namespace {
 }  // namespace
 
 ActivityWriter::ActivityWriter(const SDK::Kernel& kernel, const char* pathToDir)
-    : mKernel(kernel), mPath(pathToDir)
+    : mKernel(kernel), mPath(pathToDir), mMarker(kernel.fs, pathToDir)
 {
     assert(pathToDir != nullptr);
 }
 
 void ActivityWriter::start(const AppInfo& info)
 {
-    mLapCounter = 0;
+    mLapCounter   = 0;
+    mLastFlushUtc = info.timestamp;
 
     if (!createAndOpenFile(info.timestamp)) {
         return;
     }
 
     mFit = std::make_unique<fit::FitWriter>(*mFile);
-    mFit->begin(/*profileVersion=*/0);
+    const bool begun = mFit->begin(/*profileVersion=*/0);
+    if (!begun) {
+        LOG_ERROR("Failed to write FIT header\n");
+    }
 
     // file_id
     mFit->defineMessage(L_FILE_ID, fit::mesgNum(fit::MesgNum::FileId),
@@ -116,6 +120,16 @@ void ActivityWriter::start(const AppInfo& info)
          fit::field::Activity::LocalTimestamp, fit::field::Activity::NumSessions});
 
     addMessageEvent(info.timestamp, fit::EventType::Start);
+
+    // Header + all definitions are on disk: flush and drop the recovery marker.
+    // getPosition() here is a clean record boundary, so a crash after this point
+    // is recoverable up to at least the header/definitions. Only write the
+    // marker when begin() succeeded: a failed begin() leaves a near-empty/broken
+    // .fit that the recovery marker must not point next boot's recover() at.
+    if (begun) {
+        mFile->flush();
+        mMarker.write(mFile->getPath(), static_cast<uint32_t>(mFile->getPosition()));
+    }
 }
 
 void ActivityWriter::defineRecordMessages()
@@ -218,6 +232,17 @@ void ActivityWriter::addRecord(const RecordData& record)
     d.u8(record.hrSource).u8(record.hrOpticalBpm).u8(record.hrExternalBpm);
 
     d.write();
+
+    // Periodic durability flush: sync to eMMC and advance the marker to this
+    // record boundary so a later crash recovers a record-complete file.
+    if (record.timestamp - mLastFlushUtc >= skFlushIntervalSec) {
+        // Only advance the marker when the flush durably landed; otherwise keep
+        // the previous good offset (never point recover() past non-durable data).
+        if (mFile->flush()) {
+            mMarker.update(static_cast<uint32_t>(mFile->getPosition()));
+            mLastFlushUtc = record.timestamp;
+        }
+    }
 }
 
 void ActivityWriter::addLap(const LapData& lap)
@@ -241,6 +266,13 @@ void ActivityWriter::addLap(const LapData& lap)
         .u16(lap.wktStepIndex)
         .write();
     mLapCounter++;
+
+    // Laps are sparse: flush and advance the marker, but only when the flush
+    // durably landed (else keep the previous good offset).
+    if (mFile->flush()) {
+        mMarker.update(static_cast<uint32_t>(mFile->getPosition()));
+        mLastFlushUtc = lap.timestamp;
+    }
 }
 
 void ActivityWriter::addWorkout(const char* name, const WorkoutStepData* steps, uint8_t count)
@@ -281,13 +313,15 @@ void ActivityWriter::addWorkout(const char* name, const WorkoutStepData* steps, 
     }
 }
 
-void ActivityWriter::stop(const TrackData& track)
+bool ActivityWriter::stop(const TrackData& track)
 {
     if (!mFit) {
-        return;
+        return false;
     }
 
-    mFit->data(L_SESSION)
+    bool ok = mFit->ok();
+
+    ok = mFit->data(L_SESSION)
         .u32(unixToFitTimestamp(track.timestamp))
         .u32(unixToFitTimestamp(track.timeStart))
         .u32(static_cast<uint32_t>(track.elapsed * 1000))
@@ -305,29 +339,43 @@ void ActivityWriter::stop(const TrackData& track)
         .u8(static_cast<uint8_t>(track.hrMax))
         // Developer field: estimated distance before Calibrate & Save (100 * m).
         .u32(static_cast<uint32_t>(track.distancePreCalibrationM * 100.0f))
-        .write();
+        .write() && ok;
 
-    mFit->data(L_ACTIVITY)
+    ok = mFit->data(L_ACTIVITY)
         .u32(unixToFitTimestamp(track.timestamp))
         .u32(static_cast<uint32_t>(track.duration * 1000))
         .u32(unixToFitTimestamp(epochToLocal(track.timestamp)))
         .u16(1)
-        .write();
+        .write() && ok;
 
-    mFit->finish();
+    const bool finishOk = mFit->finish();
+    if (!finishOk) {
+        LOG_ERROR("Failed to finalize FIT file\n");
+    }
+    ok = finishOk && mFit->ok() && ok;
     mFit.reset();
 
     if (mFile) {
-        mFile->flush();
-        mFile->close();
+        ok = mFile->flush() && ok;
+        ok = mFile->close() && ok;
+    } else {
+        ok = false;
     }
 
-    saveSummary(track);
+    // The .fit is durably finished on disk: drop the recovery marker so the
+    // next boot does not treat this activity as interrupted.
+    if (ok) {
+        mMarker.remove();
+    }
+
+    const bool summaryOk = saveSummary(track);
+    return ok && summaryOk;
 }
 
 void ActivityWriter::discard()
 {
     mFit.reset();
+    mMarker.remove();
     if (!mFile) {
         return;
     }
@@ -345,6 +393,19 @@ void ActivityWriter::addMessageEvent(std::time_t t, fit::EventType type)
         .u8(static_cast<uint8_t>(fit::Event::Timer))
         .u8(static_cast<uint8_t>(type))
         .write();
+}
+
+bool ActivityWriter::recoverInterrupted()
+{
+    // All marker I/O + FitWriter::recover() orchestration lives in the shared
+    // SDK::Fit::RecordingMarker. Recovery needs no sibling .json to register a
+    // recovered activity (the kernel's activity registry tracks .fit files
+    // only), so this is pure wiring.
+    const auto result = mMarker.recover();
+    if (result.recovered) {
+        LOG_INFO("Recovery: finalized interrupted activity [%s]\n", result.path.c_str());
+    }
+    return result.recovered;
 }
 
 bool ActivityWriter::createAndOpenFile(std::time_t utc)
@@ -378,10 +439,10 @@ bool ActivityWriter::createAndOpenFile(std::time_t utc)
     return true;
 }
 
-void ActivityWriter::saveSummary(const TrackData& track)
+bool ActivityWriter::saveSummary(const TrackData& track)
 {
     if (!mFile) {
-        return;
+        return false;
     }
     char buff[256]{};
     size_t nameLen = strlen(mFile->getPath());
@@ -390,8 +451,9 @@ void ActivityWriter::saveSummary(const TrackData& track)
     mFile->setPath(buff);
 
     if (!mFile->open(true, true)) {
+        LOG_ERROR("Failed to open activity summary [%s]\n", buff);
         mFile.reset();
-        return;
+        return false;
     }
 
     SDK::JsonStreamWriter writer(mFile.get());
@@ -404,8 +466,8 @@ void ActivityWriter::saveSummary(const TrackData& track)
     writer.add("activity_type", "treadmill");
     writer.endMap();
 
-    mFile->flush();
-    mFile->close();
+    const bool ok = mFile->flush();
+    return mFile->close() && ok;
 }
 
 std::time_t ActivityWriter::tm2epoch(const struct tm* tm)

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
@@ -117,6 +117,13 @@ void Service::run()
         LOG_WARNING("Failed to load activity summary\n");
     }
 
+    // Recover any activity a previous boot left unfinished (power loss /
+    // crash mid-recording), before any new track can start.
+    if (mActivityWriter.recoverInterrupted()) {
+        LOG_INFO("Recovered an interrupted activity\n");
+        notifyNewActivity();
+    }
+
     SDK::Timer guiInitTimeout(TIMER_SECONDS(5));
     guiInitTimeout.start();
 
@@ -1088,8 +1095,13 @@ void Service::finalizeActivity(float distanceActualM)
     }
     mGuiSender.summary(&mSummary);
 
-    mActivityWriter.stop(mPendingFitTrack);
-    notifyNewActivity();
+    if (mActivityWriter.stop(mPendingFitTrack)) {
+        notifyNewActivity();
+    } else {
+        LOG_ERROR("activity save failed\n");
+        // Do NOT notify: the .fit is left unfinished, so the crash-recovery
+        // marker (if any) stays for the next boot to finalize.
+    }
 
     mAwaitingCalibration = false;
     LOG_INFO("Activity finalised: dist %.1f m (calibrated=%d, deltaUpdated=%d)\n",

--- a/Examples/Apps/Workout/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Workout/Software/Libs/Header/ActivityWriter.hpp
@@ -89,8 +89,12 @@ public:
     void resume(std::time_t timestamp);
     void addRecord(const RecordData& record);
     void addLap(const LapData& lap);
-    /// Finalize the current activity and persist its summary. Returns true only
-    /// if the FIT stream, its finish()/flush/close and the summary all succeed.
+    /// Finalize the current activity. The return value is the FIT-durability
+    /// contract: true iff the FIT stream + its finish()/flush/close succeeded, so
+    /// the .fit is safely on disk (the kernel auto-registers it on close, and
+    /// recoverInterrupted() re-registers after a crash). The auxiliary .json
+    /// summary is best-effort — a summary-only failure is logged but does NOT
+    /// flip the result, so it can never suppress the activity's registration.
     bool stop(const TrackData& track);
     void discard();
 

--- a/Examples/Apps/Workout/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Workout/Software/Libs/Header/ActivityWriter.hpp
@@ -16,6 +16,7 @@
 #include "SDK/Kernel/Kernel.hpp"
 #include "SDK/Fit/FitProfile.hpp"
 #include "SDK/Fit/FitWriter.hpp"
+#include "SDK/Fit/RecordingMarker.hpp"
 
 /**
  * @class ActivityWriter
@@ -88,8 +89,19 @@ public:
     void resume(std::time_t timestamp);
     void addRecord(const RecordData& record);
     void addLap(const LapData& lap);
-    void stop(const TrackData& track);
+    /// Finalize the current activity and persist its summary. Returns true only
+    /// if the FIT stream, its finish()/flush/close and the summary all succeed.
+    bool stop(const TrackData& track);
     void discard();
+
+    /// Finalize an activity that a previous boot left unfinished (power loss /
+    /// crash mid-recording). If the recovery marker exists it names the torn
+    /// .fit and the last record-complete data-end offset; the file is finalized
+    /// via SDK::Fit::FitWriter::recover() and the marker is removed. Returns true
+    /// only when an interrupted activity was recovered into a valid FIT file.
+    /// Safe (returns false, no side effects) when no marker is present. Must run
+    /// before any new activity is started.
+    bool recoverInterrupted();
 
 private:
     /// Local message types (FIT record header, 0-15).
@@ -115,12 +127,17 @@ private:
         DF_HR_EXTERNAL      = 7,
     };
 
+    /// Flush + marker-refresh cadence during recording (seconds of record time).
+    static constexpr std::time_t skFlushIntervalSec = 30;
+
     const SDK::Kernel& mKernel;
     const char*        mPath = nullptr;
 
     std::unique_ptr<SDK::Interface::IFile> mFile = nullptr;
     std::unique_ptr<SDK::Fit::FitWriter>   mFit  = nullptr;
-    uint16_t mLapCounter = 0;
+    SDK::Fit::RecordingMarker              mMarker;   ///< Shared crash-recovery marker.
+    uint16_t    mLapCounter   = 0;
+    std::time_t mLastFlushUtc = 0;   ///< Record timestamp of the last durability flush.
 
     void defineRecordMessages();
     void writeFieldDescription(uint8_t devFieldNum, const char* name,
@@ -128,7 +145,7 @@ private:
     void addMessageEvent(std::time_t t, SDK::Fit::EventType type);
 
     bool createAndOpenFile(std::time_t utc);
-    void saveSummary(const TrackData& track);
+    bool saveSummary(const TrackData& track);
 
     static std::time_t tm2epoch(const struct tm* tm);
     static std::time_t epochToLocal(std::time_t utc);

--- a/Examples/Apps/Workout/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Workout/Software/Libs/Sources/ActivityWriter.cpp
@@ -106,10 +106,10 @@ void ActivityWriter::start(const AppInfo& info)
     // Header + all definitions are on disk: flush and drop the recovery marker.
     // getPosition() here is a clean record boundary, so a crash after this point
     // is recoverable up to at least the header/definitions. Only write the
-    // marker when begin() succeeded: a failed begin() leaves a near-empty/broken
-    // .fit that the recovery marker must not point next boot's recover() at.
-    if (begun) {
-        mFile->flush();
+    // marker when begin() succeeded AND the initial flush is durable: a failed
+    // begin()/flush leaves a near-empty/broken or non-durable .fit that the
+    // recovery marker must not point next boot's recover() at.
+    if (begun && mFile->flush()) {
         mMarker.write(mFile->getPath(), static_cast<uint32_t>(mFile->getPosition()));
     }
 }
@@ -289,8 +289,11 @@ bool ActivityWriter::stop(const TrackData& track)
     // re-registers after a crash), so once `ok` is true the activity is never
     // orphaned. The .json summary is auxiliary/best-effort — recovery cannot
     // rebuild it — so a summary-only failure must NOT suppress registration.
-    // Attempt it, log on failure, but gate the return value on FIT durability.
-    if (!saveSummary(track)) {
+    // Attempt it ONLY when the FIT is durable (ok): with ok == false the marker
+    // is kept for next-boot recovery / the FIT is invalid, so a .json sidecar
+    // would misrepresent a non-durable activity. Log on failure; the return
+    // value is gated on FIT durability regardless.
+    if (ok && !saveSummary(track)) {
         LOG_ERROR("Activity summary (.json) save failed; FIT is durable and registered\n");
     }
     return ok;

--- a/Examples/Apps/Workout/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Workout/Software/Libs/Sources/ActivityWriter.cpp
@@ -22,21 +22,25 @@ using Field = fit::FitWriter::Field;
 using DevFieldDef = fit::FitWriter::DevField;
 
 ActivityWriter::ActivityWriter(const SDK::Kernel& kernel, const char* pathToDir)
-    : mKernel(kernel), mPath(pathToDir)
+    : mKernel(kernel), mPath(pathToDir), mMarker(kernel.fs, pathToDir)
 {
     assert(pathToDir != nullptr);
 }
 
 void ActivityWriter::start(const AppInfo& info)
 {
-    mLapCounter = 0;
+    mLapCounter   = 0;
+    mLastFlushUtc = info.timestamp;
 
     if (!createAndOpenFile(info.timestamp)) {
         return;
     }
 
     mFit = std::make_unique<fit::FitWriter>(*mFile);
-    mFit->begin(/*profileVersion=*/0);
+    const bool begun = mFit->begin(/*profileVersion=*/0);
+    if (!begun) {
+        LOG_ERROR("Failed to write FIT header\n");
+    }
 
     // file_id
     mFit->defineMessage(L_FILE_ID, fit::mesgNum(fit::MesgNum::FileId),
@@ -98,6 +102,16 @@ void ActivityWriter::start(const AppInfo& info)
          fit::field::Activity::LocalTimestamp, fit::field::Activity::NumSessions});
 
     addMessageEvent(info.timestamp, fit::EventType::Start);
+
+    // Header + all definitions are on disk: flush and drop the recovery marker.
+    // getPosition() here is a clean record boundary, so a crash after this point
+    // is recoverable up to at least the header/definitions. Only write the
+    // marker when begin() succeeded: a failed begin() leaves a near-empty/broken
+    // .fit that the recovery marker must not point next boot's recover() at.
+    if (begun) {
+        mFile->flush();
+        mMarker.write(mFile->getPath(), static_cast<uint32_t>(mFile->getPosition()));
+    }
 }
 
 void ActivityWriter::defineRecordMessages()
@@ -180,6 +194,17 @@ void ActivityWriter::addRecord(const RecordData& record)
     d.u8(record.hrSource).u8(record.hrOpticalBpm).u8(record.hrExternalBpm);
 
     d.write();
+
+    // Periodic durability flush: sync to eMMC and advance the marker to this
+    // record boundary so a later crash recovers a record-complete file.
+    if (record.timestamp - mLastFlushUtc >= skFlushIntervalSec) {
+        // Only advance the marker when the flush durably landed; otherwise keep
+        // the previous good offset (never point recover() past non-durable data).
+        if (mFile->flush()) {
+            mMarker.update(static_cast<uint32_t>(mFile->getPosition()));
+            mLastFlushUtc = record.timestamp;
+        }
+    }
 }
 
 void ActivityWriter::addLap(const LapData& lap)
@@ -200,15 +225,24 @@ void ActivityWriter::addLap(const LapData& lap)
         .u16(static_cast<uint16_t>(lap.restingCalories + 0.5f))
         .write();
     mLapCounter++;
+
+    // Laps are sparse: flush and advance the marker, but only when the flush
+    // durably landed (else keep the previous good offset).
+    if (mFile->flush()) {
+        mMarker.update(static_cast<uint32_t>(mFile->getPosition()));
+        mLastFlushUtc = lap.timestamp;
+    }
 }
 
-void ActivityWriter::stop(const TrackData& track)
+bool ActivityWriter::stop(const TrackData& track)
 {
     if (!mFit) {
-        return;
+        return false;
     }
 
-    mFit->data(L_SESSION)
+    bool ok = mFit->ok();
+
+    ok = mFit->data(L_SESSION)
         .u32(unixToFitTimestamp(track.timestamp))
         .u32(unixToFitTimestamp(track.timeStart))
         .u32(static_cast<uint32_t>(track.elapsed * 1000))
@@ -221,29 +255,43 @@ void ActivityWriter::stop(const TrackData& track)
         .u8(static_cast<uint8_t>(track.hrMax))
         .u16(static_cast<uint16_t>(track.calories + 0.5f))
         .u16(static_cast<uint16_t>(track.metabolicCalories + 0.5f))
-        .write();
+        .write() && ok;
 
-    mFit->data(L_ACTIVITY)
+    ok = mFit->data(L_ACTIVITY)
         .u32(unixToFitTimestamp(track.timestamp))
         .u32(static_cast<uint32_t>(track.duration * 1000))
         .u32(unixToFitTimestamp(epochToLocal(track.timestamp)))
         .u16(1)
-        .write();
+        .write() && ok;
 
-    mFit->finish();
+    const bool finishOk = mFit->finish();
+    if (!finishOk) {
+        LOG_ERROR("Failed to finalize FIT file\n");
+    }
+    ok = finishOk && mFit->ok() && ok;
     mFit.reset();
 
     if (mFile) {
-        mFile->flush();
-        mFile->close();
+        ok = mFile->flush() && ok;
+        ok = mFile->close() && ok;
+    } else {
+        ok = false;
     }
 
-    saveSummary(track);
+    // The .fit is durably finished on disk: drop the recovery marker so the
+    // next boot does not treat this activity as interrupted.
+    if (ok) {
+        mMarker.remove();
+    }
+
+    const bool summaryOk = saveSummary(track);
+    return ok && summaryOk;
 }
 
 void ActivityWriter::discard()
 {
     mFit.reset();
+    mMarker.remove();
     if (!mFile) {
         return;
     }
@@ -261,6 +309,19 @@ void ActivityWriter::addMessageEvent(std::time_t t, fit::EventType type)
         .u8(static_cast<uint8_t>(fit::Event::Timer))
         .u8(static_cast<uint8_t>(type))
         .write();
+}
+
+bool ActivityWriter::recoverInterrupted()
+{
+    // All marker I/O + FitWriter::recover() orchestration lives in the shared
+    // SDK::Fit::RecordingMarker. Recovery needs no sibling .json to register a
+    // recovered activity (the kernel's activity registry tracks .fit files
+    // only), so this is pure wiring.
+    const auto result = mMarker.recover();
+    if (result.recovered) {
+        LOG_INFO("Recovery: finalized interrupted activity [%s]\n", result.path.c_str());
+    }
+    return result.recovered;
 }
 
 bool ActivityWriter::createAndOpenFile(std::time_t utc)
@@ -294,10 +355,10 @@ bool ActivityWriter::createAndOpenFile(std::time_t utc)
     return true;
 }
 
-void ActivityWriter::saveSummary(const TrackData& track)
+bool ActivityWriter::saveSummary(const TrackData& track)
 {
     if (!mFile) {
-        return;
+        return false;
     }
     char buff[256]{};
     size_t nameLen = strlen(mFile->getPath());
@@ -306,8 +367,9 @@ void ActivityWriter::saveSummary(const TrackData& track)
     mFile->setPath(buff);
 
     if (!mFile->open(true, true)) {
+        LOG_ERROR("Failed to open activity summary [%s]\n", buff);
         mFile.reset();
-        return;
+        return false;
     }
 
     SDK::JsonStreamWriter writer(mFile.get());
@@ -318,8 +380,8 @@ void ActivityWriter::saveSummary(const TrackData& track)
     writer.add("activity_type", "workout");
     writer.endMap();
 
-    mFile->flush();
-    mFile->close();
+    const bool ok = mFile->flush();
+    return mFile->close() && ok;
 }
 
 std::time_t ActivityWriter::tm2epoch(const struct tm* tm)

--- a/Examples/Apps/Workout/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Workout/Software/Libs/Sources/ActivityWriter.cpp
@@ -284,8 +284,16 @@ bool ActivityWriter::stop(const TrackData& track)
         mMarker.remove();
     }
 
-    const bool summaryOk = saveSummary(track);
-    return ok && summaryOk;
+    // FIT durability IS the save-success contract: the kernel auto-registers the
+    // .fit the moment its FileGuard::close() fires (and recoverInterrupted()
+    // re-registers after a crash), so once `ok` is true the activity is never
+    // orphaned. The .json summary is auxiliary/best-effort — recovery cannot
+    // rebuild it — so a summary-only failure must NOT suppress registration.
+    // Attempt it, log on failure, but gate the return value on FIT durability.
+    if (!saveSummary(track)) {
+        LOG_ERROR("Activity summary (.json) save failed; FIT is durable and registered\n");
+    }
+    return ok;
 }
 
 void ActivityWriter::discard()

--- a/Examples/Apps/Workout/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Workout/Software/Libs/Sources/Service.cpp
@@ -91,6 +91,13 @@ void Service::run()
         LOG_WARNING("Failed to load activity summary\n");
     }
 
+    // Recover any activity a previous boot left unfinished (power loss /
+    // crash mid-recording), before any new track can start.
+    if (mActivityWriter.recoverInterrupted()) {
+        LOG_INFO("Recovered an interrupted activity\n");
+        notifyNewActivity();
+    }
+
     SDK::Timer guiInitTimeout(TIMER_SECONDS(5));
     guiInitTimeout.start();
 
@@ -807,9 +814,13 @@ void Service::stopTrack(bool discard)
         fitTrack.calories           = mTrackData.totalCalories;
         fitTrack.metabolicCalories  = mTrackData.restingCaloriesTotal;
 
-        mActivityWriter.stop(fitTrack);
-
-        notifyNewActivity();
+        if (mActivityWriter.stop(fitTrack)) {
+            notifyNewActivity();
+        } else {
+            LOG_ERROR("activity save failed\n");
+            // Do NOT notify: the .fit is left unfinished, so the crash-recovery
+            // marker (if any) stays for the next boot to finalize.
+        }
     } else {
         mActivityWriter.discard();
     }

--- a/Libs/Header/SDK/Fit/FitWriter.hpp
+++ b/Libs/Header/SDK/Fit/FitWriter.hpp
@@ -112,7 +112,35 @@ public:
 
     bool ok() const { return mOk; }
 
+    /// Recover a FIT file that was streamed but never finish()ed (e.g. power
+    /// loss mid-activity), turning it into a complete, CRC-valid file.
+    ///
+    /// Opens @p file read/write WITHOUT truncation, so a torn file is never
+    /// destroyed. If the on-disk header already describes a finalized file
+    /// (non-zero data-size field and a total size of 14 + dataSize + 2), the
+    /// file is already good and is left untouched (idempotent no-op -> true).
+    /// Otherwise it is finalized: the header data size + header CRC are
+    /// back-patched, the file CRC is recomputed by reading the bytes back, the
+    /// CRC is appended, and any torn/garbage tail past @p dataEnd is trimmed.
+    ///
+    /// @p dataEnd is the byte offset one-past the last complete, flushed data
+    /// record. It is supplied by the caller (recover() does not parse FIT
+    /// records -- it trusts @p dataEnd as a record boundary) and must satisfy
+    /// 14 <= dataEnd <= file.size(). Returns false WITHOUT modifying the file on
+    /// a bad/non-FIT header or an out-of-range @p dataEnd.
+    static bool recover(SDK::Interface::IFile& file, uint32_t dataEnd);
+
 private:
+    /// Shared finalization tail used by both finish() and recover(): read the
+    /// on-disk 14-byte header (so protocol/profile survive a reboot), validate
+    /// it, back-patch the data size + header CRC, compute the file CRC over
+    /// [0, dataEnd) by reading the bytes back, append it little-endian at
+    /// dataEnd, and truncate to dataEnd + 2 (dropping any torn tail). Manages
+    /// the file's open mode internally (write handles cannot read). Returns
+    /// false WITHOUT corrupting the file on a bad header or out-of-range
+    /// dataEnd. Requires 14 <= dataEnd <= file.size().
+    static bool finalize(SDK::Interface::IFile& file, uint32_t dataEnd);
+
     bool emitData(uint8_t localType, const std::vector<uint8_t>& payload);
     bool writeBytes(const void* p, size_t n);
 

--- a/Libs/Header/SDK/Fit/RecordingMarker.hpp
+++ b/Libs/Header/SDK/Fit/RecordingMarker.hpp
@@ -1,0 +1,85 @@
+/**
+ ******************************************************************************
+ * @file    RecordingMarker.hpp
+ * @brief   Crash-recovery marker for an in-progress FIT recording.
+ *
+ * An activity's .fit filename encodes its start time, which the next boot does
+ * not know, so a torn recording cannot be located after a power loss from the
+ * filename alone. This marker is a single fixed-path file, one per activity
+ * directory, holding the path of the currently-recording .fit and the byte
+ * offset one-past the last record-complete, flushed data record. Together they
+ * let the next boot find the interrupted file and finalize it at a clean record
+ * boundary via SDK::Fit::FitWriter::recover().
+ *
+ * The on-disk format is deliberately trivial and robust: the .fit path on the
+ * first line, the decimal offset on the second.
+ *
+ * write()/update() are crash-atomic: the new marker is staged to a ".tmp"
+ * sibling (flushed + closed) and then published by rotating the previous good
+ * primary to a ".bak" and renaming the temp into place. A crash at any point
+ * leaves either the new primary or the previous ".bak" fully intact, so read()
+ * never gets a torn/empty marker that would orphan a recoverable .fit; it falls
+ * back to the ".bak" (a slightly older but still record-aligned, durable
+ * offset). Mirrors Settings::ManagerBase's proven rotate sequence.
+ *
+ * All logic here is activity/app independent -- it is parameterized only by an
+ * IFileSystem and the activity directory -- so every FIT-writing app reuses the
+ * same marker I/O and the same one-call recover orchestration.
+ ******************************************************************************
+ */
+
+#ifndef __SDK_FIT_RECORDING_MARKER_HPP
+#define __SDK_FIT_RECORDING_MARKER_HPP
+
+#include "SDK/Interfaces/IFileSystem.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace SDK::Fit {
+
+class RecordingMarker {
+public:
+    /// Fixed marker file name, placed inside the activity directory.
+    static constexpr const char* kFileName = ".recording";
+
+    /// Result of a recover() attempt.
+    struct RecoverResult {
+        bool        recovered = false;  ///< true iff an interrupted .fit was finalized
+        std::string path;               ///< the recovered .fit path (valid iff recovered)
+    };
+
+    /// @param fs           File system used to read/write the marker + .fit.
+    /// @param activityDir  Directory the marker lives in (e.g. "Activity").
+    RecordingMarker(SDK::Interface::IFileSystem& fs, const char* activityDir);
+
+    /// (Re)write the marker = { fitPath, offset }. Remembers @p fitPath so
+    /// later update() calls need only the new offset. Flushed before return.
+    bool write(const char* fitPath, uint32_t offset);
+
+    /// Rewrite the marker keeping the .fit path from the last write(), moving
+    /// only the offset. Fails if write() was never called.
+    bool update(uint32_t offset);
+
+    /// Read the marker into @p fitPath / @p offset. Returns false when the
+    /// marker is absent or unreadable.
+    bool read(std::string& fitPath, uint32_t& offset) const;
+
+    /// Delete the marker (no-op if absent).
+    void remove();
+
+    /// Full recover orchestration: if the marker exists, open the .fit it names
+    /// and finalize it via FitWriter::recover(file, offset). The marker is
+    /// ALWAYS removed afterwards (recovery is one-shot; give up cleanly on a
+    /// missing file or a failed recover). Safe to call with no marker present.
+    RecoverResult recover();
+
+private:
+    SDK::Interface::IFileSystem& mFs;
+    std::string                  mMarkerPath;   ///< "<activityDir>/.recording"
+    std::string                  mActiveFitPath;///< last path passed to write()
+};
+
+}  // namespace SDK::Fit
+
+#endif  // __SDK_FIT_RECORDING_MARKER_HPP

--- a/Libs/Source/Fit/FitWriter.cpp
+++ b/Libs/Source/Fit/FitWriter.cpp
@@ -268,8 +268,14 @@ bool FitWriter::finish()
 
 bool FitWriter::recover(SDK::Interface::IFile& file, uint32_t dataEnd)
 {
-    // Open read/write WITHOUT truncation so a torn file is preserved.
-    if (!file.open(/*wMode=*/true, /*override=*/false)) {
+    // Inspect the file READ-ONLY first. A non-truncating WRITE open (wMode=true,
+    // override=false) maps to FatFs FA_OPEN_ALWAYS, which CREATES a missing path
+    // -- leaving a stray 0-byte .fit and violating the public "does not modify
+    // the file on bad input" contract. A read open never creates or writes, so a
+    // missing/too-short/non-FIT path is rejected untouched. We only open for
+    // write inside finalize(), and only after confirming this is a genuine crash
+    // marker (dataSize == 0). A torn file is thus preserved either way.
+    if (!file.open(/*wMode=*/false)) {
         return false;
     }
     const size_t fileSize = file.size();
@@ -285,11 +291,7 @@ bool FitWriter::recover(SDK::Interface::IFile& file, uint32_t dataEnd)
     // trailing bytes): re-finalizing here would rewrite the header/CRC at the
     // MARKER's older crash-time dataEnd, discarding the session/activity
     // messages that finish() appended past it -- a far worse outcome than a
-    // handful of harmless trailing bytes. Inspect the header in read mode (a
-    // write handle cannot read).
-    if (!file.close() || !file.open(/*wMode=*/false)) {
-        return false;
-    }
+    // handful of harmless trailing bytes.
     if (fileSize >= kHeaderSize) {
         uint8_t hdr[kHeaderSize];
         if (readExact(file, hdr, sizeof(hdr)) && hdr[0] == kHeaderSize

--- a/Libs/Source/Fit/FitWriter.cpp
+++ b/Libs/Source/Fit/FitWriter.cpp
@@ -273,42 +273,58 @@ bool FitWriter::recover(SDK::Interface::IFile& file, uint32_t dataEnd)
     // -- leaving a stray 0-byte .fit and violating the public "does not modify
     // the file on bad input" contract. A read open never creates or writes, so a
     // missing/too-short/non-FIT path is rejected untouched. We only open for
-    // write inside finalize(), and only after confirming this is a genuine crash
-    // marker (dataSize == 0). A torn file is thus preserved either way.
+    // write inside finalize().
     if (!file.open(/*wMode=*/false)) {
         return false;
     }
     const size_t fileSize = file.size();
 
-    // Idempotent guard: if the on-disk header already carries a non-zero
-    // dataSize, then finish()/finalize() has already run and back-patched it, so
-    // the file is already finalized. Return true WITHOUT calling finalize()
-    // again. Only a genuine crash marker leaves dataSize == 0 (begin() writes a
-    // zero placeholder), so that is the sole case we finalize.
-    //
-    // This must hold even when the total size does not exactly equal
-    // header + data + CRC (e.g. an isolated truncate() failure left a few
-    // trailing bytes): re-finalizing here would rewrite the header/CRC at the
-    // MARKER's older crash-time dataEnd, discarding the session/activity
-    // messages that finish() appended past it -- a far worse outcome than a
-    // handful of harmless trailing bytes.
-    if (fileSize >= kHeaderSize) {
-        uint8_t hdr[kHeaderSize];
-        if (readExact(file, hdr, sizeof(hdr)) && hdr[0] == kHeaderSize
-            && hdr[8] == '.' && hdr[9] == 'F' && hdr[10] == 'I' && hdr[11] == 'T') {
-            const uint32_t dataSize =
-                static_cast<uint32_t>(hdr[4]) | (static_cast<uint32_t>(hdr[5]) << 8)
-                | (static_cast<uint32_t>(hdr[6]) << 16)
-                | (static_cast<uint32_t>(hdr[7]) << 24);
-            if (dataSize != 0) {
-                file.close();
-                return true;  // already finalized -- do not re-finalize
-            }
-        }
+    // Read + validate the on-disk header. A missing/too-short/non-FIT path is
+    // rejected here, untouched.
+    uint8_t hdr[kHeaderSize];
+    if (fileSize < kHeaderSize || !readExact(file, hdr, sizeof(hdr))
+        || hdr[0] != kHeaderSize || hdr[8] != '.' || hdr[9] != 'F'
+        || hdr[10] != 'I' || hdr[11] != 'T') {
+        file.close();
+        return false;
     }
+    const uint32_t hdrDataSize =
+        static_cast<uint32_t>(hdr[4]) | (static_cast<uint32_t>(hdr[5]) << 8)
+        | (static_cast<uint32_t>(hdr[6]) << 16)
+        | (static_cast<uint32_t>(hdr[7]) << 24);
     file.close();
 
-    return finalize(file, dataEnd);
+    // Derive the effective data-end and ALWAYS re-run the (idempotent)
+    // finalize(). We must NOT early-return "already finalized" on dataSize != 0:
+    // finish()/finalize() flush the header (with dataSize) BEFORE writing and
+    // flushing the trailing CRC and truncating the tail. A crash in that window
+    // leaves dataSize != 0 but a missing/torn CRC -- skipping repair would leave
+    // an invalid FIT on disk forever. Re-finalizing is harmless because
+    // finalize() recomputes the same header/CRC and truncates to the same size.
+    //
+    //  - hdrDataSize != 0 (and it fits within the file): trust the header's own
+    //    dataSize -- finish()/a prior finalize got far enough to write it, so
+    //    this is the DURABLE data end, not the possibly-stale marker offset.
+    //    Finalizing here writes the correct CRC (crash-mid-finalize) and trims
+    //    any extra tail (isolated truncate() failure) WITHOUT discarding the
+    //    session/activity messages finish() appended past the marker.
+    //  - otherwise: use the caller/marker offset -- the genuine crash-mid-
+    //    recording case where dataSize is still 0, or a fallback if the header
+    //    over-claims vs the actual file size.
+    uint32_t effectiveEnd;
+    if (hdrDataSize != 0
+        && static_cast<uint64_t>(kHeaderSize) + hdrDataSize <= fileSize) {
+        effectiveEnd = kHeaderSize + hdrDataSize;
+    } else {
+        effectiveEnd = dataEnd;
+    }
+
+    // Guard: the effective data range must lie within the file.
+    if (effectiveEnd < kHeaderSize || effectiveEnd > fileSize) {
+        return false;
+    }
+
+    return finalize(file, effectiveEnd);
 }
 
 // --- Data builder -----------------------------------------------------------

--- a/Libs/Source/Fit/FitWriter.cpp
+++ b/Libs/Source/Fit/FitWriter.cpp
@@ -136,6 +136,116 @@ bool FitWriter::emitData(uint8_t localType, const std::vector<uint8_t>& payload)
     return writeBytes(rec.data(), rec.size());
 }
 
+namespace {
+    // Read exactly `n` bytes from a read-mode handle into `dst`. Returns false
+    // on any short read / IO error.
+    bool readExact(SDK::Interface::IFile& file, void* dst, size_t n)
+    {
+        auto*  p         = static_cast<char*>(dst);
+        size_t remaining = n;
+        while (remaining > 0) {
+            size_t got = 0;
+            if (!file.read(p, remaining, got) || got == 0) {
+                return false;
+            }
+            p         += got;
+            remaining -= got;
+        }
+        return true;
+    }
+}  // namespace
+
+bool FitWriter::finalize(SDK::Interface::IFile& file, uint32_t dataEnd)
+{
+    // --- Read the on-disk header (read mode) --------------------------------
+    // Protocol/profile MUST come from the file, not writer member state, so a
+    // reboot-time recover() reconstructs the correct header. A write-mode
+    // handle cannot read, so ensure we are in read mode first.
+    file.close();  // start from a known-closed handle (no-op if already closed)
+    if (!file.open(/*wMode=*/false)) {
+        return false;
+    }
+    uint8_t hdr[kHeaderSize];
+    if (!readExact(file, hdr, sizeof(hdr))) {
+        file.close();
+        return false;
+    }
+    const size_t fileSize = file.size();
+
+    // Validate: header size byte + ".FIT" signature.
+    if (hdr[0] != kHeaderSize || hdr[8] != '.' || hdr[9] != 'F'
+        || hdr[10] != 'I' || hdr[11] != 'T') {
+        file.close();
+        return false;
+    }
+    // Guard: the claimed data range must lie within the file.
+    if (dataEnd < kHeaderSize || dataEnd > fileSize) {
+        file.close();
+        return false;
+    }
+    const uint8_t  protocolVersion = hdr[1];
+    const uint16_t profileVersion =
+        static_cast<uint16_t>(hdr[2] | (static_cast<uint16_t>(hdr[3]) << 8));
+
+    // --- Back-patch the header (write mode, non-truncating) -----------------
+    // override=false must map to a non-truncating open (e.g. FatFs
+    // FA_OPEN_ALWAYS — NOT FA_CREATE_ALWAYS); a truncating backend would zero
+    // the activity here.
+    if (!file.close() || !file.open(/*wMode=*/true, /*override=*/false)) {
+        return false;
+    }
+    uint8_t patched[kHeaderSize];
+    buildHeader(patched, protocolVersion, profileVersion,
+                dataEnd - kHeaderSize, /*withCrc=*/true);
+    size_t bw = 0;
+    if (!file.seek(0)
+        || !file.write(reinterpret_cast<const char*>(patched), sizeof(patched), bw)
+        || bw != sizeof(patched)) {
+        file.close();
+        return false;
+    }
+    file.flush();
+
+    // --- Compute the file CRC over [0, dataEnd) (read mode) -----------------
+    if (!file.close() || !file.open(/*wMode=*/false)) {
+        return false;
+    }
+    uint16_t crc       = 0;
+    size_t   remaining = dataEnd;
+    char     buf[256];
+    while (remaining > 0) {
+        const size_t want = remaining < sizeof(buf) ? remaining : sizeof(buf);
+        size_t       got  = 0;
+        if (!file.read(buf, want, got) || got == 0) {
+            file.close();
+            return false;
+        }
+        crc = fitCrcUpdate(crc, buf, got);
+        remaining -= got;
+    }
+
+    // --- Append the CRC + trim any torn tail (write mode) -------------------
+    if (!file.close() || !file.open(/*wMode=*/true, /*override=*/false)) {
+        return false;
+    }
+    uint8_t crcLE[2] = {static_cast<uint8_t>(crc & 0xFFu),
+                        static_cast<uint8_t>((crc >> 8) & 0xFFu)};
+    bw = 0;
+    if (!file.seek(dataEnd)
+        || !file.write(reinterpret_cast<const char*>(crcLE), sizeof(crcLE), bw)
+        || bw != sizeof(crcLE)) {
+        file.close();
+        return false;
+    }
+    // Drop any partially-written record beyond the recovered data + CRC.
+    if (!file.truncate(dataEnd + 2)) {
+        file.close();
+        return false;
+    }
+    file.flush();
+    return true;
+}
+
 bool FitWriter::finish()
 {
     if (!mOk || !mBegun) {
@@ -148,52 +258,55 @@ bool FitWriter::finish()
         mOk = false;
         return false;
     }
-    const uint32_t dataSize = static_cast<uint32_t>(end - kHeaderSize);
-
-    // Back-patch the header in place (data size + header CRC over bytes 0..11).
-    uint8_t hdr[14];
-    buildHeader(hdr, mProtocolVersion, mProfileVersion, dataSize, /*withCrc=*/true);
-    if (!mFile.seek(0) || !writeBytes(hdr, sizeof(hdr))) {
+    // getPosition() after the final record is the current data-end offset.
+    if (!finalize(mFile, static_cast<uint32_t>(end))) {
         mOk = false;
         return false;
     }
-    mFile.flush();
-
-    // Compute the file CRC over header + data by reading the file back (a
-    // write-mode handle cannot read, so reopen read-only), then append it.
-    if (!mFile.close() || !mFile.open(/*wMode=*/false)) {
-        mOk = false;
-        return false;
-    }
-    uint16_t crc = 0;
-    size_t   remaining = end;
-    char     buf[256];
-    while (remaining > 0) {
-        const size_t want = remaining < sizeof(buf) ? remaining : sizeof(buf);
-        size_t got = 0;
-        if (!mFile.read(buf, want, got) || got == 0) {
-            mOk = false;
-            return false;
-        }
-        crc = fitCrcUpdate(crc, buf, got);
-        remaining -= got;
-    }
-    // Reopen for write WITHOUT truncating (override=false must map to a
-    // non-truncating open, e.g. FatFs FA_OPEN_ALWAYS — NOT FA_CREATE_ALWAYS),
-    // then append the CRC at the end. A truncating backend would zero the
-    // activity here.
-    if (!mFile.close() || !mFile.open(/*wMode=*/true, /*override=*/false)) {
-        mOk = false;
-        return false;
-    }
-    uint8_t crcLE[2] = {static_cast<uint8_t>(crc & 0xFFu),
-                        static_cast<uint8_t>((crc >> 8) & 0xFFu)};
-    if (!mFile.seek(end) || !writeBytes(crcLE, sizeof(crcLE))) {
-        mOk = false;
-        return false;
-    }
-    mFile.flush();
     return mOk;
+}
+
+bool FitWriter::recover(SDK::Interface::IFile& file, uint32_t dataEnd)
+{
+    // Open read/write WITHOUT truncation so a torn file is preserved.
+    if (!file.open(/*wMode=*/true, /*override=*/false)) {
+        return false;
+    }
+    const size_t fileSize = file.size();
+
+    // Idempotent guard: if the on-disk header already carries a non-zero
+    // dataSize, then finish()/finalize() has already run and back-patched it, so
+    // the file is already finalized. Return true WITHOUT calling finalize()
+    // again. Only a genuine crash marker leaves dataSize == 0 (begin() writes a
+    // zero placeholder), so that is the sole case we finalize.
+    //
+    // This must hold even when the total size does not exactly equal
+    // header + data + CRC (e.g. an isolated truncate() failure left a few
+    // trailing bytes): re-finalizing here would rewrite the header/CRC at the
+    // MARKER's older crash-time dataEnd, discarding the session/activity
+    // messages that finish() appended past it -- a far worse outcome than a
+    // handful of harmless trailing bytes. Inspect the header in read mode (a
+    // write handle cannot read).
+    if (!file.close() || !file.open(/*wMode=*/false)) {
+        return false;
+    }
+    if (fileSize >= kHeaderSize) {
+        uint8_t hdr[kHeaderSize];
+        if (readExact(file, hdr, sizeof(hdr)) && hdr[0] == kHeaderSize
+            && hdr[8] == '.' && hdr[9] == 'F' && hdr[10] == 'I' && hdr[11] == 'T') {
+            const uint32_t dataSize =
+                static_cast<uint32_t>(hdr[4]) | (static_cast<uint32_t>(hdr[5]) << 8)
+                | (static_cast<uint32_t>(hdr[6]) << 16)
+                | (static_cast<uint32_t>(hdr[7]) << 24);
+            if (dataSize != 0) {
+                file.close();
+                return true;  // already finalized -- do not re-finalize
+            }
+        }
+    }
+    file.close();
+
+    return finalize(file, dataEnd);
 }
 
 // --- Data builder -----------------------------------------------------------

--- a/Libs/Source/Fit/RecordingMarker.cpp
+++ b/Libs/Source/Fit/RecordingMarker.cpp
@@ -1,0 +1,183 @@
+/**
+ ******************************************************************************
+ * @file    RecordingMarker.cpp
+ * @brief   Crash-recovery marker for an in-progress FIT recording.
+ ******************************************************************************
+ */
+
+#include "SDK/Fit/RecordingMarker.hpp"
+
+#include "SDK/Fit/FitWriter.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace SDK::Fit {
+
+namespace {
+    // Sibling suffixes for the crash-atomic rotate (see write()).
+    constexpr const char* kTmpSuffix = ".tmp";
+    constexpr const char* kBakSuffix = ".bak";
+
+    // A sibling path is the marker path plus a 4-char suffix; size the fixed
+    // buffer for the longest possible marker path plus room for the suffix + NUL
+    // so we never allocate/grow a std::string on the hot flush path.
+    constexpr size_t kSiblingBufLen = SDK::Interface::IFileSystem::skMaxPathLen + 8;
+
+    // Build "<base><suffix>" into a fixed buffer (no heap).
+    void makeSiblingPath(char* out, size_t outSize, const char* base, const char* suffix)
+    {
+        snprintf(out, outSize, "%s%s", base, suffix);
+    }
+
+    // Read + parse one marker file (path on line 1, decimal offset on line 2).
+    // Returns false when the file is absent, unreadable, empty (torn), or
+    // unparseable -- the caller then falls back to the .bak copy.
+    bool readMarkerFile(SDK::Interface::IFileSystem& fs, const char* path,
+                        std::string& fitPath, uint32_t& offset)
+    {
+        auto marker = fs.file(path);
+        if (!marker || !marker->exist() || !marker->open(/*wMode=*/false)) {
+            return false;
+        }
+
+        char   buff[SDK::Interface::IFileSystem::skMaxPathLen + 16]{};
+        size_t br = 0;
+        const bool ok = marker->read(buff, sizeof(buff) - 1, br);
+        marker->close();
+        if (!ok || br == 0) {
+            return false;
+        }
+        buff[br] = '\0';
+
+        const char* nl = std::strchr(buff, '\n');
+        if (nl == nullptr) {
+            return false;
+        }
+        fitPath.assign(buff, static_cast<size_t>(nl - buff));
+        offset = static_cast<uint32_t>(std::strtoul(nl + 1, nullptr, 10));
+        return !fitPath.empty();
+    }
+}  // namespace
+
+RecordingMarker::RecordingMarker(SDK::Interface::IFileSystem& fs, const char* activityDir)
+    : mFs(fs)
+    , mMarkerPath(std::string(activityDir != nullptr ? activityDir : "") + "/" + kFileName)
+{
+}
+
+bool RecordingMarker::write(const char* fitPath, uint32_t offset)
+{
+    mActiveFitPath = fitPath != nullptr ? fitPath : "";
+
+    char tmpPath[kSiblingBufLen];
+    char bakPath[kSiblingBufLen];
+    makeSiblingPath(tmpPath, sizeof(tmpPath), mMarkerPath.c_str(), kTmpSuffix);
+    makeSiblingPath(bakPath, sizeof(bakPath), mMarkerPath.c_str(), kBakSuffix);
+
+    // 1) Write the new marker to a temp sibling, flush + close. This truncating
+    //    open only ever touches the temp, so a crash in the truncate->flush
+    //    window can never damage the live primary -- the old good copy (or its
+    //    .bak) survives untouched. Mirrors Settings::ManagerBase::write().
+    auto tmp = mFs.file(tmpPath);
+    if (!tmp || !tmp->open(/*wMode=*/true, /*override=*/true)) {
+        return false;
+    }
+
+    // Trivial line-based format: .fit path on line 1, decimal offset on line 2.
+    char      buff[SDK::Interface::IFileSystem::skMaxPathLen + 16]{};
+    const int len = snprintf(buff, sizeof(buff), "%s\n%u\n", mActiveFitPath.c_str(), offset);
+    if (len <= 0) {
+        tmp->close();
+        return false;
+    }
+    // Defensive clamp: on truncation of an over-long path snprintf returns the
+    // would-be length, which can exceed the buffer -- never write past it.
+    const size_t writeLen =
+        static_cast<size_t>(len) < sizeof(buff) ? static_cast<size_t>(len) : sizeof(buff) - 1;
+
+    size_t bw = 0;
+    bool   ok = tmp->write(buff, writeLen, bw) && bw == writeLen;
+    ok        = tmp->flush() && ok;   // the marker's own durability point
+    tmp->close();
+    if (!ok) {
+        mFs.remove(tmpPath);
+        return false;
+    }
+
+    // 2) Publish atomically. Keep a good copy present at every crash point.
+    if (mFs.exist(mMarkerPath.c_str())) {
+        // Normal update: rotate the current good primary to .bak (FatFs rename
+        // fails onto an existing target, so clear any stale .bak first), then
+        // promote the temp. A crash after the rotate but before the promote
+        // leaves .bak = old good, recovered by read()'s fallback.
+        if (mFs.exist(bakPath)) {
+            mFs.remove(bakPath);
+        }
+        mFs.rename(mMarkerPath.c_str(), bakPath);          // primary -> .bak
+        return mFs.rename(tmpPath, mMarkerPath.c_str());   // temp -> primary
+    }
+
+    // First write (no primary to rotate): promote the temp directly. Any
+    // existing .bak is left in place so a valid copy stays present right up to
+    // the atomic promote.
+    return mFs.rename(tmpPath, mMarkerPath.c_str());
+}
+
+bool RecordingMarker::update(uint32_t offset)
+{
+    if (mActiveFitPath.empty()) {
+        return false;
+    }
+    return write(mActiveFitPath.c_str(), offset);
+}
+
+bool RecordingMarker::read(std::string& fitPath, uint32_t& offset) const
+{
+    // Primary first; if it is missing or torn (0 bytes / unparseable after a
+    // crash mid-publish), fall back to the .bak. A recovered .bak offset is a
+    // slightly older (previous-flush) but still record-aligned, durable offset
+    // -- graceful degradation, not an error.
+    if (readMarkerFile(mFs, mMarkerPath.c_str(), fitPath, offset)) {
+        return true;
+    }
+    char bakPath[kSiblingBufLen];
+    makeSiblingPath(bakPath, sizeof(bakPath), mMarkerPath.c_str(), kBakSuffix);
+    return readMarkerFile(mFs, bakPath, fitPath, offset);
+}
+
+void RecordingMarker::remove()
+{
+    char tmpPath[kSiblingBufLen];
+    char bakPath[kSiblingBufLen];
+    makeSiblingPath(tmpPath, sizeof(tmpPath), mMarkerPath.c_str(), kTmpSuffix);
+    makeSiblingPath(bakPath, sizeof(bakPath), mMarkerPath.c_str(), kBakSuffix);
+    mFs.remove(mMarkerPath.c_str());
+    mFs.remove(bakPath);
+    mFs.remove(tmpPath);
+}
+
+RecordingMarker::RecoverResult RecordingMarker::recover()
+{
+    RecoverResult result;
+
+    std::string fitPath;
+    uint32_t    dataEnd = 0;
+    if (!read(fitPath, dataEnd)) {
+        return result;   // no marker -> nothing to recover
+    }
+
+    auto file = mFs.file(fitPath.c_str());
+    if (file && file->exist() && FitWriter::recover(*file, dataEnd)) {
+        result.recovered = true;
+        result.path      = fitPath;
+    }
+
+    // One-shot: always clear the marker (a missing file or failed recover is
+    // given up on cleanly so the next boot does not retry forever).
+    remove();
+    return result;
+}
+
+}  // namespace SDK::Fit

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(una-sdk-host-tests
     fit/FitWriter_test.cpp
     fit/FitProfile_test.cpp
     fit/FitRoundTrip_test.cpp
+    fit/RecordingMarker_test.cpp
     apps/Running/ActivityWriter_test.cpp
     sensorlayer/HeartRateParser_test.cpp
     sensorlayer/HeartRateExParser_test.cpp
@@ -59,6 +60,7 @@ add_executable(una-sdk-host-tests
     "${UNA_SDK_ROOT}/Libs/Source/Fit/FitCrc.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/Fit/FitWriter.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/Fit/FitRecordCadence.cpp"
+    "${UNA_SDK_ROOT}/Libs/Source/Fit/RecordingMarker.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/JSON/JsonStreamReader.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/JSON/JsonStreamWriter.cpp"
     "${COREJSON_DIR}/core_json.c"

--- a/Tests/Host/apps/Running/ActivityWriter_test.cpp
+++ b/Tests/Host/apps/Running/ActivityWriter_test.cpp
@@ -273,3 +273,47 @@ TEST(RunningActivityWriter, StopReturnsFalseOnWriteFailure)
     EXPECT_TRUE(fx.fileSystem.exist(kMarkerPath))
         << "on failure the marker survives so the next boot recovers the .fit";
 }
+
+// Decoupling: the FIT finishes/flushes/closes durably but the auxiliary .json
+// summary cannot be persisted. stop() must still report success (FIT durability
+// is the save contract -- the kernel registers the .fit on close), clear the
+// marker, and leave a valid CRC-good .fit. A summary-only failure must never
+// suppress the activity's registration.
+TEST(RunningActivityWriter, StopSucceedsWhenOnlySummaryFails)
+{
+    SDK::TestSupport::KernelFixture fx;
+    ActivityWriter w(fx.kernel, "Activity");
+
+    ActivityWriter::AppInfo info;
+    info.timestamp = 1782475200;
+    info.appID     = "running";
+    w.start(info);
+
+    ActivityWriter::RecordData rec;
+    rec.timestamp = info.timestamp;
+    rec.set(ActivityWriter::RecordData::Field::HEART_RATE);
+    rec.heartRate = 120;
+    w.addRecord(rec);
+
+    // Fail ONLY the summary: the .json open() fails, which happens after the
+    // .fit has been durably finished, flushed and closed. The FIT writes are
+    // untouched.
+    fx.fileSystem.failWriteOpenSuffix = ".json";
+
+    ActivityWriter::TrackData track;
+    track.timestamp = info.timestamp + 1;
+    track.timeStart = info.timestamp;
+    track.duration  = 1;
+    track.elapsed   = 1;
+
+    EXPECT_TRUE(w.stop(track))
+        << "FIT durable -> stop() succeeds despite the summary failure";
+    EXPECT_FALSE(fx.fileSystem.exist(kMarkerPath)) << "marker cleared: FIT durably saved";
+
+    // No .json persisted, but the .fit is present and CRC-valid.
+    const std::vector<uint8_t> fit = findFitFile(fx.fileSystem);
+    ASSERT_FALSE(fit.empty()) << ".fit present on disk";
+    testfit::FitReader r(fit);
+    EXPECT_TRUE(r.ok());
+    EXPECT_TRUE(r.crcValid()) << "recovered .fit CRC is valid";
+}

--- a/Tests/Host/apps/Running/ActivityWriter_test.cpp
+++ b/Tests/Host/apps/Running/ActivityWriter_test.cpp
@@ -19,17 +19,29 @@ namespace fit = SDK::Fit;
 
 namespace {
 
-std::vector<uint8_t> findFitFile(const SDK::TestSupport::InMemoryFileSystem& fs)
+std::string findFitPath(const SDK::TestSupport::InMemoryFileSystem& fs)
 {
     for (const auto& kv : fs.files) {
         const std::string& path = kv.first;
-        if (path.size() > 4 && path.compare(path.size() - 4, 4, ".fit") == 0) {
-            const std::string s = fs.readFile(path);
-            return std::vector<uint8_t>(s.begin(), s.end());
+        if (kv.second.exists && path.size() > 4
+            && path.compare(path.size() - 4, 4, ".fit") == 0) {
+            return path;
         }
     }
     return {};
 }
+
+std::vector<uint8_t> findFitFile(const SDK::TestSupport::InMemoryFileSystem& fs)
+{
+    const std::string path = findFitPath(fs);
+    if (path.empty()) {
+        return {};
+    }
+    const std::string s = fs.readFile(path);
+    return std::vector<uint8_t>(s.begin(), s.end());
+}
+
+constexpr const char* kMarkerPath = "Activity/.recording";
 
 }  // namespace
 
@@ -120,4 +132,144 @@ TEST(RunningActivityWriter, ProducesValidFitFile)
     // session sport = running.
     const auto* ses = r.withGlobal(fit::mesgNum(fit::MesgNum::Session)).front();
     EXPECT_EQ(ses->fields.at(5).u(), static_cast<uint64_t>(fit::Sport::Running));
+}
+
+// The .fit is flushed at start, then only when a record crosses a >=30 s
+// boundary (and on every lap). Records at +0/+10/+20/+35/+70 s cross the
+// boundary twice.
+TEST(RunningActivityWriter, FlushCadence)
+{
+    SDK::TestSupport::KernelFixture fx;
+    ActivityWriter w(fx.kernel, "Activity");
+
+    ActivityWriter::AppInfo info;
+    info.timestamp = 1000;  // small base keeps the flush deltas obvious
+    info.appID     = "running";
+    w.start(info);
+
+    const std::string fitPath = findFitPath(fx.fileSystem);
+    ASSERT_FALSE(fitPath.empty());
+    const size_t afterStart = fx.fileSystem.flushCounts[fitPath];
+    EXPECT_EQ(afterStart, 1u) << "start() flushes the .fit once (header + defs)";
+
+    const std::time_t offsets[] = {0, 10, 20, 35, 70};
+    for (std::time_t off : offsets) {
+        ActivityWriter::RecordData rec;
+        rec.timestamp = info.timestamp + off;
+        rec.set(ActivityWriter::RecordData::Field::HEART_RATE);
+        rec.heartRate = 120;
+        w.addRecord(rec);
+    }
+    EXPECT_EQ(fx.fileSystem.flushCounts[fitPath] - afterStart, 2u)
+        << "flush only when crossing the >=30 s boundary (at +35 and +70)";
+
+    const size_t beforeLap = fx.fileSystem.flushCounts[fitPath];
+    ActivityWriter::LapData lap;
+    lap.timestamp = info.timestamp + 70;
+    lap.timeStart = info.timestamp;
+    lap.duration  = 70;
+    lap.elapsed   = 70;
+    w.addLap(lap);
+    EXPECT_EQ(fx.fileSystem.flushCounts[fitPath] - beforeLap, 1u) << "each lap flushes";
+}
+
+// End-to-end wiring: a crash (no stop()) leaves the marker; a fresh writer's
+// recoverInterrupted() finalizes the .fit and clears the marker.
+TEST(RunningActivityWriter, RecoverInterruptedThroughApp)
+{
+    SDK::TestSupport::KernelFixture fx;
+
+    {
+        ActivityWriter w(fx.kernel, "Activity");
+        ActivityWriter::AppInfo info;
+        info.timestamp = 1782475200;  // 2026-06-26 12:00 UTC
+        info.appID     = "running";
+        w.start(info);
+
+        ActivityWriter::RecordData rec;
+        rec.timestamp = info.timestamp;
+        rec.set(ActivityWriter::RecordData::Field::HEART_RATE);
+        rec.heartRate = 120;
+        w.addRecord(rec);
+        rec.timestamp = info.timestamp + 1;
+        w.addRecord(rec);
+
+        ActivityWriter::LapData lap;  // laps flush -> marker covers all records
+        lap.timestamp = info.timestamp + 1;
+        lap.timeStart = info.timestamp;
+        lap.duration  = 1;
+        lap.elapsed   = 1;
+        w.addLap(lap);
+        // Crash: no stop() -> file left unfinished, marker present.
+    }
+
+    ASSERT_TRUE(fx.fileSystem.exist(kMarkerPath));
+
+    ActivityWriter fresh(fx.kernel, "Activity");
+    EXPECT_TRUE(fresh.recoverInterrupted());
+    EXPECT_FALSE(fx.fileSystem.exist(kMarkerPath)) << "marker cleared after recovery";
+
+    const std::vector<uint8_t> bytes = findFitFile(fx.fileSystem);
+    ASSERT_FALSE(bytes.empty());
+    testfit::FitReader r(bytes);
+    EXPECT_TRUE(r.ok()) << "recovered .fit parses";
+    EXPECT_TRUE(r.crcValid()) << "recovered .fit CRC verifies";
+
+    // Second call: no marker left -> nothing to do.
+    EXPECT_FALSE(fresh.recoverInterrupted());
+}
+
+// #40: stop() returns whether the activity was durably saved.
+TEST(RunningActivityWriter, StopReturnsTrueOnSuccess)
+{
+    SDK::TestSupport::KernelFixture fx;
+    ActivityWriter w(fx.kernel, "Activity");
+
+    ActivityWriter::AppInfo info;
+    info.timestamp = 1782475200;
+    info.appID     = "running";
+    w.start(info);
+
+    ActivityWriter::RecordData rec;
+    rec.timestamp = info.timestamp;
+    rec.set(ActivityWriter::RecordData::Field::HEART_RATE);
+    rec.heartRate = 120;
+    w.addRecord(rec);
+
+    ActivityWriter::TrackData track;
+    track.timestamp = info.timestamp + 1;
+    track.timeStart = info.timestamp;
+    track.duration  = 1;
+    track.elapsed   = 1;
+    EXPECT_TRUE(w.stop(track));
+    EXPECT_FALSE(fx.fileSystem.exist(kMarkerPath)) << "success clears the marker";
+}
+
+TEST(RunningActivityWriter, StopReturnsFalseOnWriteFailure)
+{
+    SDK::TestSupport::KernelFixture fx;
+    ActivityWriter w(fx.kernel, "Activity");
+
+    ActivityWriter::AppInfo info;
+    info.timestamp = 1782475200;
+    info.appID     = "running";
+    w.start(info);
+
+    ActivityWriter::RecordData rec;
+    rec.timestamp = info.timestamp;
+    rec.set(ActivityWriter::RecordData::Field::HEART_RATE);
+    rec.heartRate = 120;
+    w.addRecord(rec);
+
+    // Fail every write from here on: the session/activity/finish writes fail.
+    fx.fileSystem.failWritesAfterBytes = fx.fileSystem.bytesWritten;
+
+    ActivityWriter::TrackData track;
+    track.timestamp = info.timestamp + 1;
+    track.timeStart = info.timestamp;
+    track.duration  = 1;
+    track.elapsed   = 1;
+    EXPECT_FALSE(w.stop(track));
+    EXPECT_TRUE(fx.fileSystem.exist(kMarkerPath))
+        << "on failure the marker survives so the next boot recovers the .fit";
 }

--- a/Tests/Host/fit/FitWriter_test.cpp
+++ b/Tests/Host/fit/FitWriter_test.cpp
@@ -8,6 +8,7 @@
 #include "SDK/Fit/FitCrc.hpp"
 #include "SDK/Fit/FitWriter.hpp"
 #include "FakeFileSystem.hpp"
+#include "fit/FitReader.hpp"
 
 #include <gtest/gtest.h>
 
@@ -160,4 +161,197 @@ TEST(FitWriter, EmitsDeveloperFieldDefinition)
     EXPECT_EQ(b[24], 0x00);                // dev field number
     EXPECT_EQ(b[25], 0x01);                // dev field size
     EXPECT_EQ(b[26], 0x00);                // developer data index
+}
+
+// --- Crash-safety recovery (FitWriter::recover) -----------------------------
+
+namespace {
+// Stream a placeholder header + one definition (global 20: uint32 timestamp +
+// uint8 hr) + `nRecords` data records to `path`, WITHOUT calling finish() --
+// i.e. the state a file is left in when an activity is interrupted (power loss)
+// mid-recording. Returns the data-end offset (getPosition() after the last
+// record) that a recovery marker would have persisted as the last
+// record-complete boundary.
+uint32_t seedUnfinished(SDK::Test::FakeFileSystem& fs, const char* path, int nRecords)
+{
+    auto file = fs.file(path);
+    EXPECT_TRUE(file->open(/*wMode=*/true, /*override=*/true));
+    FitWriter w(*file);
+    EXPECT_TRUE(w.begin(/*profileVersion=*/0x1234));
+    EXPECT_TRUE(w.defineMessage(0, 20, {{253, BaseType::UInt32}, {3, BaseType::UInt8}}));
+    for (int i = 0; i < nRecords; ++i) {
+        EXPECT_TRUE(w.data(0).u32(1000 + static_cast<uint32_t>(i))
+                        .u8(static_cast<uint8_t>(60 + i)).write());
+    }
+    const uint32_t dataEnd = static_cast<uint32_t>(file->getPosition());
+    file->close();  // activity interrupted before finish() -- no CRC, placeholder header
+    return dataEnd;
+}
+}  // namespace
+
+// Crash -> reboot -> recover: an unfinished file (placeholder header, no file
+// CRC) is turned into a complete, CRC-valid FIT file from only the on-disk
+// bytes plus the caller-supplied dataEnd (a fresh handle -- no writer state).
+TEST(FitWriter, RecoverCrashedFileIsValid)
+{
+    SDK::Test::FakeFileSystem fs;
+    const uint32_t dataEnd = seedUnfinished(fs, "crash.fit", 5);
+
+    // Simulate a reboot: a brand-new file handle, only disk bytes + dataEnd.
+    auto file = fs.file("crash.fit");
+    ASSERT_TRUE(FitWriter::recover(*file, dataEnd));
+
+    const std::string s = fs.fileContents("crash.fit");
+    const std::vector<uint8_t> b(s.begin(), s.end());
+    testfit::FitReader r(b);
+    EXPECT_TRUE(r.ok());
+    EXPECT_TRUE(r.crcValid());
+    EXPECT_EQ(r.withGlobal(20).size(), 5u);
+    EXPECT_EQ(b.size(), dataEnd + 2u);
+}
+
+// A torn tail (a partially-written record flushed past the last complete
+// record) is trimmed: recover() finalizes exactly [0, dataEnd) + CRC.
+TEST(FitWriter, RecoverTrimsTornTail)
+{
+    SDK::Test::FakeFileSystem fs;
+    const uint32_t dataEnd = seedUnfinished(fs, "torn.fit", 4);
+
+    // Append garbage past the last flushed record (a partial post-flush write).
+    {
+        auto f = fs.file("torn.fit");
+        ASSERT_TRUE(f->open(/*wMode=*/true, /*override=*/false));
+        ASSERT_TRUE(f->seek(dataEnd));
+        const char garbage[] = {0x00, 0x11, 0x22, 0x33, 0x44};
+        size_t bw = 0;
+        ASSERT_TRUE(f->write(garbage, sizeof(garbage), bw));
+        f->close();
+    }
+    ASSERT_GT(fs.fileContents("torn.fit").size(), static_cast<size_t>(dataEnd));
+
+    auto file = fs.file("torn.fit");
+    ASSERT_TRUE(FitWriter::recover(*file, dataEnd));
+
+    const std::string s = fs.fileContents("torn.fit");
+    const std::vector<uint8_t> b(s.begin(), s.end());
+    testfit::FitReader r(b);
+    EXPECT_TRUE(r.ok());
+    EXPECT_TRUE(r.crcValid());
+    EXPECT_EQ(r.withGlobal(20).size(), 4u);
+    EXPECT_EQ(b.size(), dataEnd + 2u) << "torn tail must be trimmed";
+}
+
+// recover() on an already-finish()ed file is an idempotent no-op: returns true
+// and leaves the bytes byte-for-byte unchanged and still valid.
+TEST(FitWriter, RecoverOnFinishedFileIsNoop)
+{
+    SDK::Test::FakeFileSystem fs;
+    auto file = fs.file("done.fit");
+    ASSERT_TRUE(file->open(/*wMode=*/true, /*override=*/true));
+    FitWriter w(*file);
+    ASSERT_TRUE(w.begin(0x1234));
+    ASSERT_TRUE(w.defineMessage(0, 20, {{253, BaseType::UInt32}, {3, BaseType::UInt8}}));
+    for (int i = 0; i < 3; ++i) {
+        ASSERT_TRUE(w.data(0).u32(1000 + static_cast<uint32_t>(i))
+                        .u8(static_cast<uint8_t>(60 + i)).write());
+    }
+    const uint32_t dataEnd = static_cast<uint32_t>(file->getPosition());
+    ASSERT_TRUE(w.finish());
+    file->close();
+
+    const std::string before = fs.fileContents("done.fit");
+
+    auto f2 = fs.file("done.fit");
+    ASSERT_TRUE(FitWriter::recover(*f2, dataEnd));
+
+    const std::string after = fs.fileContents("done.fit");
+    EXPECT_EQ(before, after) << "recover() must not touch an already-finalized file";
+
+    const std::vector<uint8_t> b(after.begin(), after.end());
+    testfit::FitReader r(b);
+    EXPECT_TRUE(r.ok());
+    EXPECT_TRUE(r.crcValid());
+    EXPECT_EQ(r.withGlobal(20).size(), 3u);
+}
+
+// An already-finalized file (non-zero on-disk dataSize) that carries extra
+// trailing bytes -- e.g. an isolated truncate() failure left a torn tail past
+// the CRC -- must be treated as already finalized: recover() returns true and
+// leaves the bytes UNCHANGED. Re-finalizing at the marker's older crash-time
+// dataEnd would rewrite the header/CRC and truncate away the session/activity
+// messages that finish() appended -- silently discarding the recorded activity.
+TEST(FitWriter, RecoverOnFinalizedFileWithTrailingBytesIsNoop)
+{
+    SDK::Test::FakeFileSystem fs;
+    auto file = fs.file("trailing.fit");
+    ASSERT_TRUE(file->open(/*wMode=*/true, /*override=*/true));
+    FitWriter w(*file);
+    ASSERT_TRUE(w.begin(0x1234));
+    ASSERT_TRUE(w.defineMessage(0, 20, {{253, BaseType::UInt32}, {3, BaseType::UInt8}}));
+    ASSERT_TRUE(w.data(0).u32(1000).u8(60).write());
+    file->flush();
+    // The offset a crash marker would have persisted (only 1 record so far),
+    // BEFORE finish() appends the rest of the session.
+    const uint32_t staleDataEnd = static_cast<uint32_t>(file->getPosition());
+    for (int i = 1; i < 4; ++i) {
+        ASSERT_TRUE(w.data(0).u32(1000 + static_cast<uint32_t>(i))
+                        .u8(static_cast<uint8_t>(60 + i)).write());
+    }
+    ASSERT_TRUE(w.finish());   // patches header dataSize != 0, appends the CRC
+    file->close();
+
+    const std::string finalized = fs.fileContents("trailing.fit");
+
+    // Simulate an isolated truncate() failure: a few bytes linger past the CRC.
+    {
+        auto f = fs.file("trailing.fit");
+        ASSERT_TRUE(f->open(/*wMode=*/true, /*override=*/false));
+        ASSERT_TRUE(f->seek(f->size()));
+        const char trailing[] = {0x55, static_cast<char>(0xAA), 0x12};
+        size_t bw = 0;
+        ASSERT_TRUE(f->write(trailing, sizeof(trailing), bw));
+        f->close();
+    }
+    const std::string before = fs.fileContents("trailing.fit");
+    ASSERT_GT(before.size(), finalized.size()) << "trailing bytes present";
+
+    // Recover with the STALE (older, 1-record) offset. Must be a no-op.
+    auto f2 = fs.file("trailing.fit");
+    ASSERT_TRUE(FitWriter::recover(*f2, staleDataEnd));
+    const std::string after = fs.fileContents("trailing.fit");
+    EXPECT_EQ(after, before)
+        << "already-finalized file must not be re-finalized at a stale offset";
+
+    // The full 4-record session is still intact -- not truncated back to the
+    // marker's 1-record offset. (The finalized prefix still parses cleanly.)
+    const std::vector<uint8_t> prefix(after.begin(), after.begin() + finalized.size());
+    testfit::FitReader r(prefix);
+    EXPECT_TRUE(r.ok());
+    EXPECT_TRUE(r.crcValid());
+    EXPECT_EQ(r.withGlobal(20).size(), 4u) << "session data preserved, not discarded";
+}
+
+// Bad input must be rejected (return false) without corrupting the file.
+TEST(FitWriter, RecoverRejectsBadInputWithoutClobbering)
+{
+    // (a) dataEnd beyond EOF.
+    {
+        SDK::Test::FakeFileSystem fs;
+        const uint32_t dataEnd = seedUnfinished(fs, "oor.fit", 2);
+        const std::string before = fs.fileContents("oor.fit");
+
+        auto file = fs.file("oor.fit");
+        EXPECT_FALSE(FitWriter::recover(*file, dataEnd + 100));
+        EXPECT_EQ(fs.fileContents("oor.fit"), before) << "out-of-range dataEnd must not clobber";
+    }
+    // (b) non-FIT header.
+    {
+        SDK::Test::FakeFileSystem fs;
+        const std::string junk = "NOTAFITFILE_________________";  // >=14 bytes, no ".FIT" at 8..11
+        fs.seedFile("junk.bin", junk);
+
+        auto file = fs.file("junk.bin");
+        EXPECT_FALSE(FitWriter::recover(*file, 14));
+        EXPECT_EQ(fs.fileContents("junk.bin"), junk) << "non-FIT header must not be clobbered";
+    }
 }

--- a/Tests/Host/fit/FitWriter_test.cpp
+++ b/Tests/Host/fit/FitWriter_test.cpp
@@ -355,3 +355,15 @@ TEST(FitWriter, RecoverRejectsBadInputWithoutClobbering)
         EXPECT_EQ(fs.fileContents("junk.bin"), junk) << "non-FIT header must not be clobbered";
     }
 }
+
+// recover() on a NON-EXISTENT path must return false and must NOT create the
+// file: it inspects read-only first, so a missing target is never conjured into
+// a stray 0-byte .fit (a non-truncating write open would create it).
+TEST(FitWriter, RecoverOnMissingFileDoesNotCreateIt)
+{
+    SDK::Test::FakeFileSystem fs;
+
+    auto file = fs.file("ghost.fit");
+    EXPECT_FALSE(FitWriter::recover(*file, 100));
+    EXPECT_FALSE(fs.hasFile("ghost.fit")) << "recover() must not create a missing file";
+}

--- a/Tests/Host/fit/FitWriter_test.cpp
+++ b/Tests/Host/fit/FitWriter_test.cpp
@@ -19,6 +19,9 @@
 using SDK::Fit::BaseType;
 using SDK::Fit::FitWriter;
 
+// The FIT file header is a fixed 14 bytes.
+static constexpr size_t kFitHeaderSize = 14u;
+
 // FIT's file CRC is CRC-16/ARC; its canonical check value over "123456789"
 // is 0xBB3D. This is an independent known-answer check on the algorithm.
 TEST(FitCrc, KnownAnswerVectors)
@@ -276,11 +279,11 @@ TEST(FitWriter, RecoverOnFinishedFileIsNoop)
 
 // An already-finalized file (non-zero on-disk dataSize) that carries extra
 // trailing bytes -- e.g. an isolated truncate() failure left a torn tail past
-// the CRC -- must be treated as already finalized: recover() returns true and
-// leaves the bytes UNCHANGED. Re-finalizing at the marker's older crash-time
-// dataEnd would rewrite the header/CRC and truncate away the session/activity
-// messages that finish() appended -- silently discarding the recorded activity.
-TEST(FitWriter, RecoverOnFinalizedFileWithTrailingBytesIsNoop)
+// the CRC -- is repaired by trimming the tail: recover() re-finalizes at the
+// header's OWN durable dataSize (14 + dataSize), NOT the marker's stale offset,
+// so the session/activity messages finish() appended are preserved while the
+// extra bytes are dropped. The file ends exactly header + data + CRC.
+TEST(FitWriter, RecoverTrimsTrailingBytesAfterFinalizedHeader)
 {
     SDK::Test::FakeFileSystem fs;
     auto file = fs.file("trailing.fit");
@@ -301,6 +304,9 @@ TEST(FitWriter, RecoverOnFinalizedFileWithTrailingBytesIsNoop)
     file->close();
 
     const std::string finalized = fs.fileContents("trailing.fit");
+    // The durable data size stamped in the finalized header (== finalized size
+    // minus header minus the 2-byte CRC).
+    const size_t durableDataSize = finalized.size() - kFitHeaderSize - 2u;
 
     // Simulate an isolated truncate() failure: a few bytes linger past the CRC.
     {
@@ -312,23 +318,78 @@ TEST(FitWriter, RecoverOnFinalizedFileWithTrailingBytesIsNoop)
         ASSERT_TRUE(f->write(trailing, sizeof(trailing), bw));
         f->close();
     }
-    const std::string before = fs.fileContents("trailing.fit");
-    ASSERT_GT(before.size(), finalized.size()) << "trailing bytes present";
+    ASSERT_GT(fs.fileContents("trailing.fit").size(), finalized.size())
+        << "trailing bytes present";
 
-    // Recover with the STALE (older, 1-record) offset. Must be a no-op.
+    // Recover with the STALE (older, 1-record) marker offset. recover() must
+    // ignore it in favour of the header's durable dataSize and trim the tail.
     auto f2 = fs.file("trailing.fit");
     ASSERT_TRUE(FitWriter::recover(*f2, staleDataEnd));
     const std::string after = fs.fileContents("trailing.fit");
-    EXPECT_EQ(after, before)
-        << "already-finalized file must not be re-finalized at a stale offset";
 
-    // The full 4-record session is still intact -- not truncated back to the
-    // marker's 1-record offset. (The finalized prefix still parses cleanly.)
-    const std::vector<uint8_t> prefix(after.begin(), after.begin() + finalized.size());
-    testfit::FitReader r(prefix);
+    // Trailing bytes trimmed: file is exactly header + data + CRC.
+    EXPECT_EQ(after.size(), kFitHeaderSize + durableDataSize + 2u)
+        << "trailing tail must be trimmed to header + data + CRC";
+
+    const std::vector<uint8_t> b(after.begin(), after.end());
+    testfit::FitReader r(b);
     EXPECT_TRUE(r.ok());
     EXPECT_TRUE(r.crcValid());
-    EXPECT_EQ(r.withGlobal(20).size(), 4u) << "session data preserved, not discarded";
+    EXPECT_EQ(r.withGlobal(20).size(), 4u)
+        << "full session data preserved, not discarded at the stale marker";
+}
+
+// Crash AFTER the header flush (dataSize != 0) but BEFORE the trailing CRC was
+// written -- the exact window finalize() leaves open between flushing the header
+// and flushing the CRC. The file is header + data with NO CRC (size == 14 + D).
+// recover() must repair it (write the missing CRC) rather than trust the
+// non-zero dataSize and skip repair, which would leave an invalid FIT forever.
+TEST(FitWriter, RecoverRepairsCrashMidFinalize)
+{
+    SDK::Test::FakeFileSystem fs;
+    auto file = fs.file("midfinalize.fit");
+    ASSERT_TRUE(file->open(/*wMode=*/true, /*override=*/true));
+    FitWriter w(*file);
+    ASSERT_TRUE(w.begin(0x1234));
+    ASSERT_TRUE(w.defineMessage(0, 20, {{253, BaseType::UInt32}, {3, BaseType::UInt8}}));
+    for (int i = 0; i < 3; ++i) {
+        ASSERT_TRUE(w.data(0).u32(1000 + static_cast<uint32_t>(i))
+                        .u8(static_cast<uint8_t>(60 + i)).write());
+    }
+    file->flush();
+    const uint32_t dataEnd = static_cast<uint32_t>(file->getPosition());
+    file->close();
+
+    // Hand-patch the header so dataSize == D (= dataEnd - 14) but leave NO CRC
+    // appended: the file size stays 14 + D. This is the crash-mid-finalize state
+    // (header flushed with dataSize, CRC not yet written).
+    {
+        const uint32_t d = dataEnd - 14u;
+        auto f = fs.file("midfinalize.fit");
+        ASSERT_TRUE(f->open(/*wMode=*/true, /*override=*/false));
+        ASSERT_TRUE(f->seek(4));
+        const char sz[4] = {static_cast<char>(d & 0xFF),
+                            static_cast<char>((d >> 8) & 0xFF),
+                            static_cast<char>((d >> 16) & 0xFF),
+                            static_cast<char>((d >> 24) & 0xFF)};
+        size_t bw = 0;
+        ASSERT_TRUE(f->write(sz, sizeof(sz), bw));
+        f->close();
+    }
+    ASSERT_EQ(fs.fileContents("midfinalize.fit").size(), static_cast<size_t>(dataEnd))
+        << "no CRC yet -- size is header + data only";
+
+    // The marker offset is irrelevant here (header dataSize wins); pass it anyway.
+    auto f2 = fs.file("midfinalize.fit");
+    ASSERT_TRUE(FitWriter::recover(*f2, dataEnd));
+
+    const std::string s = fs.fileContents("midfinalize.fit");
+    const std::vector<uint8_t> b(s.begin(), s.end());
+    testfit::FitReader r(b);
+    EXPECT_TRUE(r.ok());
+    EXPECT_TRUE(r.crcValid()) << "missing CRC must be written by recover()";
+    EXPECT_EQ(r.withGlobal(20).size(), 3u);
+    EXPECT_EQ(b.size(), dataEnd + 2u) << "CRC appended: header + data + CRC";
 }
 
 // Bad input must be rejected (return false) without corrupting the file.

--- a/Tests/Host/fit/RecordingMarker_test.cpp
+++ b/Tests/Host/fit/RecordingMarker_test.cpp
@@ -1,0 +1,238 @@
+/**
+ ******************************************************************************
+ * @file    RecordingMarker_test.cpp
+ * @brief   Host tests for the shared crash-recovery marker + recover
+ *          orchestration (SDK::Fit::RecordingMarker). App-independent: every
+ *          FIT-writing app reuses this, so it is tested once here.
+ ******************************************************************************
+ */
+
+#include "SDK/Fit/RecordingMarker.hpp"
+
+#include "SDK/Fit/FitWriter.hpp"
+#include "KernelTestDoubles.hpp"
+#include "fit/FitReader.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using SDK::Fit::BaseType;
+using SDK::Fit::FitWriter;
+using SDK::Fit::RecordingMarker;
+using SDK::TestSupport::InMemoryFileSystem;
+
+namespace {
+
+// Seed a torn (streamed-but-never-finished) .fit into the file system and
+// return the data-end offset a recovery marker would have persisted -- the
+// getPosition() after the last complete record.
+uint32_t seedTornFit(InMemoryFileSystem& fs, const char* path)
+{
+    auto file = fs.file(path);
+    EXPECT_TRUE(file->open(/*wMode=*/true, /*override=*/true));
+    FitWriter w(*file);
+    EXPECT_TRUE(w.begin(/*profileVersion=*/0));
+    EXPECT_TRUE(w.defineMessage(0, 20, {{253, BaseType::UInt32}, {3, BaseType::UInt8}}));
+    EXPECT_TRUE(w.data(0).u32(1000).u8(60).write());
+    EXPECT_TRUE(w.data(0).u32(1001).u8(61).write());
+    const uint32_t dataEnd = static_cast<uint32_t>(file->getPosition());
+    file->flush();
+    file->close();
+    return dataEnd;  // no finish() -> torn
+}
+
+std::vector<uint8_t> bytesOf(const InMemoryFileSystem& fs, const std::string& path)
+{
+    const std::string s = fs.readFile(path);
+    return std::vector<uint8_t>(s.begin(), s.end());
+}
+
+}  // namespace
+
+TEST(RecordingMarker, WriteReadRemoveRoundTrip)
+{
+    InMemoryFileSystem fs;
+    RecordingMarker m(fs, "Activity");
+
+    ASSERT_TRUE(m.write("Activity/202606/activity.fit", 1234));
+    EXPECT_TRUE(fs.exist("Activity/.recording"));
+
+    std::string path;
+    uint32_t    offset = 0;
+    ASSERT_TRUE(m.read(path, offset));
+    EXPECT_EQ(path, "Activity/202606/activity.fit");
+    EXPECT_EQ(offset, 1234u);
+
+    m.remove();
+    EXPECT_FALSE(fs.exist("Activity/.recording"));
+
+    std::string p2;
+    uint32_t    o2 = 0;
+    EXPECT_FALSE(m.read(p2, o2)) << "read after remove must fail";
+}
+
+TEST(RecordingMarker, UpdateMovesOffsetKeepsPath)
+{
+    InMemoryFileSystem fs;
+    RecordingMarker m(fs, "Activity");
+
+    ASSERT_TRUE(m.write("Activity/x.fit", 100));
+    ASSERT_TRUE(m.update(500));
+
+    std::string path;
+    uint32_t    offset = 0;
+    ASSERT_TRUE(m.read(path, offset));
+    EXPECT_EQ(path, "Activity/x.fit");
+    EXPECT_EQ(offset, 500u);
+}
+
+TEST(RecordingMarker, UpdateWithoutWriteFails)
+{
+    InMemoryFileSystem fs;
+    RecordingMarker m(fs, "Activity");
+    EXPECT_FALSE(m.update(10)) << "update() before any write() has no path";
+    EXPECT_FALSE(fs.exist("Activity/.recording"));
+}
+
+TEST(RecordingMarker, RecoverFinalizesTornFit)
+{
+    InMemoryFileSystem fs;
+    const char* fitPath = "Activity/202606/activity.fit";
+    const uint32_t dataEnd = seedTornFit(fs, fitPath);
+
+    RecordingMarker m(fs, "Activity");
+    ASSERT_TRUE(m.write(fitPath, dataEnd));
+
+    const auto res = m.recover();
+    EXPECT_TRUE(res.recovered);
+    EXPECT_EQ(res.path, fitPath);
+    EXPECT_FALSE(fs.exist("Activity/.recording")) << "marker cleared after recovery";
+
+    const std::vector<uint8_t> b = bytesOf(fs, fitPath);
+    testfit::FitReader r(b);
+    EXPECT_TRUE(r.ok()) << "recovered file parses";
+    EXPECT_TRUE(r.crcValid()) << "recovered file CRC verifies";
+    EXPECT_EQ(b.size(), dataEnd + 2u) << "finalized to [0,dataEnd) + CRC";
+}
+
+TEST(RecordingMarker, RecoverNoMarkerIsNoop)
+{
+    InMemoryFileSystem fs;
+    RecordingMarker m(fs, "Activity");
+
+    const auto res = m.recover();
+    EXPECT_FALSE(res.recovered);
+    EXPECT_TRUE(res.path.empty());
+    EXPECT_TRUE(fs.files.empty()) << "no marker -> no side effects";
+}
+
+TEST(RecordingMarker, RecoverMissingFitGivesUpCleanly)
+{
+    InMemoryFileSystem fs;
+    RecordingMarker m(fs, "Activity");
+    ASSERT_TRUE(m.write("Activity/gone.fit", 40));  // names a file that never existed
+
+    const auto res = m.recover();
+    EXPECT_FALSE(res.recovered);
+    EXPECT_FALSE(fs.exist("Activity/.recording")) << "marker cleared even on give-up";
+}
+
+TEST(RecordingMarker, RecoverBadOffsetGivesUpWithoutClobber)
+{
+    InMemoryFileSystem fs;
+    const char* fitPath = "Activity/torn.fit";
+    const uint32_t dataEnd = seedTornFit(fs, fitPath);
+    const std::vector<uint8_t> before = bytesOf(fs, fitPath);
+
+    RecordingMarker m(fs, "Activity");
+    ASSERT_TRUE(m.write(fitPath, dataEnd + 100));  // beyond EOF -> FitWriter rejects
+
+    const auto res = m.recover();
+    EXPECT_FALSE(res.recovered);
+    EXPECT_FALSE(fs.exist("Activity/.recording"));
+    EXPECT_EQ(bytesOf(fs, fitPath), before) << "out-of-range offset must not clobber the .fit";
+}
+
+// Fix 1: a crash during update() can leave the primary marker torn (empty).
+// read()/recover() must fall back to the .bak (the previous, slightly older but
+// still record-aligned offset) so the fully-flushed .fit is NOT orphaned/lost.
+TEST(RecordingMarker, CrashDuringUpdateFallsBackToBak)
+{
+    InMemoryFileSystem fs;
+    const char* fitPath = "Activity/202606/activity.fit";
+
+    // Seed a torn .fit and capture two record-aligned, flushed offsets.
+    uint32_t off1 = 0;
+    uint32_t off2 = 0;
+    {
+        auto file = fs.file(fitPath);
+        ASSERT_TRUE(file->open(/*wMode=*/true, /*override=*/true));
+        FitWriter w(*file);
+        ASSERT_TRUE(w.begin(/*profileVersion=*/0));
+        ASSERT_TRUE(w.defineMessage(0, 20, {{253, BaseType::UInt32}, {3, BaseType::UInt8}}));
+        ASSERT_TRUE(w.data(0).u32(1000).u8(60).write());
+        file->flush();
+        off1 = static_cast<uint32_t>(file->getPosition());
+        ASSERT_TRUE(w.data(0).u32(1001).u8(61).write());
+        file->flush();
+        off2 = static_cast<uint32_t>(file->getPosition());
+        file->close();
+    }
+    ASSERT_LT(off1, off2);
+
+    RecordingMarker m(fs, "Activity");
+    ASSERT_TRUE(m.write(fitPath, off1));   // first marker: primary = off1, no .bak
+    ASSERT_TRUE(m.update(off2));           // rotate: .bak = off1, primary = off2
+    ASSERT_TRUE(fs.exist("Activity/.recording"));
+    ASSERT_TRUE(fs.exist("Activity/.recording.bak"));
+
+    // Simulate a crash mid-update: the primary is left torn (empty), while the
+    // previous good copy survives in .bak.
+    fs.seedFile("Activity/.recording", "");
+
+    // read() transparently falls back to the .bak's (previous) offset.
+    RecordingMarker m2(fs, "Activity");
+    std::string path;
+    uint32_t    offset = 0;
+    ASSERT_TRUE(m2.read(path, offset)) << "torn primary must fall back to .bak";
+    EXPECT_EQ(path, fitPath);
+    EXPECT_EQ(offset, off1) << ".bak holds the previous flush offset";
+
+    // recover() finalizes the .fit at the recovered offset: the activity is
+    // preserved (not lost) and the marker set is fully cleared afterwards.
+    const auto res = m2.recover();
+    EXPECT_TRUE(res.recovered);
+    EXPECT_EQ(res.path, fitPath);
+    EXPECT_FALSE(fs.exist("Activity/.recording"));
+    EXPECT_FALSE(fs.exist("Activity/.recording.bak"));
+
+    const std::vector<uint8_t> b = bytesOf(fs, fitPath);
+    testfit::FitReader r(b);
+    EXPECT_TRUE(r.ok()) << "recovered-from-.bak file parses";
+    EXPECT_TRUE(r.crcValid()) << "recovered-from-.bak file CRC verifies";
+    EXPECT_EQ(b.size(), off1 + 2u) << "finalized to the .bak offset [0,off1) + CRC";
+}
+
+// Fix 1: remove() must clear the whole marker set -- primary, .bak and any
+// stray .tmp left by an interrupted publish.
+TEST(RecordingMarker, RemoveCleansPrimaryBakAndTmp)
+{
+    InMemoryFileSystem fs;
+    RecordingMarker m(fs, "Activity");
+
+    ASSERT_TRUE(m.write("Activity/a.fit", 100));
+    ASSERT_TRUE(m.update(200));                          // creates the .bak
+    fs.seedFile("Activity/.recording.tmp", "stale");     // stray temp from a crash
+
+    ASSERT_TRUE(fs.exist("Activity/.recording"));
+    ASSERT_TRUE(fs.exist("Activity/.recording.bak"));
+    ASSERT_TRUE(fs.exist("Activity/.recording.tmp"));
+
+    m.remove();
+    EXPECT_FALSE(fs.exist("Activity/.recording"));
+    EXPECT_FALSE(fs.exist("Activity/.recording.bak"));
+    EXPECT_FALSE(fs.exist("Activity/.recording.tmp"));
+}

--- a/Tests/Host/support/KernelTestDoubles.cpp
+++ b/Tests/Host/support/KernelTestDoubles.cpp
@@ -207,6 +207,11 @@ bool InMemoryFileSystem::InMemoryFile::write(const char* buff, size_t btw, size_
         return false;
     }
 
+    // Injected storage failure: refuse writes once the byte budget is spent.
+    if (mFs.bytesWritten >= mFs.failWritesAfterBytes) {
+        return false;
+    }
+
     auto& entry = mFs.files[mPath];
     entry.exists = true;
 
@@ -221,6 +226,7 @@ bool InMemoryFileSystem::InMemoryFile::write(const char* buff, size_t btw, size_
     std::memcpy(entry.content.data() + mPos, buff, btw);
     mPos += btw;
     bw = btw;
+    mFs.bytesWritten += btw;
     return true;
 }
 
@@ -248,6 +254,9 @@ bool InMemoryFileSystem::InMemoryFile::truncate(size_t offset)
 
 bool InMemoryFileSystem::InMemoryFile::flush()
 {
+    if (mOpen) {
+        ++mFs.flushCounts[mPath];
+    }
     return mOpen;
 }
 

--- a/Tests/Host/support/KernelTestDoubles.cpp
+++ b/Tests/Host/support/KernelTestDoubles.cpp
@@ -149,6 +149,16 @@ size_t InMemoryFileSystem::InMemoryFile::size() const
 
 bool InMemoryFileSystem::InMemoryFile::open(bool wMode, bool override)
 {
+    // Injected, file-kind-scoped storage failure: refuse to open a matching path
+    // for writing without touching the entry (e.g. the auxiliary ".json" summary
+    // fails while the ".fit" is already durable).
+    if (wMode && !mFs.failWriteOpenSuffix.empty()
+        && mPath.size() >= mFs.failWriteOpenSuffix.size()
+        && mPath.compare(mPath.size() - mFs.failWriteOpenSuffix.size(),
+                         mFs.failWriteOpenSuffix.size(), mFs.failWriteOpenSuffix) == 0) {
+        return false;
+    }
+
     mWriteMode = wMode;
 
     if (wMode) {

--- a/Tests/Host/support/KernelTestDoubles.hpp
+++ b/Tests/Host/support/KernelTestDoubles.hpp
@@ -136,6 +136,10 @@ public:
     /// Once bytesWritten reaches this threshold, subsequent write() calls fail
     /// (simulates a storage write error). Defaults to "never fail".
     size_t failWritesAfterBytes = static_cast<size_t>(-1);
+    /// A write-mode open() targeting a path ending with this suffix fails without
+    /// creating/touching the entry (simulates a storage error scoped to one file
+    /// kind, e.g. the auxiliary ".json" summary). Empty = never fail.
+    std::string failWriteOpenSuffix;
 };
 
 struct KernelFixture {

--- a/Tests/Host/support/KernelTestDoubles.hpp
+++ b/Tests/Host/support/KernelTestDoubles.hpp
@@ -127,6 +127,15 @@ public:
     std::string readFile(const std::string& path) const;
 
     std::unordered_map<std::string, InMemoryFileEntry> files;
+
+    // -- Test instrumentation -------------------------------------------------
+    /// Number of successful flush() calls, keyed by file path.
+    std::unordered_map<std::string, size_t> flushCounts;
+    /// Total bytes written across all files (successful writes only).
+    size_t bytesWritten = 0;
+    /// Once bytesWritten reaches this threshold, subsequent write() calls fail
+    /// (simulates a storage write error). Defaults to "never fail".
+    size_t failWritesAfterBytes = static_cast<size_t>(-1);
 };
 
 struct KernelFixture {

--- a/cmake/una-sdk.cmake
+++ b/cmake/una-sdk.cmake
@@ -19,6 +19,7 @@ set(UNA_SDK_SOURCES_FIT
     "$ENV{UNA_SDK}/Libs/Source/Fit/FitCrc.cpp"
     "$ENV{UNA_SDK}/Libs/Source/Fit/FitWriter.cpp"
     "$ENV{UNA_SDK}/Libs/Source/Fit/FitRecordCadence.cpp"
+    "$ENV{UNA_SDK}/Libs/Source/Fit/RecordingMarker.cpp"
 )
 
 set(UNA_SDK_SOURCES_JSON


### PR DESCRIPTION
## Summary

Makes `.fit` activity recording crash-safe. A reset mid-recording (the field-reboot class) used to leave the `.fit` with a placeholder header (`dataSize=0`, no CRC) — unrecoverable and unimportable — so the whole workout was lost. This is the **SDK half of robustness-audit finding #4** (the kernel half — atomic settings + boot-time mount recovery — is a separate kernel PR).

Two findings:

### #11 — Flush during recording + next-boot recovery
- **`FitWriter`**: `finish()`'s back-patch / read-back-CRC / append tail is refactored into a shared `finalize(IFile&, dataEnd)` and exposed as `static recover(IFile&, dataEnd)`. `recover()` reads the on-disk header (protocol/profile survive a reboot), back-patches `dataSize`, recomputes the file CRC over `[0,dataEnd)`, writes the CRC and **truncates to `dataEnd+2`** to trim any torn tail. Idempotent — a header with a non-zero `dataSize` is treated as already finalized and left intact, so a stale recovery offset can never discard a completed session/activity. `finish()`'s normal path is byte-identical (verified by the existing encoder tests).
- **New `SDK::Fit::RecordingMarker`** (all shared, zero per-app logic): a crash marker at `<activityDir>/.recording` holding the `.fit` path + the last flushed, record-complete offset. Written after the header+definitions, refreshed on each durable flush, removed on clean `stop()`/`discard()`. `recover()` reads it, finalizes the `.fit` at that offset, and always clears the marker. **The marker itself is crash-atomic** (staged `.tmp` then rotate, with a `.bak` fallback) so a crash mid-update degrades to the previous flushed offset rather than losing the activity — mirrors the kernel's `SettingsManagerBase` rotate.
- **Per-app `ActivityWriter`** (all 6 apps): flush the `.fit` + refresh the marker every ~30 s of records and on every lap, **only when `flush()` succeeds** (so the marker never advances past non-durable data); the start-time marker is written only when `begin()` succeeded. `recoverInterrupted()` is a one-call wrapper over the shared marker recover.
- **Per-app `Service`**: `run()` finalizes any interrupted activity at startup (before the first `startTrack`) and registers it via `notifyNewActivity()`. Recovery loses at most ~30 s and produces a strictly valid, importable `.fit`.

### #40 — Propagate the save status
- `ActivityWriter::stop()` now returns `bool`, threading `ok()` / `finish()` / flush / close / `saveSummary`; `LOG_ERROR` on failure. The marker is removed **only** once the `.fit` is durably finished, so a failed save is retried by next-boot recovery.
- `Service` gates registration: `notifyNewActivity()` only on `stop()==true`, else `LOG_ERROR("activity save failed")`. No user-facing UI (per agreed scope).

## Minimal per-app footprint
All reusable logic (marker I/O + recover orchestration + FIT finalize/recover) lives in the shared Fit lib. Each app gets thin wiring only — no duplicated marker/recover logic across the 6 copies.

## Testing
- **Host tests: 152/152 pass.**
  - `FitWriter`: crash→reboot→recover, torn-tail trim, idempotent, already-finalized-with-trailing-bytes no-op, bad input.
  - `RecordingMarker`: round-trip, **crash-during-update `.bak` fallback**, cleanup of primary+bak+tmp.
  - Running `ActivityWriter`: flush cadence (30 s + lap), end-to-end recovery through the app, `stop()` success/failure gating.
- **`Cycling.uapp` arm-built** (arm-none-eabi + Ninja) to verify the per-app wiring links on target — this also caught the missing `RecordingMarker.cpp` in `cmake/una-sdk.cmake` (now fixed; host-test CMake updated too).

## Known limitations (by design)
- Recovery finalizes the `.fit` only; the sibling `.json` summary is not reconstructed. Activities register off the `.fit` path, not the `.json`, so the recovered workout still appears (its on-watch summary card may be blank until synced; the real data is in the `.fit`).
- **HRMonitor** has no activity-notify mechanism (it never has — it relies on the kernel's boot-time activity scan for every `.fit`). So a recovered HRMonitor session registers on the *next* boot's scan rather than immediately. Documented in its `run()`; not a regression.

## On-device verification (not covered by host tests / arm-link)
- [ ] Force a reset mid-activity (all 6 apps); confirm on next boot the interrupted `.fit` is finalized, imports cleanly, and the marker is gone.
- [ ] Confirm a normal stop still produces a byte-valid `.fit` and its `.json`, and registers exactly once (no double-registration vs. recovery).
- [ ] Confirm the ~30 s flush cadence has no visible recording-thread stall on eMMC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added crash/power-loss recovery for interrupted activities, with automatic recovery on app/service startup.
  * Introduced a dedicated on-disk recording marker to finalize partially written FIT recordings.

* **Bug Fixes**
  * Improved durability: recovery/marker progression now advances only after successful flushes.
  * FIT finalization is now result-driven: notifications depend on successful FIT durability, not best-effort sidecar output.
  * Discarding/failing finalization now preserves recovery for the next boot.

* **Tests**
  * Expanded host tests for marker behavior, FIT recovery edge cases, flush cadence, and recovery/failure semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->