### PR TITLE
fix(docs): multi-version Pages deploy that preserves prior versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,131 +1,143 @@
 name: Documentation
 
+# Multi-version docs. Each released tag (sdk-v*) is published to its own
+# subdirectory on the `gh-pages` branch and PRESERVED across deploys; the site
+# root redirects to the latest released version. `main` publishes to /preview/
+# (never the default). PRs build only, to validate.
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
     tags: [ 'sdk-v*' ]
-    paths:
-      - 'Docs/**'
-      - '.github/workflows/docs.yml'
   pull_request:
     paths:
       - 'Docs/**'
       - '.github/workflows/docs.yml'
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Slot to (re)build when dispatched on a branch (ignored on a tag ref, which uses the tag name). Use to rebuild "preview".'
+        required: false
+        default: 'preview'
 
 concurrency:
-  group: "pages"
+  group: "docs-pages"
   cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      slot: ${{ steps.slot.outputs.slot }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        submodules: false
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
 
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
+      - name: Determine version slot
+        id: slot
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/sdk-v* ]]; then
+            slot="${GITHUB_REF_NAME}"                       # a release tag -> its own version dir
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            slot="${{ github.event.inputs.version }}"       # manual rebuild on a branch
+          else
+            slot="preview"                                  # main / PR -> preview, never the root default
+          fi
+          echo "slot=${slot}" >> "$GITHUB_OUTPUT"
+          echo "Building docs slot: ${slot}"
 
-    - name: Install dependencies
-      run: pip install -r Docs/requirements.txt
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
-    - name: Install Doxygen and Graphviz
-      run: sudo apt-get update && sudo apt-get install -y doxygen graphviz
+      - name: Install dependencies
+        run: pip install -r Docs/requirements.txt
 
-    - name: Generate API Docs
-      run: |
-        mkdir -p Docs/_build/doxygen
-        cd Docs && doxygen Doxyfile
+      - name: Install Doxygen and Graphviz
+        run: sudo apt-get update && sudo apt-get install -y doxygen graphviz
 
