### PR TITLE
fix(tools): make textconvert run on Ruby 3.2+

### DIFF
--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/application_font_provider_cpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/application_font_provider_cpp.rb
@@ -32,7 +32,7 @@ class ApplicationFontProviderCpp < Template
     @cache["typographies"] = typographies.collect{|t| [t.name, t.font_file, t.font_size, t.bpp] }
     @cache["generate_font_format"] = @generate_font_format
     new_cache_file = false
-    if not File::exists?(cache_file)
+    if not File.exist?(cache_file)
       new_cache_file = true
     else
       #cache file exists, compare data with cache file
@@ -43,7 +43,7 @@ class ApplicationFontProviderCpp < Template
       #write new cache file
       FileIO.write_file_silent(cache_file, @cache.to_json)
     end
-    if !File::exists?(output_filename) || new_cache_file
+    if !File.exist?(output_filename) || new_cache_file
       #generate ApplicationFontProvider.cpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/application_font_provider_hpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/application_font_provider_hpp.rb
@@ -36,7 +36,7 @@ class ApplicationFontProviderHpp < Template
     @cache["typographies"] = @typographies.collect{|t| [t.name, t.font_file, t.font_size, t.bpp] }
     @cache["generate_font_format"] = @generate_font_format
     new_cache_file = false
-    if not File::exists?(cache_file)
+    if not File.exist?(cache_file)
       new_cache_file = true
     else
       #cache file exists, compare data with cache file
@@ -47,7 +47,7 @@ class ApplicationFontProviderHpp < Template
       #write new cache file
       FileIO.write_file_silent(cache_file, @cache.to_json)
     end
-    if !File::exists?(output_filename) || new_cache_file
+    if !File.exist?(output_filename) || new_cache_file
       #generate ApplicationFontProvider.hpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/cached_font_cpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/cached_font_cpp.rb
@@ -19,7 +19,7 @@ class CachedFontCpp < Template
     File.join(@output_directory, output_path)
   end
   def run
-    if !File::exists?(output_filename)
+    if !File.exist?(output_filename)
       #generate CachedFont.cpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/cached_font_hpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/cached_font_hpp.rb
@@ -19,7 +19,7 @@ class CachedFontHpp < Template
     File.join(@output_directory, output_path)
   end
   def run
-    if !File::exists?(output_filename)
+    if !File.exist?(output_filename)
       #generate CachedFont.hpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/compressed_font_cache_cpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/compressed_font_cache_cpp.rb
@@ -19,7 +19,7 @@ class CompressedFontCacheCpp < Template
     File.join(@output_directory, output_path)
   end
   def run
-    if !File::exists?(output_filename)
+    if !File.exist?(output_filename)
       #generate CompressedFontCache.cpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/compressed_font_cache_hpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/compressed_font_cache_hpp.rb
@@ -29,7 +29,7 @@ class CompressedFontCacheHpp < Template
   def run
     @cache["cache_size"] = @compressed_font_cache_size
     new_cache_file = false
-    if not File::exists?(cache_file)
+    if not File.exist?(cache_file)
       new_cache_file = true
     else
       #cache file exists, compare data with cache file
@@ -40,7 +40,7 @@ class CompressedFontCacheHpp < Template
       #write new cache file
       FileIO.write_file_silent(cache_file, @cache.to_json)
     end
-    if !File::exists?(output_filename) || new_cache_file
+    if !File.exist?(output_filename) || new_cache_file
       #generate CompressedFontCache.hpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/compressed_unmapped_font_cache_cpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/compressed_unmapped_font_cache_cpp.rb
@@ -19,7 +19,7 @@ class CompressedUnmappedFontCacheCpp < Template
     File.join(@output_directory, output_path)
   end
   def run
-    if !File::exists?(output_filename)
+    if !File.exist?(output_filename)
       #generate CompressedUnmappedFontCache.cpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/compressed_unmapped_font_cache_hpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/compressed_unmapped_font_cache_hpp.rb
@@ -29,7 +29,7 @@ class CompressedUnmappedFontCacheHpp < Template
   def run
     @cache["cache_size"] = @compressed_font_cache_size
     new_cache_file = false
-    if not File::exists?(cache_file)
+    if not File.exist?(cache_file)
       new_cache_file = true
     else
       #cache file exists, compare data with cache file
