### PR TITLE
feat(treadmill): per-record distance stream so Strava draws the pace graph

### DIFF
--- a/Examples/Apps/Treadmill/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Header/ActivityWriter.hpp
@@ -35,6 +35,7 @@ public:
     struct RecordData {
         // Treadmill records carry no position/altitude (§7.4.1).
         enum class Field : uint8_t {
+            DISTANCE     = 1u << 0,
             SPEED        = 1u << 1,
             HEART_RATE   = 1u << 3,
             BATTERY      = 1u << 4,
@@ -50,6 +51,7 @@ public:
 
         std::time_t timestamp      = 0;     // UTC
         float       speed          = 0.0f;  // m/s
+        float       distance       = 0.0f;  // m (cumulative, uncorrected estimate)
         float       heartRate      = 0.0f;  // bpm (arbitrated)
         uint8_t     hrSource       = 0;     // HeartRateEx::Source (0=none,1=optical,2=external)
         uint8_t     hrOpticalBpm   = 0;     // raw wrist-optical (PPG) bpm (0 = none)

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/ActivityWriter.cpp
@@ -23,7 +23,8 @@ using DevFieldDef = fit::FitWriter::DevField;
 
 namespace {
     // Native record fields shared by every record variant (treadmill: no GPS,
-    // no altitude -- cadence-driven speed, HR, cadence, model step length).
+    // no altitude -- cadence-driven speed, HR, cadence, model step length,
+    // cumulative estimated distance).
     // Field order here defines the on-wire order and must match the value-write
     // order in addRecord().
     const Field kRecordCommonTail[] = {
@@ -32,6 +33,7 @@ namespace {
         fit::field::Record::Cadence,
         fit::field::Record::FractionalCadence,
         fit::field::Record::StepLength,
+        fit::field::Record::Distance,
     };
 }  // namespace
 
@@ -146,14 +148,14 @@ void ActivityWriter::defineRecordMessages()
     mFit->defineMessage(L_RECORD, fit::mesgNum(fit::MesgNum::Record),
         {fit::field::Record::Timestamp,
          kRecordCommonTail[0], kRecordCommonTail[1], kRecordCommonTail[2],
-         kRecordCommonTail[3], kRecordCommonTail[4]},
+         kRecordCommonTail[3], kRecordCommonTail[4], kRecordCommonTail[5]},
         {hr3[0], hr3[1], hr3[2]});
 
     // + battery (5 developer fields).
     mFit->defineMessage(L_RECORD_B, fit::mesgNum(fit::MesgNum::Record),
         {fit::field::Record::Timestamp,
          kRecordCommonTail[0], kRecordCommonTail[1], kRecordCommonTail[2],
-         kRecordCommonTail[3], kRecordCommonTail[4]},
+         kRecordCommonTail[3], kRecordCommonTail[4], kRecordCommonTail[5]},
         {batt5[0], batt5[1], batt5[2], batt5[3], batt5[4]});
 }
 
@@ -224,6 +226,11 @@ void ActivityWriter::addRecord(const RecordData& record)
     d.u16(record.has(RecordData::Field::STEP_LENGTH)
               ? SDK::FitRecordCadence::encodeStepLengthM(record.stepLengthM)
               : static_cast<uint16_t>(fit::baseTypeInvalid(fit::BaseType::UInt16)));
