### PR TITLE
fix(docs): keep /latest/ alias pointing at the current release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -152,6 +152,15 @@ jobs:
             printf '<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0; url=./preview/">\n<title>Una SDK Documentation</title>\n<a href="./preview/">Una SDK Documentation</a>\n' > site/index.html
           fi
 
+          # /latest/ alias -> current release, regenerated every deploy so an
+          # external link to /latest/ always resolves to the newest release.
+          # Target is the version dir directly (not the site root) so it can
+          # never loop against a stale cached root redirect.
+          if [ -n "${latest}" ]; then
+            mkdir -p site/latest
+            printf '<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0; url=/%s/">\n<title>Una SDK Documentation</title>\n<a href="/%s/">Una SDK Documentation (latest)</a>\n' "${latest}" "${latest}" > site/latest/index.html
+          fi
+
           # Version manifest consumed at runtime by _static/version-selector.js.
           {
             printf '{\n  "latest": "%s",\n  "versions": [\n' "${latest:-}"


### PR DESCRIPTION
Follow-up to the multi-version docs work. Our main website links to `https://www.developers.unawatch.com/latest/…` (a link we can't change), but the multi-version layout uses `/sdk-vX/` + `/preview/` and dropped `/latest/`.

This makes the deploy regenerate a `/latest/` alias every run, redirecting to the current released version (the same `${latest}` the root uses). It targets the **version dir directly** (`/sdk-v1.2.0/`), not the site root, so it can't loop against a stale cached root redirect.

Already applied the equivalent redirect straight to `gh-pages` so the live link works now; this change keeps it correct automatically on every future release (otherwise `/latest/` would go stale at the next release). `/latest/` is an alias, not a version, so it's intentionally excluded from `versions.json`/the dropdown.

One file, +9 lines in the assemble step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/latest/` documentation URL that automatically redirects visitors to the most recent released SDK documentation.
  * The alias is created only when a released SDK version is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->