@@ -40,7 +40,7 @@ class CompressedUnmappedFontCacheHpp < Template
       #write new cache file
       FileIO.write_file_silent(cache_file, @cache.to_json)
     end
-    if !File::exists?(output_filename) || new_cache_file
+    if !File.exist?(output_filename) || new_cache_file
       #generate CompressedUnmappedFontCache.hpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/font_cache_cpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/font_cache_cpp.rb
@@ -19,7 +19,7 @@ class FontCacheCpp < Template
     File.join(@output_directory, output_path)
   end
   def run
-    if !File::exists?(output_filename)
+    if !File.exist?(output_filename)
       #generate FontCache.cpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/font_cache_hpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/font_cache_hpp.rb
@@ -19,7 +19,7 @@ class FontCacheHpp < Template
     File.join(@output_directory, output_path)
   end
   def run
-    if !File::exists?(output_filename)
+    if !File.exist?(output_filename)
       #generate FontCache.hpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/fonts_cpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/fonts_cpp.rb
@@ -277,7 +277,7 @@ class FontsCpp
     @cache["max_commands"] = @max_commands
     @cache["max_font"] = @max_font
     new_cache_file = false
-    if not File::exists?(cache_file)
+    if not File.exist?(cache_file)
       new_cache_file = true
     else
       #cache file exists, compare data to cache file
@@ -288,9 +288,9 @@ class FontsCpp
       #write new cache file
       FileIO.write_file_silent(cache_file, @cache.to_json)
     end
-    if !File::exists?(output_filename) || new_cache_file
+    if !File.exist?(output_filename) || new_cache_file
       #generate VectorFontRendererBuffers.cpp
-      result = ERB.new(File.read(input_path).gsub(WINDOWS_LINE_ENDINGS, UNIX_LINE_ENDINGS),0,"<>").
+      result = ERB.new(File.read(input_path).gsub(WINDOWS_LINE_ENDINGS, UNIX_LINE_ENDINGS), trim_mode: "<>").
                  result(binding).
                  gsub(WINDOWS_LINE_ENDINGS, UNIX_LINE_ENDINGS).
                  gsub(UNIX_LINE_ENDINGS, LINE_ENDINGS)

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/generated_font_cpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/generated_font_cpp.rb
@@ -19,7 +19,7 @@ class GeneratedFontCpp < Template
     File.join(@output_directory, output_path)
   end
   def run
-    if !File::exists?(output_filename)
+    if !File.exist?(output_filename)
       #generate GeneratedFont.cpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/generated_font_hpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/generated_font_hpp.rb
@@ -19,7 +19,7 @@ class GeneratedFontHpp < Template
     File.join(@output_directory, output_path)
   end
   def run
-    if !File::exists?(output_filename)
+    if !File.exist?(output_filename)
       #generate GeneratedFont.hpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/languages_bin.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/languages_bin.rb
@@ -165,7 +165,7 @@ class LanguageXxBin < Template
     @cache["indices"] = list
 
     new_cache_file = false
-    if not File::exists?(cache_file)
+    if not File.exist?(cache_file)
       new_cache_file = true
     else
       #cache file exists, compare data with cache file
@@ -178,7 +178,7 @@ class LanguageXxBin < Template
       FileIO.write_file_silent(cache_file, @cache.to_json)
     end
 
-    if !File::exists?(output_filename) || new_cache_file
+    if !File.exist?(output_filename) || new_cache_file
       #generate LanguageXX.bin
       FileUtils.mkdir_p(File.dirname(input_path))
       callingPath = Pathname.new($calling_path)

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/languages_cpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/languages_cpp.rb
@@ -87,7 +87,7 @@ class LanguageXxCpp < Template
     @cache["generate_binary_translations"] = @generate_binary_translations
 
     new_cache_file = false
-    if not File::exists?(cache_file)
+    if not File.exist?(cache_file)
       new_cache_file = true
     else
       #cache file exists, compare data with cache file
@@ -100,7 +100,7 @@ class LanguageXxCpp < Template
       FileIO.write_file_silent(cache_file, @cache.to_json)
     end
 
-    if !File::exists?(output_filename) || new_cache_file
+    if !File.exist?(output_filename) || new_cache_file
       #generate LanguageXX.cpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/template.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/template.rb
@@ -23,7 +23,7 @@ class Template
     @output_directory = output_directory
   end
   def run
