### PR TITLE
fix(apps): pin distance auto-laps to the km/mi grid (no drift)

### DIFF
--- a/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
@@ -142,7 +142,7 @@ private:
     void sendInitialInfoToGui();
     void startTrack(std::time_t utc);
     void processTrack();
-    void saveLap();
+    void saveLap(float autoLapDistanceM = 0.0f);
     void stopTrack(bool discard);
     void pauseTrack(bool pause);
     void buildPartialSummary();

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -709,11 +709,17 @@ void Service::processTrack()
         mSessionNotEmpty = true;    // Session has at least one record
         mLapNotEmpty = true;        // Lap has at least one record
 
-        bool switchLap = false;
+        bool  switchLap        = false;
+        float autoLapDistanceM = 0.0f;  // >0 marks a grid-aligned distance auto-lap
         switch (mLapDivSource) {
-        case LapDivSource::DISTANCE:
-            switchLap = mDistanceCounter.getLapValueActive() >= Settings::Alerts::Distance::toMeters(mSettings.alertDistanceId, mIsImperial);
+        case LapDivSource::DISTANCE: {
+            const float target = Settings::Alerts::Distance::toMeters(mSettings.alertDistanceId, mIsImperial);
+            if (mDistanceCounter.getLapValueActive() >= target) {
+                switchLap        = true;
+                autoLapDistanceM = target;
+            }
             break;
+        }
         case LapDivSource::TIME:
             switchLap = static_cast<uint32_t>(mTimeCounter.getLapValueActive()) >= Settings::Alerts::Time::toSeconds(mSettings.alertTimeId);
             break;
@@ -723,17 +729,23 @@ void Service::processTrack()
         }
 
         if (switchLap) {
-            saveLap();
+            saveLap(autoLapDistanceM);
             mGuiSender.lapEnd(mTrackData.lapNum);
             notifyLapEnd();
         }
     }
 }
 
-void Service::saveLap()
+void Service::saveLap(float autoLapDistanceM)
 {
     const auto  lapTime     = mTimeCounter.getLapValueActive();
-    const float lapDistance = mDistanceCounter.getLapValueActive();
+    // A distance auto-lap (autoLapDistanceM > 0) is recorded as exactly the
+    // target distance; the overshoot is carried into the next lap below. This
+    // keeps lap boundaries on the km/mi grid and makes the reported lap pace
+    // agree with the lap duration.
+    const bool  gridLap     = autoLapDistanceM > 0.0f;
+    const float lapDistance = gridLap ? autoLapDistanceM
+                                      : mDistanceCounter.getLapValueActive();
     const float lapSpeed    = speedFromTotals(lapDistance, static_cast<float>(lapTime));
 
     // Accumulate lap into summary
@@ -775,7 +787,11 @@ void Service::saveLap()
 
     // Reset lap counters
     mTimeCounter.resetLap();
-    mDistanceCounter.resetLap();
+    if (gridLap) {
+        mDistanceCounter.advanceLap(lapDistance);
+    } else {
+        mDistanceCounter.resetLap();
+    }
     mSpeedCounter.resetLap();
     mHrCounter.resetLap();
     mAltitudeCounter.resetLap();

--- a/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
@@ -147,7 +147,7 @@ private:
     void sendInitialInfoToGui();
     void startTrack(std::time_t utc);
     void processTrack();
-    void saveLap();
+    void saveLap(float autoLapDistanceM = 0.0f);
     void stopTrack(bool discard);
     void pauseTrack(bool pause);
     void buildPartialSummary();

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -745,11 +745,17 @@ void Service::processTrack()
         mSessionNotEmpty = true;    // Session has at least one record
         mLapNotEmpty = true;        // Lap has at least one record
 
-        bool switchLap = false;
+        bool  switchLap        = false;
+        float autoLapDistanceM = 0.0f;  // >0 marks a grid-aligned distance auto-lap
         switch (mLapDivSource) {
-        case LapDivSource::DISTANCE:
-            switchLap = mDistanceCounter.getLapValueActive() >= Settings::Alerts::Distance::toMeters(mSettings.alertDistanceId, mIsImperial);
+        case LapDivSource::DISTANCE: {
+            const float target = Settings::Alerts::Distance::toMeters(mSettings.alertDistanceId, mIsImperial);
+            if (mDistanceCounter.getLapValueActive() >= target) {
+                switchLap        = true;
+                autoLapDistanceM = target;
+            }
             break;
+        }
         case LapDivSource::TIME:
             switchLap = static_cast<uint32_t>(mTimeCounter.getLapValueActive()) >= Settings::Alerts::Time::toSeconds(mSettings.alertTimeId);
             break;
@@ -759,17 +765,23 @@ void Service::processTrack()
         }
 
         if (switchLap) {
-            saveLap();
+            saveLap(autoLapDistanceM);
             mGuiSender.lapEnd(mTrackData.lapNum);
             notifyLapEnd();
         }
     }
 }
 
