### PR TITLE
fix(docs): /latest/ = full copy of current release (not a redirect stub)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -152,13 +152,12 @@ jobs:
             printf '<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0; url=./preview/">\n<title>Una SDK Documentation</title>\n<a href="./preview/">Una SDK Documentation</a>\n' > site/index.html
           fi
 
-          # /latest/ alias -> current release, regenerated every deploy so an
-          # external link to /latest/ always resolves to the newest release.
-          # Target is the version dir directly (not the site root) so it can
-          # never loop against a stale cached root redirect.
+          # /latest/ = a full copy of the current release, refreshed every deploy
+          # so external deep links (e.g. /latest/sdk-setup.html) always resolve to
+          # the newest release. Relative links keep the copy self-contained.
           if [ -n "${latest}" ]; then
-            mkdir -p site/latest
-            printf '<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0; url=/%s/">\n<title>Una SDK Documentation</title>\n<a href="/%s/">Una SDK Documentation (latest)</a>\n' "${latest}" "${latest}" > site/latest/index.html
+            rm -rf site/latest
+            cp -a "site/${latest}/." site/latest/
           fi
 
           # Version manifest consumed at runtime by _static/version-selector.js.


### PR DESCRIPTION
Corrects #192. The external website deep-links into `/latest/` (e.g. `/latest/sdk-setup.html`), so `/latest/` must be a **full docs tree**, not a redirect stub — a stub only covers `/latest/` itself and 404s every sub-page.

Changes the deploy to copy the current release dir into `/latest/` every run (`rm -rf site/latest; cp -a site/${latest}/. site/latest/`). Sphinx uses relative links, so the copy is self-contained and every deep link resolves; it refreshes to the newest release automatically.

(Already applied the equivalent full mirror straight to `gh-pages` so the live site works now — `/latest/sdk-setup.html` is 200. This keeps it correct on every future deploy; without it, the #192 stub would overwrite `/latest/index.html` and freeze the other pages stale.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the latest documentation deployment so the `site/latest` path contains a complete copy of the newest release documentation.
  * Ensured older content is removed during deployment, keeping the latest documentation snapshot accurate and self-contained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->