-    result = ERB.new(File.read(input_path).gsub(WINDOWS_LINE_ENDINGS, UNIX_LINE_ENDINGS),0,"<>").
+    result = ERB.new(File.read(input_path).gsub(WINDOWS_LINE_ENDINGS, UNIX_LINE_ENDINGS), trim_mode: "<>").
                result(binding).
                gsub(WINDOWS_LINE_ENDINGS, UNIX_LINE_ENDINGS).
                gsub(UNIX_LINE_ENDINGS, LINE_ENDINGS)

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/text_keys_and_languages_hpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/text_keys_and_languages_hpp.rb
@@ -38,7 +38,7 @@ class TextKeysAndLanguages < Template
     @cache["textids"] = get_texts
 
     new_cache_file = false
-    if not File::exists?(cache_file)
+    if not File.exist?(cache_file)
       new_cache_file = true
     else
       #cache file exists, compare data with cache file
@@ -51,7 +51,7 @@ class TextKeysAndLanguages < Template
       FileIO.write_file_silent(cache_file, @cache.to_json)
     end
 
-    if !File::exists?(output_filename) || new_cache_file || $Force_Generate_TextKeysAndLanguages
+    if !File.exist?(output_filename) || new_cache_file || $Force_Generate_TextKeysAndLanguages
       #generate TextKeysAndLanguages.hpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/texts_cpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/texts_cpp.rb
@@ -49,7 +49,7 @@ class TextsCpp < Template
     @cache["generate_binary_translations"] = @generate_binary_translations
 
     new_cache_file = false
-    if not File::exists?(cache_file)
+    if not File.exist?(cache_file)
       new_cache_file = true
     else
       #cache file exists, compare data with cache file
@@ -62,7 +62,7 @@ class TextsCpp < Template
       FileIO.write_file_silent(cache_file, @cache.to_json)
     end
 
-    if !File::exists?(output_filename) || new_cache_file
+    if !File.exist?(output_filename) || new_cache_file
       #generate TypedTextDatabase.cpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/typed_text_database_cpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/typed_text_database_cpp.rb
@@ -62,7 +62,7 @@ class TypedTextDatabaseCpp < Template
     @cache["copy_translations_to_ram"] = @copy_translations_to_ram
 
     new_cache_file = false
-    if not File::exists?(cache_file)
+    if not File.exist?(cache_file)
       new_cache_file = true
     else
       #cache file exists, compare data with cache file
@@ -75,7 +75,7 @@ class TypedTextDatabaseCpp < Template
       FileIO.write_file_silent(cache_file, @cache.to_json)
     end
 
-    if !File::exists?(output_filename) || new_cache_file
+    if !File.exist?(output_filename) || new_cache_file
       #generate TypedTextDatabase.cpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/typed_text_database_hpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/typed_text_database_hpp.rb
@@ -19,7 +19,7 @@ class TypedTextDatabaseHpp < Template
     File.join(@output_directory, output_path)
   end
   def run
-    if !File::exists?(output_filename)
+    if !File.exist?(output_filename)
       #generate TypedTextDatabase.hpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/unmapped_data_font_cpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/unmapped_data_font_cpp.rb
@@ -19,7 +19,7 @@ class UnmappedDataFontCpp < Template
     File.join(@output_directory, output_path)
   end
   def run
-    if !File::exists?(output_filename)
+    if !File.exist?(output_filename)
       #generate UnmappedDataFont.cpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/unmapped_data_font_hpp.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/emitters/unmapped_data_font_hpp.rb
@@ -19,7 +19,7 @@ class UnmappedDataFontHpp < Template
     File.join(@output_directory, output_path)
   end
   def run
-    if !File::exists?(output_filename)
+    if !File.exist?(output_filename)
       #generate GeneratedFont.hpp
       super
     end

--- a/ThirdParty/touchgfx/framework/tools/textconvert/lib/xml_validator.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/lib/xml_validator.rb
@@ -14,7 +14,7 @@ class XMLValidator
   def validate(xml_file_name)
     xml_doc = Nokogiri::XML(File.read(xml_file_name))
     schema_file_name = xml_file_name.gsub(/\.xml$/, '.xsd')
-    if File.exists?(schema_file_name)
+    if File.exist?(schema_file_name)
       xsd = Nokogiri::XML::Schema(File.read(schema_file_name))
       result = xsd.validate(xml_doc)
       if !result.empty?