-void Service::saveLap()
+void Service::saveLap(float autoLapDistanceM)
 {
     const auto  lapTime     = mTimeCounter.getLapValueActive();
-    const float lapDistance = mDistanceCounter.getLapValueActive();
+    // A distance auto-lap (autoLapDistanceM > 0) is recorded as exactly the
+    // target distance; the overshoot is carried into the next lap below. This
+    // keeps lap boundaries on the km/mi grid and makes the reported lap pace
+    // agree with the lap duration.
+    const bool  gridLap     = autoLapDistanceM > 0.0f;
+    const float lapDistance = gridLap ? autoLapDistanceM
+                                      : mDistanceCounter.getLapValueActive();
     const float lapSpeed    = speedFromTotals(lapDistance, static_cast<float>(lapTime));
 
     // Accumulate lap into summary
@@ -816,7 +828,11 @@ void Service::saveLap()
 
     // Reset lap counters
     mTimeCounter.resetLap();
-    mDistanceCounter.resetLap();
+    if (gridLap) {
+        mDistanceCounter.advanceLap(lapDistance);
+    } else {
+        mDistanceCounter.resetLap();
+    }
     mSpeedCounter.resetLap();
     mHrCounter.resetLap();
     mAltitudeCounter.resetLap();

--- a/Examples/Apps/Running/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Service.hpp
@@ -198,7 +198,7 @@ private:
     void sendInitialInfoToGui();
     void startTrack(std::time_t utc);
     void processTrack();
-    void saveLap();
+    void saveLap(float autoLapDistanceM = 0.0f);
     void stopTrack(bool discard);
     void pauseTrack(bool pause);
     void buildPartialSummary();

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -889,11 +889,17 @@ void Service::processTrack()
         mLapNotEmpty = true;        // Lap has at least one record
 
         // Next lap
-        bool switchLap = false;
+        bool  switchLap        = false;
+        float autoLapDistanceM = 0.0f;  // >0 marks a grid-aligned distance auto-lap
         switch (mLapDivSource) {
-        case LapDivSource::DISTANCE:
-            switchLap = mDistanceCounter.getLapValueActive() >= Settings::Alerts::Distance::toMeters(mSettings.alertDistanceId, mIsImperial);
+        case LapDivSource::DISTANCE: {
+            const float target = Settings::Alerts::Distance::toMeters(mSettings.alertDistanceId, mIsImperial);
+            if (mDistanceCounter.getLapValueActive() >= target) {
+                switchLap        = true;
+                autoLapDistanceM = target;
+            }
             break;
+        }
         case LapDivSource::TIME:
             switchLap = static_cast<uint32_t>(mTimeCounter.getLapValueActive()) >= Settings::Alerts::Time::toSeconds(mSettings.alertTimeId);
             break;
@@ -904,7 +910,7 @@ void Service::processTrack()
         }
 
         if (switchLap) {
-            saveLap();
+            saveLap(autoLapDistanceM);
             mGuiSender.lapEnd(mTrackData.lapNum);
             notifyLapEnd();
         }
@@ -913,10 +919,16 @@ void Service::processTrack()
 
 }
 
-void Service::saveLap()
+void Service::saveLap(float autoLapDistanceM)
 {
     const auto  lapTime     = mTimeCounter.getLapValueActive();
-    const float lapDistance = mDistanceCounter.getLapValueActive();
+    // A distance auto-lap (autoLapDistanceM > 0) is recorded as exactly the
+    // target distance; the overshoot is carried into the next lap below. This
+    // keeps lap boundaries on the km/mi grid and makes the reported lap pace
+    // agree with the lap duration.
+    const bool  gridLap     = autoLapDistanceM > 0.0f;
+    const float lapDistance = gridLap ? autoLapDistanceM
+                                      : mDistanceCounter.getLapValueActive();
     const float lapSpeed    = speedFromTotals(lapDistance, static_cast<float>(lapTime));
 
     // Accumulate lap into summary
@@ -962,7 +974,11 @@ void Service::saveLap()
 
     // Reset lap counters
     mTimeCounter.resetLap();
-    mDistanceCounter.resetLap();
+    if (gridLap) {
+        mDistanceCounter.advanceLap(lapDistance);
+    } else {
+        mDistanceCounter.resetLap();
+    }
     mSpeedCounter.resetLap();
     mHrCounter.resetLap();
     mAltitudeCounter.resetLap();

--- a/Examples/Apps/Treadmill/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Header/Service.hpp
@@ -219,7 +219,7 @@ private:
     void sendInitialInfoToGui();
     void startTrack(std::time_t utc);
     void processTrack();
-    void saveLap();
+    void saveLap(float autoLapDistanceM = 0.0f);
     void stopTrack(bool discard);
     void finalizeActivity(float distanceActualM); ///< Apply §5 calibration (<=0 = skip) + write FIT session.
     void pauseTrack(bool pause);

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
@@ -853,11 +853,17 @@ void Service::processTrack()
         mLapNotEmpty = true;        // Lap has at least one record
 
         // Next lap
-        bool switchLap = false;
+        bool  switchLap        = false;
+        float autoLapDistanceM = 0.0f;  // >0 marks a grid-aligned distance auto-lap
         switch (mLapDivSource) {
-        case LapDivSource::DISTANCE:
-            switchLap = mDistanceCounter.getLapValueActive() >= Settings::Alerts::Distance::toMeters(mSettings.alertDistanceId, mIsImperial);
+        case LapDivSource::DISTANCE: {
+            const float target = Settings::Alerts::Distance::toMeters(mSettings.alertDistanceId, mIsImperial);
+            if (mDistanceCounter.getLapValueActive() >= target) {
+                switchLap        = true;
+                autoLapDistanceM = target;
+            }
             break;
+        }
         case LapDivSource::TIME:
             switchLap = static_cast<uint32_t>(mTimeCounter.getLapValueActive()) >= Settings::Alerts::Time::toSeconds(mSettings.alertTimeId);
             break;
@@ -868,7 +874,7 @@ void Service::processTrack()
         }
 
         if (switchLap) {
-            saveLap();
+            saveLap(autoLapDistanceM);
             mGuiSender.lapEnd(mTrackData.lapNum);
             notifyLapEnd();
         }
@@ -877,10 +883,16 @@ void Service::processTrack()
 
 }
 
