### PR TITLE
fix(docs): Pages CNAME -> www.developers.unawatch.com

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -164,7 +164,7 @@ jobs:
           } > site/versions.json
 
           # Custom domain + disable Jekyll processing of Sphinx output.
-          echo "developers.unawatch.com" > site/CNAME
+          echo "www.developers.unawatch.com" > site/CNAME
           touch site/.nojekyll
           echo "Assembled versions:"; ls -1 site | grep -E '^(sdk-v|preview)' || true
 
@@ -175,7 +175,7 @@ jobs:
           publish_dir: ./site
           publish_branch: gh-pages
           force_orphan: false      # keep gh-pages history so a destructive publish can be reverted
-          cname: developers.unawatch.com
+          cname: www.developers.unawatch.com
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
           commit_message: "docs: publish ${{ needs.build.outputs.slot }} (${{ github.sha }})"


### PR DESCRIPTION
Follow-up to #190, needed **before** the Pages branch-serve cutover.

The multi-version workflow writes `CNAME = developers.unawatch.com` (apex), but the live GitHub Pages custom domain is `www.developers.unawatch.com`:
- `www.developers.unawatch.com` -> GitHub Pages directly (185.199.x)
- `developers.unawatch.com` (apex) -> Cloudflare-fronted

Flipping Pages to serve from the `gh-pages` branch with the apex CNAME would repoint the Pages custom domain to the apex and break the `www` site that works today. This sets both CNAME spots (the `echo > site/CNAME` and the peaceiris `cname:` input) to `www.developers.unawatch.com`. 2-line change; found during pre-flip inspection of the seeded `gh-pages`.

After merge: re-seed (`gh workflow run docs.yml --ref main -f build_ref=sdk-v1.2.0` + a `--ref main` preview run) so the branch CNAME becomes www, then flip Pages source to `gh-pages`/(root).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the published documentation site to use the new `www.developers.unawatch.com` domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->