--- a/ThirdParty/touchgfx/framework/tools/textconvert/main.rb
+++ b/ThirdParty/touchgfx/framework/tools/textconvert/main.rb
@@ -52,8 +52,8 @@ UPGRADE
   end
 
   def self.missing_files
-    return !File.exists?("#{@fonts_output_path}/include/fonts/ApplicationFontProvider.hpp") ||
-           !File.exists?("#{@localization_output_path}/include/texts/TextKeysAndLanguages.hpp")
+    return !File.exist?("#{@fonts_output_path}/include/fonts/ApplicationFontProvider.hpp") ||
+           !File.exist?("#{@localization_output_path}/include/texts/TextKeysAndLanguages.hpp")
   end
 
   if Integer(RUBY_VERSION.match(/\d+/)[0]) < 3 && !RUBY_PLATFORM.match(/linux/)
@@ -217,8 +217,8 @@ UPGRADE
       # 0:
       if file_name.match(/\.xlsx$/)
         xml_file_name = file_name.gsub(/\.xlsx$/, '.xml')
-        if File.exists?(xml_file_name)
-          if File.exists?(file_name)
+        if File.exist?(xml_file_name)
+          if File.exist?(file_name)
             puts "WARNING: Using \"#{xml_file_name}\" instead of \"#{file_name}\""
           end
         else
@@ -230,7 +230,7 @@ UPGRADE
       # 1:
       text_converter_time = Dir[File.join(__dir__,'**','*'), font_convert_path].collect{|f| [File.mtime(f), File.ctime(f)]}.flatten.max
 
-      if ((compile_time_exists = File.exists?("#{@localization_output_path}/cache/compile_time.cache")) && text_converter_time > File.mtime("#{@localization_output_path}/cache/compile_time.cache")) || !compile_time_exists
+      if ((compile_time_exists = File.exist?("#{@localization_output_path}/cache/compile_time.cache")) && text_converter_time > File.mtime("#{@localization_output_path}/cache/compile_time.cache")) || !compile_time_exists
         #remove all files, as text converter is newer (probably upgraded to new TouchGFX)
         puts "Cleaning generated files from #{@localization_output_path} and #{@fonts_output_path}."
         if @localization_output_path.match /generated\/texts$/
@@ -249,7 +249,7 @@ UPGRADE
       # 1c:
       force_run = false
       options_file = "#{@localization_output_path}/cache/options.cache"
-      options = File.exists?(options_file) && File.read(options_file)
+      options = File.exist?(options_file) && File.read(options_file)
 
       new_options = { :remap => remap_global,
                       :autohint => autohint_setting,
@@ -267,7 +267,7 @@ UPGRADE
       end
 
       # 2:
-      if File.exists?("#{@localization_output_path}/cache/compile_time.cache") && !self.missing_files && !force_run
+      if File.exist?("#{@localization_output_path}/cache/compile_time.cache") && !self.missing_files && !force_run
         mod_time = [File.mtime(file_name), File.ctime(file_name)].max
         cache_mod_time = File.mtime("#{@localization_output_path}/cache/compile_time.cache")
         # exit if cache is newer than input file and cache is also newer than application.config and target.config


### PR DESCRIPTION
_Caveat_: I do not see a history of changing the vendored library, so consider whether this is something to go ahead with or not. A future TouchGFX bump will clobber these changes, hopefully they'll update and this will be unnecessary but otherwise this would need re-applying.

`File.exists?` was removed in Ruby 3.2 (hit EoL 3 months ago) and ERB's positional `safe_level`argument in 3.1 (hit EoL in March 2025), so the text converter dies on any machine using supported versions of Ruby. ST requiring users to install a dead version of Ruby to run this tool is a little objectionable. `File.exist?` (no 's') and `trim_mode:` do the same thing and work on everything back to Ruby 2.6, including the Ruby 3 the TouchGFX environment ships with, so this is both backward and forward compatible.

This is ultimately ST's bug. 4.26.1 still ships with these obsolete and unsupported methods in EoL ruby versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with current Ruby versions by updating file-existence checks throughout the text conversion and validation workflows.
  * Preserved existing cache reuse and generated-file refresh behavior.
  * Improved template rendering compatibility while maintaining existing output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->