-    - name: Generate version selector
-      run: |
-        TAGS_JSON=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -s https://api.github.com/repos/${{ github.repository }}/tags)
-        TAGS=$(echo "$TAGS_JSON" | jq -r '.[].name' 2>/dev/null | sed 's/.*/"&"/' | tr '\n' ',' | sed 's/,$//')
-        if [ -z "$TAGS" ]; then
-          TAGS='"v1.0","v2.0"'
-        fi
-        cat > Docs/_static/version-selector.js << EOF
-        // Version selector for Sphinx documentation
-        document.addEventListener('DOMContentLoaded', function() {
-            const baseUrl = window.location.origin + '/';
-            const versions = ['latest', $TAGS];
-            // Create the selector
-            const selector = document.createElement('select');
-            selector.id = 'version-selector';
-            selector.style.cssText = \`
-                position: absolute;
-                top: 10px;
-                right: 10px;
-                z-index: 1000;
-                padding: 5px;
-                font-size: 14px;
-            \`;
-            // Add options
-            versions.forEach(version => {
-                const option = document.createElement('option');
-                option.textContent = version;
-                option.value = baseUrl + version + '/';
-                selector.appendChild(option);
-            });
-            // Insert
-            const nav = document.querySelector('.wy-nav-side') || document.querySelector('nav') || document.body;
-            nav.appendChild(selector);
-            // Set current
-            const currentPath = window.location.pathname;
-            const currentVersion = versions.find(v => currentPath.includes('/' + v + '/'));
-            if (currentVersion) {
-                selector.value = baseUrl + currentVersion + '/';
-            } else {
-                selector.value = baseUrl + 'latest/';
-            }
-            // Handle change
-            selector.addEventListener('change', function() {
-                window.location.href = this.value;
-            });
-        });
-        EOF
+      - name: Generate API docs (doxygen)
+        run: |
+          mkdir -p Docs/_build/doxygen
+          cd Docs && doxygen Doxyfile
 
-    - name: Set version
-      run: |
-        if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-          VERSION="latest"
-        elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-          VERSION="${{ github.ref_name }}"
-        else
-          VERSION="${{ github.ref_name }}"
-        fi
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Build HTML
+        run: sphinx-build Docs _build/html
 
-    - name: Build documentation
-      run: sphinx-build Docs _site/$VERSION
-
-    - name: Add redirect for main page
-      if: github.ref == 'refs/heads/main'
-      run: |
-        echo '<html><head><meta http-equiv="refresh" content="0; url=latest/" /></head><body></body></html>' > _site/index.html
-
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: './_site'
+      - name: Upload built HTML
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: _build/html
 
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    # PRs run `build` only (validation); never publish from a PR.
+    if: github.event_name != 'pull_request'
     needs: build
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write            # push to the gh-pages serve branch
     steps:
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
+      - name: Check out existing published site (gh-pages)
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: site
+        continue-on-error: true   # first ever run: branch does not exist yet
+
+      - name: Prepare site tree
+        run: |
+          mkdir -p site
+          rm -rf site/.git         # never publish the checkout's git metadata
+
+      - name: Download freshly built HTML
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-html
+          path: docs-html
+
+      - name: Assemble multi-version site (preserve all prior versions)
+        env:
+          SLOT: ${{ needs.build.outputs.slot }}
+        run: |
+          set -euo pipefail
+          # Replace ONLY this version's subdir; every other version is left intact.
+          rm -rf "site/${SLOT}"
+          mkdir -p "site/${SLOT}"
+          cp -a docs-html/. "site/${SLOT}/"
+
+          # Latest RELEASED version = highest sdk-v* dir present (preview never wins the root).
+          latest="$(ls -1 site | { grep -E '^sdk-v' || true; } | sort -V | tail -1)"
+          if [ -n "${latest}" ]; then
+            printf '<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0; url=./%s/">\n<title>Una SDK Documentation</title>\n<a href="./%s/">Una SDK Documentation</a>\n' "${latest}" "${latest}" > site/index.html
+          fi
+
+          # Version manifest consumed at runtime by _static/version-selector.js.
+          {
+            printf '{\n  "latest": "%s",\n  "versions": [\n' "${latest:-}"
+            first=1
+            for d in $(ls -1 site | { grep -E '^(sdk-v|preview$)' || true; } | sort -Vr); do
+              if [ $first -eq 1 ]; then first=0; else printf ',\n'; fi
+              printf '    "%s"' "$d"
+            done
+            printf '\n  ]\n}\n'
+          } > site/versions.json
+
+          # Custom domain + disable Jekyll processing of Sphinx output.
+          echo "developers.unawatch.com" > site/CNAME
+          touch site/.nojekyll
+          echo "Assembled versions:"; ls -1 site | grep -E '^(sdk-v|preview)' || true
+
+      - name: Publish to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          force_orphan: true       # single-commit branch; the full multi-version tree is assembled above
+          cname: developers.unawatch.com
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: "docs: publish ${{ needs.build.outputs.slot }} (${{ github.sha }})"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,14 @@ on:
         description: 'Slot to (re)build when dispatched on a branch (ignored on a tag ref, which uses the tag name). Use to rebuild "preview".'
         required: false
         default: 'preview'
+      build_ref:
+        description: 'Git ref to build docs from (e.g. sdk-v1.2.0). Slot is derived from it. Blank = use the triggering ref.'
+        required: false
+        default: ''
 
+# NOTE: with a shared group and cancel-in-progress off, GitHub keeps only the
+# newest QUEUED run per group — a run superseded while queued never publishes
+# its version. Re-dispatch the workflow (with build_ref) to recover that slot.
 concurrency:
   group: "docs-pages"
   cancel-in-progress: false
@@ -33,17 +40,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.build_ref || github.ref }}
           submodules: false
+          persist-credentials: false
 
       - name: Determine version slot
         id: slot
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_BUILD_REF: ${{ github.event.inputs.build_ref }}
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/sdk-v* ]]; then
+          if [ -n "${INPUT_BUILD_REF}" ]; then
+            slot="${INPUT_BUILD_REF}"                       # explicit ref to (re)build -> its own slot
+          elif [[ "${GITHUB_REF}" == refs/tags/sdk-v* ]]; then
             slot="${GITHUB_REF_NAME}"                       # a release tag -> its own version dir
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            slot="${{ github.event.inputs.version }}"       # manual rebuild on a branch
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            slot="${INPUT_VERSION}"                         # manual rebuild on a branch
           else
             slot="preview"                                  # main / PR -> preview, never the root default
+          fi
+          # Allow-list the slot: it is used as a directory name and in rm -rf.
+          if [[ ! "${slot}" =~ ^(preview|sdk-v[A-Za-z0-9._-]+)$ ]]; then
+            echo "::error::Invalid/unsafe slot: '${slot}'"; exit 1
           fi
           echo "slot=${slot}" >> "$GITHUB_OUTPUT"
           echo "Building docs slot: ${slot}"
@@ -80,17 +98,30 @@ jobs:
     permissions:
       contents: write            # push to the gh-pages serve branch
     steps:
+      # Gate the gh-pages checkout on branch existence rather than masking
+      # failures: a transient checkout error followed by the publish step would
+      # otherwise silently wipe every previously published version.
+      - name: Check if gh-pages exists
+        id: ghp
+        run: |
+          if git ls-remote --exit-code --heads "https://github.com/${{ github.repository }}.git" gh-pages >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check out existing published site (gh-pages)
+        if: steps.ghp.outputs.exists == 'true'
         uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: site
-        continue-on-error: true   # first ever run: branch does not exist yet
+          persist-credentials: false
 
       - name: Prepare site tree
         run: |
-          mkdir -p site
-          rm -rf site/.git         # never publish the checkout's git metadata
+          mkdir -p site                # first ever run: gh-pages does not exist yet
+          rm -rf site/.git             # never publish the checkout's git metadata
 
       - name: Download freshly built HTML
         uses: actions/download-artifact@v4
@@ -103,15 +134,22 @@ jobs:
           SLOT: ${{ needs.build.outputs.slot }}
         run: |
           set -euo pipefail
+          # Defense in depth: never rm -rf with an unvalidated slot name.
+          [[ "${SLOT}" =~ ^(preview|sdk-v[A-Za-z0-9._-]+)$ ]] || { echo "::error::bad SLOT"; exit 1; }
           # Replace ONLY this version's subdir; every other version is left intact.
           rm -rf "site/${SLOT}"
           mkdir -p "site/${SLOT}"
           cp -a docs-html/. "site/${SLOT}/"
 
-          # Latest RELEASED version = highest sdk-v* dir present (preview never wins the root).
-          latest="$(ls -1 site | { grep -E '^sdk-v' || true; } | sort -V | tail -1)"
+          # Latest RELEASED version = highest final-release-shaped sdk-v* dir
+          # (preview and RC/pre-release dirs never win the root).
+          latest="$(ls -1 site | { grep -E '^sdk-v[0-9]+(\.[0-9]+)*$' || true; } | sort -V | tail -1)"
           if [ -n "${latest}" ]; then
             printf '<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0; url=./%s/">\n<title>Una SDK Documentation</title>\n<a href="./%s/">Una SDK Documentation</a>\n' "${latest}" "${latest}" > site/index.html
+          elif [ -d "site/preview" ]; then
+            # No released version published yet: fall back to /preview/ so the
+            # site root never 404s regardless of publish order.
+            printf '<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0; url=./preview/">\n<title>Una SDK Documentation</title>\n<a href="./preview/">Una SDK Documentation</a>\n' > site/index.html
           fi
 
           # Version manifest consumed at runtime by _static/version-selector.js.
@@ -136,7 +174,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
           publish_branch: gh-pages
-          force_orphan: true       # single-commit branch; the full multi-version tree is assembled above
+          force_orphan: false      # keep gh-pages history so a destructive publish can be reverted
           cname: developers.unawatch.com
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/Docs/_static/version-selector.js
+++ b/Docs/_static/version-selector.js
@@ -1,34 +1,30 @@
-// Version selector for Sphinx documentation on GitHub Pages
-// Fetches GitHub tags and creates a dropdown in the navigation
+// Version selector for the Sphinx docs.
+//
+// Reads /versions.json (written at deploy time by .github/workflows/docs.yml),
+// so the dropdown lists exactly the versions that are actually published — every
+// entry links to a real page, never a 404. Docs are served at
+// <site>/<version>/..., so the first path segment is the current version.
 
-document.addEventListener('DOMContentLoaded', function() {
-    // Assuming the repo is una-watch/una-sdk, adjust if needed
-    const repoOwner = 'una-watch';
-    const repoName = 'una-sdk';
-    const baseUrl = `https://${repoOwner}.github.io/${repoName}/`;
-
-    // Create the selector element
+document.addEventListener('DOMContentLoaded', function () {
     const selector = document.createElement('select');
     selector.id = 'version-selector';
     selector.style.cssText = `
-    display: block;
-    margin: 8px auto 12px;
-    padding: 5px 10px;
-    font-size: 14px;
-    border-radius: 4px;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    background: var(--white, #fff);
-    color: #333;
-    cursor: pointer;
+        display: block;
+        margin: 8px auto 12px;
+        padding: 5px 10px;
+        font-size: 14px;
+        border-radius: 4px;
+        border: 1px solid rgba(255, 255, 255, 0.3);
+        background: var(--white, #fff);
+        color: #333;
+        cursor: pointer;
     `;
 
+    const loading = document.createElement('option');
+    loading.textContent = 'Loading versions…';
+    selector.appendChild(loading);
 
-    // Add loading option
-    const loadingOption = document.createElement('option');
-    loadingOption.textContent = 'Loading versions...';
-    selector.appendChild(loadingOption);
-
-    // Insert below the header title in the sidebar search area
+    // Insert below the header title in the RTD sidebar search area.
     const searchArea = document.querySelector('.wy-side-nav-search');
     const searchContainer = searchArea ? searchArea.querySelector('[role="search"]') : null;
     if (searchArea && searchContainer) {
@@ -36,47 +32,36 @@ document.addEventListener('DOMContentLoaded', function() {
     } else if (searchArea) {
         searchArea.appendChild(selector);
     } else {
-        const nav = document.querySelector('.wy-nav-side') || document.querySelector('nav') || document.body;
-        nav.appendChild(selector);
+        (document.querySelector('.wy-nav-side') || document.querySelector('nav') || document.body).appendChild(selector);
     }
 
-    // Fetch tags from GitHub API
-    fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/tags`)
-        .then(response => response.json())
-        .then(tags => {
-            // Clear loading option
+    // Current version = first non-empty path segment (e.g. /sdk-v1.2.0/… -> sdk-v1.2.0).
+    const segments = window.location.pathname.split('/').filter(Boolean);
+    const current = segments.length ? segments[0] : '';
+
+    // versions.json lives at the site root, regardless of custom domain.
+    fetch('/versions.json', { cache: 'no-store' })
+        .then(r => { if (!r.ok) throw new Error('versions.json ' + r.status); return r.json(); })
+        .then(data => {
+            const versions = Array.isArray(data.versions) ? data.versions : [];
             selector.innerHTML = '';
-
-            // Add current version option
-            const currentOption = document.createElement('option');
-            currentOption.textContent = 'latest';
-            currentOption.value = baseUrl;
-            selector.appendChild(currentOption);
-
-            // Add tag options
-            tags.forEach(tag => {
-                const option = document.createElement('option');
-                option.textContent = tag.name;
-                option.value = `${baseUrl}${tag.name}/`;
-                selector.appendChild(option);
+            versions.forEach(v => {
+                const opt = document.createElement('option');
+                opt.value = '/' + v + '/';
+                opt.textContent = (v === data.latest) ? (v + ' (latest)') : v;
+                if (v === current) opt.selected = true;
+                selector.appendChild(opt);
             });
-
-            // Set current version based on URL
-            const currentPath = window.location.pathname;
-            const versionMatch = currentPath.match(/\/([^\/]+)\//);
-            if (versionMatch) {
-                selector.value = `${baseUrl}${versionMatch[1]}/`;
-            } else {
-                selector.value = baseUrl;
+            if (!versions.length) {
+                selector.innerHTML = '<option>No versions published</option>';
+                return;
             }
-
-            // Handle change
-            selector.addEventListener('change', function() {
+            selector.addEventListener('change', function () {
                 window.location.href = this.value;
             });
         })
-        .catch(error => {
-            console.error('Failed to load versions:', error);
-            selector.innerHTML = '<option>Error loading versions</option>';
+        .catch(err => {
+            console.error('version-selector: failed to load versions.json', err);
+            selector.innerHTML = '<option>Versions unavailable</option>';
         });
 });

--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -55,7 +55,7 @@ language = 'en'
 
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
-html_js_files = []
+html_js_files = ['version-selector.js']
 html_css_files = ['custom.css']
 
 # -- Options for intersphinx extension ---------------------------------------


### PR DESCRIPTION
## Problem
The docs site (developers.unawatch.com) went **down on every `sdk-v*` release**. `docs.yml` did *last-deploy-wins* (each deploy replaced the entire site) and wrote the root redirect **only on `main` builds** — so a release-**tag** deploy replaced the site with just `/<tag>/` and no root redirect → the site root 404'd. It also silently wiped every other version.

## Fix (full multi-version, preserving)
- **Persist + accumulate**: each version publishes to `gh-pages/<version>`; every prior version is preserved (the full tree is reassembled from the existing `gh-pages` each run, then republished via `peaceiris/actions-gh-pages`).
- **Root always works**: root `index.html` redirects to the **latest released** version (highest `sdk-v*`). `main` publishes to `/preview/` and **never** becomes the default.
- **Working version selector**: `_static/version-selector.js` now reads `/versions.json` (written at deploy time), so the dropdown lists only *published* versions — no more 404 links. Wired in via `conf.py` `html_js_files` (it wasn't loaded before).
- **Serve from the `gh-pages` branch** (writing `CNAME`), which also **removes the `github-pages` environment-allowlist dependency** that's bitten us before.
- **`workflow_dispatch`** added to rebuild/backfill any version on demand.
- PRs build-only (validation); they never publish.

## Rollout (safe order — site stays up until the final flip)
1. **Merge** this PR. (No effect yet — Pages still serves the current content.)
2. **Seed `gh-pages`**: `gh workflow run docs.yml --repo UNAWatch/una-sdk --ref main -f build_ref=sdk-v1.2.0` → checks out the released tag but runs the *new* workflow from `main`, publishing into `gh-pages/sdk-v1.2.0` + root redirect + CNAME. (Repeat with `-f build_ref=<tag>` for any older tag you want preserved, e.g. `sdk-v1.0.0`; dispatching `--ref <old-tag>` directly would 422 because the tag's own `docs.yml` predates `workflow_dispatch`.) Then `gh workflow run docs.yml --repo UNAWatch/una-sdk --ref main` for `/preview/`.
3. **Flip Pages source** to *Deploy from a branch → `gh-pages` / (root)* (Settings ▸ Pages, or API). This is the go-live moment.
4. **Verify**: `developers.unawatch.com/` → `/sdk-v1.2.0/`; dropdown switches versions.

## Notes
- CNAME is written by the workflow, so the custom domain persists after the flip.
- Old versions aren't auto-backfilled — re-run `docs.yml` on a tag to add it.
- Only 3 files change; `conf.py` is a one-line edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version-aware documentation publishing, preserving separate documentation versions.
  * Added a documentation version selector with links to published versions.
  * Added preview and manually triggered documentation builds.
* **Improvements**
  * Documentation deployments now preserve existing versioned content.
  * Added clearer loading and offline error states for the version selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