-void Service::saveLap()
+void Service::saveLap(float autoLapDistanceM)
 {
     const auto  lapTime     = mTimeCounter.getLapValueActive();
-    const float lapDistance = mDistanceCounter.getLapValueActive();
+    // A distance auto-lap (autoLapDistanceM > 0) is recorded as exactly the
+    // target distance; the overshoot is carried into the next lap below. This
+    // keeps lap boundaries on the km/mi grid and makes the reported lap pace
+    // agree with the lap duration.
+    const bool  gridLap     = autoLapDistanceM > 0.0f;
+    const float lapDistance = gridLap ? autoLapDistanceM
+                                      : mDistanceCounter.getLapValueActive();
     const float lapSpeed    = speedFromTotals(lapDistance, static_cast<float>(lapTime));
 
     // Accumulate lap into summary
@@ -926,7 +938,11 @@ void Service::saveLap()
 
     // Reset lap counters
     mTimeCounter.resetLap();
-    mDistanceCounter.resetLap();
+    if (gridLap) {
+        mDistanceCounter.advanceLap(lapDistance);
+    } else {
+        mDistanceCounter.resetLap();
+    }
     mSpeedCounter.resetLap();
     mHrCounter.resetLap();
     mAltitudeCounter.resetLap();

--- a/Libs/Header/SDK/Metrics/MonotonicCounter.hpp
+++ b/Libs/Header/SDK/Metrics/MonotonicCounter.hpp
@@ -236,7 +236,11 @@ void MonotonicCounter<T>::add(T currentValue)
         return;
     }
 