+
+    // distance (100 * m, cumulative)
+    d.u32(record.has(RecordData::Field::DISTANCE)
+              ? static_cast<uint32_t>(record.distance * 100.0f)
+              : static_cast<uint32_t>(fit::baseTypeInvalid(fit::BaseType::UInt32)));
 
     // Developer fields, in definition order.
     if (batt) {

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
@@ -600,6 +600,12 @@ ActivityWriter::RecordData Service::prepareRecordData()
     fitRecord.set(ActivityWriter::RecordData::Field::SPEED, mSpeedCounter.isValid());
     fitRecord.speed        = mSpeedCounter.getCurrent();
 
+    // Cumulative active distance (live uncorrected estimate, same source as the
+    // session total pre-calibration). Monotonic and always valid while recording,
+    // so it is written unconditionally.
+    fitRecord.set(ActivityWriter::RecordData::Field::DISTANCE, true);
+    fitRecord.distance     = mDistanceCounter.getValueActive();
+
     bool hasHeartRate = (mHrCounter.getCurrent() > 20 && mTrackData.hrTrustLevel >= 1 && mTrackData.hrTrustLevel <= 3);
     fitRecord.set(ActivityWriter::RecordData::Field::HEART_RATE, hasHeartRate);
     fitRecord.heartRate    = mHrCounter.getCurrent();

--- a/Libs/Header/SDK/Fit/FitProfile.hpp
+++ b/Libs/Header/SDK/Fit/FitProfile.hpp
@@ -85,6 +85,7 @@ namespace Record {
     constexpr FitWriter::Field PositionLong{1, BaseType::SInt32};      // semicircles
     constexpr FitWriter::Field HeartRate{3, BaseType::UInt8};          // bpm
     constexpr FitWriter::Field Cadence{4, BaseType::UInt8};            // rpm
+    constexpr FitWriter::Field Distance{5, BaseType::UInt32};          // scale 100, m
     constexpr FitWriter::Field FractionalCadence{53, BaseType::UInt8}; // scale 128, rpm
     constexpr FitWriter::Field EnhancedSpeed{73, BaseType::UInt32};    // scale 1000, m/s
     constexpr FitWriter::Field EnhancedAltitude{78, BaseType::UInt32}; // scale 5, off 500, m


### PR DESCRIPTION
## Problem

A Treadmill activity uploaded to Strava shows no pace graph — only HR and cadence. Treadmill records carry `enhanced_speed` but **no per-record distance**, and (being indoor) no GPS positions. Strava derives an activity's pace/splits from a distance source (GPS track or a per-record distance stream), not from `enhanced_speed` alone, so with neither it has nothing to plot.

## Fix

Add a per-record cumulative `distance` field to the Treadmill FIT record message.

- **`FitProfile.hpp`** — add the record `Distance` field (global profile field **5**, `uint32`, scale 100 = cm, units m). It was genuinely missing from the SDK profile.
- **`ActivityWriter`** — append `Record::Distance` as the last field of the shared `kRecordCommonTail`; include it in both record definitions (`L_RECORD`, `L_RECORD_B`); write it in `addRecord()` after `step_length` and before the developer fields. On-wire field order stays in lockstep with the value-write order (verified: 7 native fields = 7 native writes).
- **`RecordData`** — new `DISTANCE` field flag (`1u << 0`, previously free) + `float distance` member.
- **`Service::prepareRecordData()`** — set `distance = mDistanceCounter.getValueActive()` (cumulative active distance, the same source as the session total). Monotonic and always valid while recording, so written unconditionally; frozen across pauses.

Encoding (`distance * 100`, uint32) matches the existing lap/session `TotalDistance` scaling.

## Behaviour notes

- The stream is the **live uncorrected estimate** — it matches the per-record `enhanced_speed` stream. This is standard practice.
- The end-of-run Calibrate & Save corrects only the **session total**, so the last record's cumulative distance (uncalibrated) will differ from `session.total_distance` (calibrated). This is intended, and matches how Garmin's own record stream can diverge from its session summary.
- Per an accuracy comparison against a simultaneous Garmin GPS run, the current stride model runs the per-record distance ~7% short, so Strava will render pace slightly slow until stride calibration matures. Not a regression — a known property of the uncalibrated stream.

## Verification

- Treadmill `.uapp` builds clean (arm-gcc + Ninja), compile + link.
- Record definition ↔ `addRecord` write order reviewed field-by-field (types and widths match); both record variants share the same tail so both line up.

## Affected apps

Treadmill only (this PR). Running/Hiking record via their own writers and already emit GPS positions, so Strava pace works there without a per-record distance field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Treadmill activity records now include cumulative distance measurements.
  * Distance is reported in meters with improved precision and consistency across session totals and individual records.
  * FIT activity files now store distance data for supported record types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->