-    if (mBaseValue == T{} && mValueActive == T{}) {
+    // Seat the base on the first sample. Keyed off mHasData, not the values:
+    // a first sample equal to T{} (e.g. distance starting at 0) would otherwise
+    // keep the value-sentinel true and re-seat on the next call, dropping the
+    // first real movement.
+    if (!mHasData) {
         mBaseValue         = currentValue;
         mBaseValueTotal    = currentValue;
         mLapBaseValue      = currentValue;
@@ -247,7 +251,9 @@ void MonotonicCounter<T>::add(T currentValue)
         return;
     }
 
-    if (mLapBaseValue == T{} && mLapValueActive == T{}) {
+    // Re-seat the lap base on the first sample after resetLap(); keyed off
+    // mHasLapData for the same reason as above.
+    if (!mHasLapData) {
         mLapBaseValue      = currentValue;
         mLapBaseValueTotal = currentValue;
         mHasLapData        = true;

--- a/Libs/Header/SDK/Metrics/MonotonicCounter.hpp
+++ b/Libs/Header/SDK/Metrics/MonotonicCounter.hpp
@@ -51,7 +51,10 @@ public:
     void reset();
 
     /**
-     * @brief Reset current lap values only. Total values are preserved.
+     * @brief Close the current lap and start a new one from the current
+     *        position, gap-free. Lap values reset to zero; total values are
+     *        preserved. Unlike a re-seat on the next sample, no sub-sample
+     *        distance is dropped at the lap boundary.
      */
     void resetLap();
 
@@ -209,11 +212,17 @@ void MonotonicCounter<T>::reset()
 template<typename T>
 void MonotonicCounter<T>::resetLap()
 {
+    // Close the current lap exactly where it stands and start the next lap
+    // there, with no gap: advance each lap base by the amount this lap already
+    // consumed (active and includes-pauses independently, so pauses stay
+    // correct). The old approach zeroed the base and re-seated on the *next*
+    // sample, which dropped the sub-sample sliver between the lap event and the
+    // following sample. Base stays seated (mHasLapData untouched), so add()
+    // keeps accumulating contiguously.
+    mLapBaseValue      = mLapBaseValue      + mLapValueActive;
+    mLapBaseValueTotal = mLapBaseValueTotal + mLapValueTotal;
     mLapValueActive    = T{};
     mLapValueTotal     = T{};
-    mLapBaseValue      = T{};
-    mLapBaseValueTotal = T{};
-    mHasLapData        = false;
 }
 
 template<typename T>
@@ -239,7 +248,8 @@ void MonotonicCounter<T>::add(T currentValue)
     // Seat the base on the first sample. Keyed off mHasData, not the values:
     // a first sample equal to T{} (e.g. distance starting at 0) would otherwise
     // keep the value-sentinel true and re-seat on the next call, dropping the
-    // first real movement.
+    // first real movement. This also seats the lap base; resetLap()/advanceLap()
+    // keep the lap base seated afterwards, so there is no separate re-seat path.
     if (!mHasData) {
         mBaseValue         = currentValue;
         mBaseValueTotal    = currentValue;
@@ -249,14 +259,6 @@ void MonotonicCounter<T>::add(T currentValue)
         mHasData           = true;
         mHasLapData        = true;
         return;
-    }
-
-    // Re-seat the lap base on the first sample after resetLap(); keyed off
-    // mHasLapData for the same reason as above.
-    if (!mHasLapData) {
-        mLapBaseValue      = currentValue;
-        mLapBaseValueTotal = currentValue;
-        mHasLapData        = true;
     }
 
     if (currentValue < mLastValidValue) {

--- a/Libs/Header/SDK/Metrics/MonotonicCounter.hpp
+++ b/Libs/Header/SDK/Metrics/MonotonicCounter.hpp
@@ -228,6 +228,14 @@ void MonotonicCounter<T>::resetLap()
 template<typename T>
 void MonotonicCounter<T>::advanceLap(T span)
 {
+    // Never advance past what the lap has accumulated: a span larger than the
+    // current lap value would drive the accumulators negative. Callers close on
+    // a target they have already reached (getLapValueActive() >= span), so this
+    // only guards against future misuse. Clamping to the active value keeps the
+    // total non-negative too, since the active value never exceeds the total.
+    if (span > mLapValueActive) {
+        span = mLapValueActive;
+    }
     // Move the lap base forward by exactly `span`; the excess already covered
     // this lap (the overshoot past the target) rolls into the new lap so lap
     // boundaries never drift. Base stays seated, so add() keeps accumulating

--- a/Libs/Header/SDK/Metrics/MonotonicCounter.hpp
+++ b/Libs/Header/SDK/Metrics/MonotonicCounter.hpp
@@ -56,6 +56,21 @@ public:
     void resetLap();
 
     /**
+     * @brief Close the current lap as exactly @p span and carry the overshoot
+     *        into the next lap.
+     *
+     * Unlike resetLap(), which re-bases at the next sample and therefore
+     * discards whatever was accumulated beyond the lap target, advanceLap()
+     * shifts the lap base forward by @p span. The amount already accumulated
+     * past @p span becomes the starting value of the new lap, so distance-
+     * triggered laps stay pinned to exact multiples of the target instead of
+     * drifting by the per-sample overshoot.
+     *
+     * @param span Lap size to close on, in the counter's value units.
+     */
+    void advanceLap(T span);
+
+    /**
      * @brief Add new metric measurement.
      *
      * First call after init/reset sets the base point.
@@ -199,6 +214,19 @@ void MonotonicCounter<T>::resetLap()
     mLapBaseValue      = T{};
     mLapBaseValueTotal = T{};
     mHasLapData        = false;
+}
+
+template<typename T>
+void MonotonicCounter<T>::advanceLap(T span)
+{
+    // Move the lap base forward by exactly `span`; the excess already covered
+    // this lap (the overshoot past the target) rolls into the new lap so lap
+    // boundaries never drift. Base stays seated, so add() keeps accumulating
+    // instead of re-seating on the next sample.
+    mLapValueActive    = mLapValueActive    - span;
+    mLapValueTotal     = mLapValueTotal     - span;
+    mLapBaseValue      = mLapBaseValue      + span;
+    mLapBaseValueTotal = mLapBaseValueTotal + span;
 }
 
 template<typename T>

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(una-sdk-host-tests
     apps/Running/ActivityWriter_test.cpp
     sensorlayer/HeartRateParser_test.cpp
     sensorlayer/HeartRateExParser_test.cpp
+    metrics/MonotonicCounter_test.cpp
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/SettingsSerializer.cpp"
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/Calibration/OutdoorStrideCalibrator.cpp"

--- a/Tests/Host/metrics/MonotonicCounter_test.cpp
+++ b/Tests/Host/metrics/MonotonicCounter_test.cpp
@@ -54,24 +54,62 @@ TEST(MonotonicCounter, FirstMovementFromZeroNotDropped)
     EXPECT_FLOAT_EQ(c.getValueActive(), 11.0f);
 }
 
-// Baseline behaviour: resetLap() re-bases at the next sample, discarding the
-// overshoot. This is what caused the drift and is preserved for manual /
-// time / final laps.
-TEST(MonotonicCounter, ResetLapDropsOvershoot)
+// resetLap() closes the lap where it stands and starts the next lap there with
+// no gap: the distance travelled between the lap event and the next sample is
+// counted in the new lap, not dropped. (Used for manual / time / final laps.)
+TEST(MonotonicCounter, ResetLapIsGapFree)
 {
     MonotonicCounter<float> c;
     c.init();
 
     c.add(kBase);            // seat base
     c.add(kBase + 6.0f);
-    c.add(kBase + 12.0f);    // lap value now 12, target 10 -> overshoot 2
+    c.add(kBase + 12.0f);    // lap value now 12
 
     EXPECT_FLOAT_EQ(c.getLapValueActive(), 12.0f);
-    c.resetLap();
-    c.add(kBase + 18.0f);    // re-based here; overshoot of 2 is lost
+    c.resetLap();            // close the lap exactly here
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 0.0f);
 
-    EXPECT_FLOAT_EQ(c.getLapValueActive(), 0.0f); // 18 - 18 lap base
+    c.add(kBase + 18.0f);    // +6 m since the lap event
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 6.0f); // sliver counted, not dropped
     EXPECT_FLOAT_EQ(c.getValueActive(), 18.0f);   // total is unaffected
+}
+
+// resetLap() called mid-pause must stay consistent through resume(): the closed
+// lap keeps its pre-pause active distance, and the new lap starts from the reset
+// point with the paused distance correctly excluded from active. The old
+// re-seat path re-based to a mid-pause sample and then had resume() add the
+// pause offset on top, double-counting it into a NEGATIVE lap distance.
+TEST(MonotonicCounter, ResetLapDuringPauseStaysConsistent)
+{
+    MonotonicCounter<float> c;
+    c.init();
+
+    c.add(0.0f);
+    c.add(100.0f);          // 100 m of active distance this lap
+
+    c.pause();              // pause at 100
+    c.add(150.0f);          // sensor keeps moving while paused (not active)
+
+    // Manual lap while paused: closes at the frozen active distance and the
+    // includes-pauses total.
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 100.0f);
+    EXPECT_FLOAT_EQ(c.getLapValueTotal(), 150.0f);
+    c.resetLap();
+
+    c.add(170.0f);          // still paused after the reset -- the old bug trigger
+    c.resume();             // resume at 170; 70 m elapsed during the pause
+
+    c.add(200.0f);          // 30 m of real movement after resuming
+
+    // New lap counts only post-resume active movement; never negative.
+    EXPECT_GE(c.getLapValueActive(), 0.0f);
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 30.0f);
+    // New lap's includes-pauses total spans the reset point (150) to 200 = 50
+    // (20 m during the pause tail + 30 m active).
+    EXPECT_FLOAT_EQ(c.getLapValueTotal(), 50.0f);
+    // Session active distance excludes the 70 m paused: 100 + 30.
+    EXPECT_FLOAT_EQ(c.getValueActive(), 130.0f);
 }
 
 // advanceLap() carries the overshoot: after closing a 10 m lap at value 12,
@@ -93,15 +131,17 @@ TEST(MonotonicCounter, AdvanceLapCarriesOvershoot)
 }
 
 // The core regression: over many laps, advanceLap keeps the auto-lap firing on
-// exact multiples of the target, while resetLap drifts by the overshoot.
+// exact multiples of the target. resetLap is gap-free but does not carry the
+// overshoot, so a resetLap-driven auto-lap still drifts by the accumulated
+// overshoot -- which is exactly why the distance auto-lap uses advanceLap.
 TEST(MonotonicCounter, DistanceLapsDoNotDriftWithAdvanceLap)
 {
     constexpr float kTarget = 1000.0f;
     // 7 m/s at 1 Hz -> 7 m per sample; boundaries are crossed mid-sample.
     const std::vector<float> stream = makeStream(7.0f, 2000);
 
-    MonotonicCounter<float> drift;   // old behaviour
-    MonotonicCounter<float> fixed;   // new behaviour
+    MonotonicCounter<float> drift;   // resetLap: drifts by accumulated overshoot
+    MonotonicCounter<float> fixed;   // advanceLap: pinned to the grid
     drift.init();
     fixed.init();
 
@@ -164,4 +204,68 @@ TEST(MonotonicCounter, AdvanceLapCarriesActiveAndTotal)
     c.advanceLap(1000.0f);
     EXPECT_FLOAT_EQ(c.getLapValueActive(), 4.0f);
     EXPECT_FLOAT_EQ(c.getLapValueTotal(), 4.0f);
+}
+
+// End-to-end mix of distance auto-laps and manual laps, mirroring the Service
+// lap logic: auto-laps record exactly the target and carry (advanceLap); manual
+// laps record the actual distance and reset (resetLap). Verifies (a) a manual
+// lap re-syncs the auto grid to the manual point -- the next auto fires one full
+// target later, not on the original grid -- and (b) every metre is accounted
+// for: recorded laps + final partial sum to the total distance (no gap).
+TEST(MonotonicCounter, MixedAutoAndManualLaps)
+{
+    constexpr float kTarget    = 1000.0f;
+    constexpr float kManualAt  = 2500.0f;   // press lap here (getValueActive terms)
+    // 7 m/s at 1 Hz; enough samples for autos at ~1k/2k, a manual at 2.5k, then
+    // more autos out past 4.5k.
+    const std::vector<float> stream = makeStream(7.0f, 800);
+
+    MonotonicCounter<float> c;
+    c.init();
+
+    std::vector<float> recorded;        // every closed lap's recorded distance
+    std::vector<float> autoFires;       // cumulative distance at each auto fire
+    float manualFireDist = 0.0f;
+    bool  manualDone      = false;
+
+    for (float sample : stream) {
+        c.add(sample);
+        const float d = c.getValueActive();
+
+        if (!manualDone && d >= kManualAt) {
+            recorded.push_back(c.getLapValueActive());   // manual: actual distance
+            manualFireDist = d;
+            manualDone = true;
+            c.resetLap();
+        } else if (c.getLapValueActive() >= kTarget) {
+            recorded.push_back(kTarget);                 // auto: exactly the target
+            autoFires.push_back(d);
+            c.advanceLap(kTarget);
+        }
+    }
+    recorded.push_back(c.getLapValueActive());           // final partial lap
+    const float total = c.getValueActive();
+
+    ASSERT_TRUE(manualDone);
+
+    // Two autos land on the grid before the manual lap.
+    ASSERT_GE(autoFires.size(), 3u);
+    EXPECT_NEAR(autoFires[0], 1000.0f, 7.0f);
+    EXPECT_NEAR(autoFires[1], 2000.0f, 7.0f);
+
+    // The first auto after the manual lap fires ~1 target past the manual point
+    // (grid re-synced to the manual lap), NOT on the original 3000 m grid line.
+    float firstAutoAfterManual = 0.0f;
+    for (float f : autoFires) {
+        if (f > manualFireDist) { firstAutoAfterManual = f; break; }
+    }
+    ASSERT_GT(firstAutoAfterManual, 0.0f);
+    EXPECT_NEAR(firstAutoAfterManual, manualFireDist + kTarget, 7.0f);
+
+    // Conservation / gap-free: recorded laps + final partial == total distance.
+    // A dropped sub-sample sliver at the manual lap would make this short by
+    // ~one sample step (7 m), far above the 0.5 m float-noise tolerance.
+    float sum = 0.0f;
+    for (float r : recorded) sum += r;
+    EXPECT_NEAR(sum, total, 0.5f);
 }

--- a/Tests/Host/metrics/MonotonicCounter_test.cpp
+++ b/Tests/Host/metrics/MonotonicCounter_test.cpp
@@ -188,22 +188,48 @@ TEST(MonotonicCounter, DistanceLapsDoNotDriftWithAdvanceLap)
     EXPECT_FLOAT_EQ(sum, static_cast<float>(fixedLapSizes.size()) * kTarget);
 }
 
-// advanceLap must carry both the active and the total (includes-pauses) lap
-// accumulators so paused sessions stay consistent too.
+// advanceLap must carry the active and the total (includes-pauses) lap
+// accumulators independently. A pause makes them diverge (total > active), so
+// this exercises both carry paths rather than the degenerate active == total.
 TEST(MonotonicCounter, AdvanceLapCarriesActiveAndTotal)
 {
     MonotonicCounter<float> c;
     c.init();
 
-    c.add(kBase);            // seat base
-    c.add(kBase + 1004.0f);
+    c.add(kBase);                 // seat base
+    c.add(kBase + 200.0f);        // 200 m active
 
-    EXPECT_FLOAT_EQ(c.getLapValueActive(), 1004.0f);
+    c.pause();                    // pause at +200
+    c.add(kBase + 500.0f);        // +300 m while paused: total grows, active frozen
+    c.resume();                   // resume at +500
+
+    c.add(kBase + 1004.0f);       // +504 m active after resuming
+
+    // active = 200 + 504 = 704; total = 1004 (includes the 300 m paused).
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 704.0f);
     EXPECT_FLOAT_EQ(c.getLapValueTotal(), 1004.0f);
 
-    c.advanceLap(1000.0f);
+    c.advanceLap(700.0f);
+    // Each accumulator is carried independently: active 704-700, total 1004-700.
     EXPECT_FLOAT_EQ(c.getLapValueActive(), 4.0f);
-    EXPECT_FLOAT_EQ(c.getLapValueTotal(), 4.0f);
+    EXPECT_FLOAT_EQ(c.getLapValueTotal(), 304.0f);
+}
+
+// advanceLap must never drive the accumulators negative: an oversized span is
+// clamped to the current lap value.
+TEST(MonotonicCounter, AdvanceLapClampsOversizedSpan)
+{
+    MonotonicCounter<float> c;
+    c.init();
+
+    c.add(kBase);
+    c.add(kBase + 300.0f);        // lap value 300
+
+    c.advanceLap(1000.0f);        // span > lap value -> clamp to 300
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 0.0f);
+    EXPECT_GE(c.getLapValueActive(), 0.0f);
+    EXPECT_FLOAT_EQ(c.getLapValueTotal(), 0.0f);
+    EXPECT_FLOAT_EQ(c.getValueActive(), 300.0f);  // total unaffected
 }
 
 // End-to-end mix of distance auto-laps and manual laps, mirroring the Service

--- a/Tests/Host/metrics/MonotonicCounter_test.cpp
+++ b/Tests/Host/metrics/MonotonicCounter_test.cpp
@@ -18,9 +18,8 @@ namespace {
 // samples is > 0 so a lap boundary is generally crossed mid-sample, producing
 // an overshoot -- exactly the condition that used to make laps drift.
 //
-// The stream starts at a non-zero base: MonotonicCounter treats a first sample
-// equal to T{} as a not-yet-seeded sentinel and would re-seat the base on the
-// following call, which is not the behaviour under test here.
+// The stream starts at a non-zero base to mimic an absolute odometer; the
+// lap-drift maths is independent of the base value.
 constexpr float kBase = 10000.0f;
 
 std::vector<float> makeStream(float stepM, int samples)
@@ -36,6 +35,24 @@ std::vector<float> makeStream(float stepM, int samples)
 }
 
 } // namespace
+
+// The base is seated on the very first sample, even when that sample is 0, so
+// the first real movement after a zero start is counted rather than consumed
+// as a second base point.
+TEST(MonotonicCounter, FirstMovementFromZeroNotDropped)
+{
+    MonotonicCounter<float> c;
+    c.init();
+
+    c.add(0.0f);   // seat base at 0
+    c.add(5.0f);   // first movement -- must count, not re-seat the base
+
+    EXPECT_FLOAT_EQ(c.getValueActive(), 5.0f);
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 5.0f);
+
+    c.add(11.0f);
+    EXPECT_FLOAT_EQ(c.getValueActive(), 11.0f);
+}
 
 // Baseline behaviour: resetLap() re-bases at the next sample, discarding the
 // overshoot. This is what caused the drift and is preserved for manual /

--- a/Tests/Host/metrics/MonotonicCounter_test.cpp
+++ b/Tests/Host/metrics/MonotonicCounter_test.cpp
@@ -1,0 +1,150 @@
+// Unit tests for SDK::Metric::MonotonicCounter, focused on the distance
+// auto-lap "drift" fix: advanceLap() closes a lap on an exact target and
+// carries the per-sample overshoot into the next lap, so lap boundaries stay
+// pinned to the km/mi grid instead of walking forward by the overshoot.
+
+#include <gtest/gtest.h>
+
+#include "SDK/Metrics/MonotonicCounter.hpp"
+
+#include <vector>
+
+using SDK::Metric::MonotonicCounter;
+
+namespace {
+
+// A cumulative distance stream sampled at 1 Hz. Each element is the absolute
+// distance (metres) reported by the sensor at that tick. The step between
+// samples is > 0 so a lap boundary is generally crossed mid-sample, producing
+// an overshoot -- exactly the condition that used to make laps drift.
+//
+// The stream starts at a non-zero base: MonotonicCounter treats a first sample
+// equal to T{} as a not-yet-seeded sentinel and would re-seat the base on the
+// following call, which is not the behaviour under test here.
+constexpr float kBase = 10000.0f;
+
+std::vector<float> makeStream(float stepM, int samples)
+{
+    std::vector<float> out;
+    out.reserve(static_cast<size_t>(samples));
+    float d = kBase;
+    for (int i = 0; i < samples; ++i) {
+        out.push_back(d);
+        d += stepM;
+    }
+    return out;
+}
+
+} // namespace
+
+// Baseline behaviour: resetLap() re-bases at the next sample, discarding the
+// overshoot. This is what caused the drift and is preserved for manual /
+// time / final laps.
+TEST(MonotonicCounter, ResetLapDropsOvershoot)
+{
+    MonotonicCounter<float> c;
+    c.init();
+
+    c.add(kBase);            // seat base
+    c.add(kBase + 6.0f);
+    c.add(kBase + 12.0f);    // lap value now 12, target 10 -> overshoot 2
+
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 12.0f);
+    c.resetLap();
+    c.add(kBase + 18.0f);    // re-based here; overshoot of 2 is lost
+
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 0.0f); // 18 - 18 lap base
+    EXPECT_FLOAT_EQ(c.getValueActive(), 18.0f);   // total is unaffected
+}
+
+// advanceLap() carries the overshoot: after closing a 10 m lap at value 12,
+// the new lap already holds the 2 m overshoot.
+TEST(MonotonicCounter, AdvanceLapCarriesOvershoot)
+{
+    MonotonicCounter<float> c;
+    c.init();
+
+    c.add(kBase);            // seat base
+    c.add(kBase + 12.0f);    // lap value 12, close on target 10
+
+    c.advanceLap(10.0f);
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 2.0f);   // overshoot carried
+    EXPECT_FLOAT_EQ(c.getValueActive(), 12.0f);     // total unchanged
+
+    c.add(kBase + 20.0f);    // +8 m
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 10.0f);  // 2 carried + 8
+}
+
+// The core regression: over many laps, advanceLap keeps the auto-lap firing on
+// exact multiples of the target, while resetLap drifts by the overshoot.
+TEST(MonotonicCounter, DistanceLapsDoNotDriftWithAdvanceLap)
+{
+    constexpr float kTarget = 1000.0f;
+    // 7 m/s at 1 Hz -> 7 m per sample; boundaries are crossed mid-sample.
+    const std::vector<float> stream = makeStream(7.0f, 2000);
+
+    MonotonicCounter<float> drift;   // old behaviour
+    MonotonicCounter<float> fixed;   // new behaviour
+    drift.init();
+    fixed.init();
+
+    std::vector<float> driftBoundaries;   // cumulative distance at each lap fire
+    std::vector<float> fixedBoundaries;
+    std::vector<float> fixedLapSizes;     // recorded size of each closed lap
+
+    for (float sample : stream) {
+        drift.add(sample);
+        fixed.add(sample);
+
+        if (drift.getLapValueActive() >= kTarget) {
+            driftBoundaries.push_back(drift.getValueActive());
+            drift.resetLap();
+        }
+        if (fixed.getLapValueActive() >= kTarget) {
+            fixedBoundaries.push_back(fixed.getValueActive());
+            fixedLapSizes.push_back(kTarget);     // Service records exactly the target
+            fixed.advanceLap(kTarget);
+        }
+    }
+
+    ASSERT_GE(fixedBoundaries.size(), 5u);
+    ASSERT_EQ(driftBoundaries.size(), fixedBoundaries.size());
+
+    // Fixed: every fire lands within one sample-step of the exact grid line and
+    // never accumulates. The Nth boundary is at ~N*1000, not N*1000 + N*drift.
+    for (size_t i = 0; i < fixedBoundaries.size(); ++i) {
+        const float grid = static_cast<float>(i + 1) * kTarget;
+        EXPECT_LT(fixedBoundaries[i] - grid, 7.0f + 0.01f)
+            << "fixed lap " << i << " overshoot exceeded one sample step";
+        EXPECT_GE(fixedBoundaries[i], grid);
+    }
+
+    // Drift: the last boundary is far past its grid line -- the bug.
+    const size_t last = driftBoundaries.size() - 1;
+    const float lastGrid = static_cast<float>(last + 1) * kTarget;
+    EXPECT_GT(driftBoundaries[last] - lastGrid, 7.0f)
+        << "resetLap should visibly drift past the grid over many laps";
+
+    // Fixed lap sizes sum to exactly N*target (conservation, no lost/added distance).
+    float sum = 0.0f;
+    for (float s : fixedLapSizes) sum += s;
+    EXPECT_FLOAT_EQ(sum, static_cast<float>(fixedLapSizes.size()) * kTarget);
+}
+
+// advanceLap must carry both the active and the total (includes-pauses) lap
+// accumulators so paused sessions stay consistent too.
+TEST(MonotonicCounter, AdvanceLapCarriesActiveAndTotal)
+{
+    MonotonicCounter<float> c;
+    c.init();
+
+    c.add(kBase);            // seat base
+    c.add(kBase + 1004.0f);
+
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 1004.0f);
+    EXPECT_FLOAT_EQ(c.getLapValueTotal(), 1004.0f);
+
+    c.advanceLap(1000.0f);
+    EXPECT_FLOAT_EQ(c.getLapValueActive(), 4.0f);
+    EXPECT_FLOAT_EQ(c.getLapValueTotal(), 4.0f);
+}


### PR DESCRIPTION
## Problem

Distance auto-lap (e.g. "auto lap every 1 km") drifts. The lap fired when the
**per-lap** distance counter crossed the target, then `resetLap()` re-based the
counter at the current sensor reading — discarding the overshoot past the
boundary. At 1 Hz sampling each tick advances several metres, so every lap ran
`target + overshoot`, producing three symptoms from one root cause:

1. **Boundaries drift** off the km/mi grid as the overshoot accumulates.
2. Laps record as e.g. **1.01 km** instead of a clean km.
3. Per-lap **average pace disagrees with the lap duration** (a 1.006 km lap
   reports `time / 1.006 km`).

## Fix

**`fix(apps): pin distance auto-laps to the km/mi grid`**
- Adds `MonotonicCounter::advanceLap(span)`: closes the current lap as exactly
  `span` and carries the overshoot into the next lap by shifting the lap base
  forward (both active and includes-pauses accumulators) instead of zeroing it.
- Running, Hiking, Cycling and Treadmill now record each distance auto-lap as
  exactly the target and carry the remainder, so boundaries stay pinned to the
  grid. Because pace is derived as `target / lapTime`, the reported lap pace
  now equals the lap duration by construction. `saveLap()` gained a
  `float autoLapDistanceM = 0.0f` parameter; time, manual and interval laps
  keep using `resetLap()` and are unchanged.
- Session total distance is untouched; recorded laps still sum to N×target plus
  the final partial lap.

**`fix(metrics): don't drop the first movement when a counter starts at zero`**
- A pre-existing quirk surfaced while testing: `add()` decided whether the base
  was seated using the value-sentinel `mBaseValue == T{} && mValueActive == T{}`.
  When the first sample equals `T{}` (distance starting at 0) the sentinel
  stayed true, so the next call re-seated the base and the first real movement
  was dropped. Now keyed off `mHasData`. Non-zero-start behaviour is unchanged;
  the `advanceLap` carry is unaffected.

**`fix(metrics): make resetLap gap-free; test mixed auto/manual laps`**
- `resetLap()` zeroed the lap base and re-seated on the *next* sample, dropping
  the sub-sample sliver between a lap event and the following sample — so manual
  (and time / interval) laps lost a few metres each from lap accounting (session
  total unaffected). It now closes the lap in place by advancing each lap base by
  what the lap consumed (active and includes-pauses independently, pause-safe),
  matching the gap-free behaviour `advanceLap` already gave auto-laps. The
  now-unreachable lap re-seat branch in `add()` is removed.
- Adds a **mixed auto+manual regression test**: verifies a manual lap re-syncs
  the auto grid to the manual point (next auto one full target later, not on the
  original grid) and that recorded laps + final partial sum to the total (no gap).

## Tests

New host tests in `SDK/Tests/Host/metrics/MonotonicCounter_test.cpp` (8 tests):
overshoot carry, active/total carry across a pause, span clamp, gap-free reset,
zero-start regression, a 2000-sample multi-lap drift regression, a mixed
auto+manual end-to-end test, and a reset-during-pause consistency test.
**Full SDK host suite: 142/142 pass.** All four app service ELFs build for ARM.

## Note / follow-up

On an unfiltered GPS spike where a single 1 Hz sample jumps ≥2× the lap target,
the code emits a short burst of degenerate ~1 s laps (one per subsequent sample)
as the grid catches up, rather than one oversized lap. No loop/hang — at most one
lap per tick. GPS distance is filtered upstream so this is largely theoretical;
happy to add a multi-boundary skip if we want to harden it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved distance-based auto-lap handling so auto-laps can align precisely to the configured lap target.
* **Bug Fixes**
  * Corrected lap distance reporting for distance auto-laps, including better management of boundary overshoot to prevent later laps from being skewed.
  * Improved long-run stability to reduce accumulated lap distance drift when repeatedly splitting by distance.
* **Tests**
  * Expanded coverage for distance auto-lap/overshoot behavior, including clamping and mixed manual/auto lap sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->