### PR TITLE
feat(settings): implement time-of-day format setting

### DIFF
--- a/Docs/Examples/Cycling-Architecture.md
+++ b/Docs/Examples/Cycling-Architecture.md
@@ -680,6 +680,7 @@ constexpr SDK::MessageType::Type MANUAL_LAP     = 0x0000000F;
 struct SettingsUpd : public SDK::MessageBase {
     Settings settings;
     bool     unitsImperial;
+    SDK::Message::TimeFormat timeFormat;
     uint8_t  hrThresholds[kHrThresholdsCount];  // C-array of 6
     uint8_t  hrThresholdsCount;
 };
@@ -703,7 +704,7 @@ public:
     Sender(const SDK::Kernel& kernel);
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, SDK::Message::TimeFormat timeFormat,
                      const uint8_t (&thresholds)[kHrThresholdsCount],
                      uint8_t thresholdCount);
     bool time(std::tm localTime);

--- a/Docs/Examples/Hiking-Architecture.md
+++ b/Docs/Examples/Hiking-Architecture.md
@@ -682,6 +682,7 @@ constexpr SDK::MessageType::Type MANUAL_LAP     = 0x0000000F;
 struct SettingsUpd : public SDK::MessageBase {
     Settings settings;
     bool     unitsImperial;
+    SDK::Message::TimeFormat timeFormat;
     uint8_t  hrThresholds[kHrThresholdsCount];  // C-array of 6
     uint8_t  hrThresholdsCount;
 };
@@ -705,7 +706,7 @@ public:
     Sender(const SDK::Kernel& kernel);
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, SDK::Message::TimeFormat timeFormat,
                      const uint8_t (&thresholds)[kHrThresholdsCount],
                      uint8_t thresholdCount);
     bool time(std::tm localTime);

--- a/Docs/Examples/Running-Architecture.md
+++ b/Docs/Examples/Running-Architecture.md
@@ -833,6 +833,7 @@ constexpr SDK::MessageType::Type INTERVALS_NEXT_PHASE = 0x00000011;
 struct SettingsUpd : public SDK::MessageBase {
     Settings settings;
     bool     unitsImperial;
+    SDK::Message::TimeFormat timeFormat;
     uint8_t  hrThresholds[kHrThresholdsCount];  // C-array of 6
     uint8_t  hrThresholdsCount;
 };
@@ -868,7 +869,7 @@ public:
     Sender(const SDK::Kernel& kernel);
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, SDK::Message::TimeFormat timeFormat,
                      const uint8_t (&thresholds)[kHrThresholdsCount],
                      uint8_t thresholdCount);
     bool time(std::tm localTime);

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -3,6 +3,7 @@
 
 #include <gui_generated/containers/TrackFaceStatusBase.hpp>
 #include <SDK/GUI/SensorStatusRow.hpp>
+#include <SDK/Messages/CommandMessages.hpp>
 
 /**
  * @brief Track face showing device status: current time of day and battery level.
@@ -21,8 +22,9 @@ public:
      * @brief Display the current time of day.
      * @param h Hour   (0-23).
      * @param m Minute (0-59).
+     * @param format Time-of-day rendering format.
      */
-    void setTime(uint8_t h, uint8_t m);
+    void setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format);
 
     /**
      * @brief Display the battery charge level.

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -79,6 +79,7 @@ public:
 
     // Settings
     bool isUnitsImperial() const;
+    SDK::Message::TimeFormat getTimeFormat() const;
     const uint8_t* getHrThresholds() const;
     uint8_t        getHrThresholdsCount() const;
     const Settings& getSettings() const;
@@ -136,6 +137,7 @@ private:
 
     // Settings (mirrored from Service)
     bool    mUnitsImperial     = false;
+    SDK::Message::TimeFormat mTimeFormat = SDK::Message::TimeFormat::Hour24;
     uint8_t mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t mHrThresholdsCount = App::Config::kHrThresholdsCount;
     Settings mSettings {};

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
@@ -15,7 +15,7 @@ public:
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 
-    void setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount);
+    void setConfig(bool isImperial, SDK::Message::TimeFormat timeFormat, const uint8_t* thresholds, uint8_t thresholdCount);
     void setTrackData(const Track::Data& data);
 
     void setTime(uint8_t h, uint8_t m);
@@ -33,6 +33,7 @@ protected:
 
     uint16_t mCurrentFaceId = 0;
     bool     mIsImperial = false;
+    SDK::Message::TimeFormat mTimeFormat = SDK::Message::TimeFormat::Hour24;
     uint8_t  mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t  mHrThresholdCount = 0;
     uint8_t  mAccessoryState = 0;  // last SDK::Accessory::State (engaged?)

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -16,9 +16,21 @@ void TrackFaceStatus::initialize()
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
 }
 
-void TrackFaceStatus::setTime(uint8_t h, uint8_t m)
+void TrackFaceStatus::setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format)
 {
-    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+    switch (format) {
+        case SDK::Message::TimeFormat::Hour12: {
+            const uint8_t h12 = (h % 12 == 0) ? 12 : (h % 12);
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h12, m);
+        } break;
+        case SDK::Message::TimeFormat::Military:
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%02u%02u", h, m);
+            break;
+        case SDK::Message::TimeFormat::Hour24:
+        default:
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+            break;
+    }
     dayTimeValue.invalidate();
 }
 

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -1,5 +1,6 @@
 #include <gui/containers/TrackFaceStatus.hpp>
 #include <images/BitmapDatabase.hpp>
+#include <SDK/Utils/TimeFormat.hpp>
 
 TrackFaceStatus::TrackFaceStatus()
 {
@@ -18,19 +19,9 @@ void TrackFaceStatus::initialize()
 
 void TrackFaceStatus::setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format)
 {
-    switch (format) {
-        case SDK::Message::TimeFormat::Hour12: {
-            const uint8_t h12 = (h % 12 == 0) ? 12 : (h % 12);
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h12, m);
-        } break;
-        case SDK::Message::TimeFormat::Military:
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%02u%02u", h, m);
-            break;
-        case SDK::Message::TimeFormat::Hour24:
-        default:
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
-            break;
-    }
+    char text[8];
+    SDK::Utils::formatTimeOfDay(text, sizeof(text), h, m, format);
+    Unicode::strncpy(dayTimeValueBuffer, text, DAYTIMEVALUE_SIZE);
     dayTimeValue.invalidate();
 }
 

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -115,6 +115,11 @@ bool Model::isUnitsImperial() const
     return mUnitsImperial;
 }
 
+SDK::Message::TimeFormat Model::getTimeFormat() const
+{
+    return mTimeFormat;
+}
+
 const uint8_t* Model::getHrThresholds() const
 {
     return mHrThresholds;
@@ -273,6 +278,7 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             auto* msg          = static_cast<CustomMessage::SettingsUpd*>(message);
             mSettings          = msg->settings;
             mUnitsImperial     = msg->unitsImperial;
+            mTimeFormat        = msg->timeFormat;
             memcpy(mHrThresholds, msg->hrThresholds, sizeof(mHrThresholds));
             mHrThresholdsCount = msg->hrThresholdsCount;
             modelListener->onSettings(mSettings);

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
@@ -14,7 +14,7 @@ void TrackPresenter::activate()
 
     view.setPositionId(model->menu().track.get());
 
-    view.setConfig(model->isUnitsImperial(), model->getHrThresholds(), model->getHrThresholdsCount());
+    view.setConfig(model->isUnitsImperial(), model->getTimeFormat(), model->getHrThresholds(), model->getHrThresholdsCount());
 
     onTrackData(model->getTrackData());
 

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -60,9 +60,10 @@ uint16_t TrackView::getPositionId()
     return mCurrentFaceId;
 }
 
-void TrackView::setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount)
+void TrackView::setConfig(bool isImperial, SDK::Message::TimeFormat timeFormat, const uint8_t* thresholds, uint8_t thresholdCount)
 {
     mIsImperial = isImperial;
+    mTimeFormat = timeFormat;
     mHrThresholdCount = thresholdCount < App::Config::kHrThresholdsCount ?
         thresholdCount : static_cast<uint8_t>(App::Config::kHrThresholdsCount);
     memcpy(mHrThresholds, thresholds, mHrThresholdCount);
@@ -102,7 +103,7 @@ void TrackView::setTrackData(const Track::Data& data)
 
 void TrackView::setTime(uint8_t h, uint8_t m)
 {
-    trackFaceStatus.setTime(h, m);
+    trackFaceStatus.setTime(h, m, mTimeFormat);
 }
 
 void TrackView::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Cycling/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Commands.hpp
@@ -51,12 +51,14 @@ namespace CustomMessage {
 
         // Kernel settings
         bool    unitsImperial;
+        SDK::Message::TimeFormat timeFormat;
         uint8_t hrThresholds[kHrThresholdsCount];
         uint8_t hrThresholdsCount;
 
         SettingsUpd()
             : SDK::MessageBase(SETTINGS_UPDATE)
             , unitsImperial(false)
+            , timeFormat(SDK::Message::TimeFormat::Hour24)
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
@@ -176,12 +178,13 @@ public:
     virtual ~Sender() = default;
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, SDK::Message::TimeFormat timeFormat,
                      const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
     {
         if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
             msg->settings          = settings;
             msg->unitsImperial     = units;
+            msg->timeFormat        = timeFormat;
             memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
             msg->hrThresholdsCount = thresholdCount;
             return msg.send();

--- a/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
@@ -46,6 +46,7 @@ private:
 
     Settings                  mSettings;
     bool                      mIsImperial = false;
+    SDK::Message::TimeFormat  mTimeFormat = SDK::Message::TimeFormat::Hour24;
     SettingsSerializer        mSettingsSerializer;
     ActivitySummary           mSummary;
     ActivitySummarySerializer mActivitySummarySerializer;

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -586,6 +586,7 @@ void Service::sendInitialInfoToGui()
     if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
         if (msg.send(100) && msg.ok()) {
             mIsImperial = msg->imperialUnits;
+            mTimeFormat = msg->timeFormat;
 
             if (msg->heartRateCount > CustomMessage::kHrThresholdsCount) {
                 msg->heartRateCount = CustomMessage::kHrThresholdsCount;
@@ -610,7 +611,7 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, hrThresholds, hrThresholdsCount);
+    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat, hrThresholds, hrThresholdsCount);
     mGuiSender.summary(&mSummary);
     mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
 }

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -3,6 +3,7 @@
 
 #include <gui_generated/containers/TrackFaceStatusBase.hpp>
 #include <SDK/GUI/SensorStatusRow.hpp>
+#include <SDK/Messages/CommandMessages.hpp>
 
 /**
  * @brief Track face showing device status: current time of day and battery level.
@@ -21,8 +22,9 @@ public:
      * @brief Display the current time of day.
      * @param h Hour   (0-23).
      * @param m Minute (0-59).
+     * @param format Time-of-day rendering format.
      */
-    void setTime(uint8_t h, uint8_t m);
+    void setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format);
 
     /**
      * @brief Display the battery charge level.

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -78,6 +78,7 @@ public:
 
     // Settings
     bool isUnitsImperial() const;
+    SDK::Message::TimeFormat getTimeFormat() const;
     const uint8_t* getHrThresholds() const;
     uint8_t        getHrThresholdsCount() const;
     const Settings& getSettings() const;
@@ -136,6 +137,7 @@ private:
 
     // Settings (mirrored from Service)
     bool    mUnitsImperial     = false;
+    SDK::Message::TimeFormat mTimeFormat = SDK::Message::TimeFormat::Hour24;
     uint8_t mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t mHrThresholdsCount = App::Config::kHrThresholdsCount;
     Settings mSettings {};

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
@@ -15,7 +15,7 @@ public:
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 
-    void setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount);
+    void setConfig(bool isImperial, SDK::Message::TimeFormat timeFormat, const uint8_t* thresholds, uint8_t thresholdCount);
     void setTrackData(const Track::Data& data);
 
     void setTime(uint8_t h, uint8_t m);
@@ -33,6 +33,7 @@ protected:
 
     uint16_t mCurrentFaceId = 0;
     bool     mIsImperial = false;
+    SDK::Message::TimeFormat mTimeFormat = SDK::Message::TimeFormat::Hour24;
     uint8_t  mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t  mHrThresholdCount = 0;
     uint8_t  mAccessoryState = 0;  // last SDK::Accessory::State (engaged?)

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -15,9 +15,21 @@ void TrackFaceStatus::initialize()
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
 }
 
-void TrackFaceStatus::setTime(uint8_t h, uint8_t m)
+void TrackFaceStatus::setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format)
 {
-    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+    switch (format) {
+        case SDK::Message::TimeFormat::Hour12: {
+            const uint8_t h12 = (h % 12 == 0) ? 12 : (h % 12);
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h12, m);
+        } break;
+        case SDK::Message::TimeFormat::Military:
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%02u%02u", h, m);
+            break;
+        case SDK::Message::TimeFormat::Hour24:
+        default:
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+            break;
+    }
     dayTimeValue.invalidate();
 }
 

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -1,5 +1,6 @@
 #include <gui/containers/TrackFaceStatus.hpp>
 #include <images/BitmapDatabase.hpp>
+#include <SDK/Utils/TimeFormat.hpp>
 
 TrackFaceStatus::TrackFaceStatus()
 {}
@@ -17,19 +18,9 @@ void TrackFaceStatus::initialize()
 
 void TrackFaceStatus::setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format)
 {
-    switch (format) {
-        case SDK::Message::TimeFormat::Hour12: {
-            const uint8_t h12 = (h % 12 == 0) ? 12 : (h % 12);
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h12, m);
-        } break;
-        case SDK::Message::TimeFormat::Military:
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%02u%02u", h, m);
-            break;
-        case SDK::Message::TimeFormat::Hour24:
-        default:
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
-            break;
-    }
+    char text[8];
+    SDK::Utils::formatTimeOfDay(text, sizeof(text), h, m, format);
+    Unicode::strncpy(dayTimeValueBuffer, text, DAYTIMEVALUE_SIZE);
     dayTimeValue.invalidate();
 }
 

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -115,6 +115,11 @@ bool Model::isUnitsImperial() const
     return mUnitsImperial;
 }
 
+SDK::Message::TimeFormat Model::getTimeFormat() const
+{
+    return mTimeFormat;
+}
+
 const uint8_t* Model::getHrThresholds() const
 {
     return mHrThresholds;
@@ -273,6 +278,7 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             auto* msg          = static_cast<CustomMessage::SettingsUpd*>(message);
             mSettings          = msg->settings;
             mUnitsImperial     = msg->unitsImperial;
+            mTimeFormat        = msg->timeFormat;
             memcpy(mHrThresholds, msg->hrThresholds, sizeof(mHrThresholds));
             mHrThresholdsCount = msg->hrThresholdsCount;
             modelListener->onSettings(mSettings);

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
@@ -14,7 +14,7 @@ void TrackPresenter::activate()
 
     view.setPositionId(model->menu().track.get());
 
-    view.setConfig(model->isUnitsImperial(), model->getHrThresholds(), model->getHrThresholdsCount());
+    view.setConfig(model->isUnitsImperial(), model->getTimeFormat(), model->getHrThresholds(), model->getHrThresholdsCount());
 
     onTrackData(model->getTrackData());
 

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -60,9 +60,10 @@ uint16_t TrackView::getPositionId()
     return mCurrentFaceId;
 }
 
-void TrackView::setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount)
+void TrackView::setConfig(bool isImperial, SDK::Message::TimeFormat timeFormat, const uint8_t* thresholds, uint8_t thresholdCount)
 {
     mIsImperial = isImperial;
+    mTimeFormat = timeFormat;
     mHrThresholdCount = thresholdCount < App::Config::kHrThresholdsCount ?
         thresholdCount : static_cast<uint8_t>(App::Config::kHrThresholdsCount);
     memcpy(mHrThresholds, thresholds, mHrThresholdCount);
@@ -104,7 +105,7 @@ void TrackView::setTrackData(const Track::Data& data)
 
 void TrackView::setTime(uint8_t h, uint8_t m)
 {
-    trackFaceStatus.setTime(h, m);
+    trackFaceStatus.setTime(h, m, mTimeFormat);
 }
 
 void TrackView::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Hiking/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Commands.hpp
@@ -51,12 +51,14 @@ namespace CustomMessage {
 
         // Kernel settings
         bool    unitsImperial;
+        SDK::Message::TimeFormat timeFormat;
         uint8_t hrThresholds[kHrThresholdsCount];
         uint8_t hrThresholdsCount;
 
         SettingsUpd()
             : SDK::MessageBase(SETTINGS_UPDATE)
             , unitsImperial(false)
+            , timeFormat(SDK::Message::TimeFormat::Hour24)
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
@@ -176,12 +178,13 @@ public:
     virtual ~Sender() = default;
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, SDK::Message::TimeFormat timeFormat,
                      const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
     {
         if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
             msg->settings          = settings;
             msg->unitsImperial     = units;
+            msg->timeFormat        = timeFormat;
             memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
             msg->hrThresholdsCount = thresholdCount;
             return msg.send();

--- a/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
@@ -47,6 +47,7 @@ private:
 
     Settings                  mSettings;
     bool                      mIsImperial = false;
+    SDK::Message::TimeFormat  mTimeFormat = SDK::Message::TimeFormat::Hour24;
     SettingsSerializer        mSettingsSerializer;
     ActivitySummary           mSummary;
     ActivitySummarySerializer mActivitySummarySerializer;

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -609,6 +609,7 @@ void Service::sendInitialInfoToGui()
     if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
         if (msg.send(100) && msg.ok()) {
             mIsImperial = msg->imperialUnits;
+            mTimeFormat = msg->timeFormat;
 
             if (msg->heartRateCount > CustomMessage::kHrThresholdsCount) {
                 msg->heartRateCount = CustomMessage::kHrThresholdsCount;
@@ -633,7 +634,7 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, hrThresholds, hrThresholdsCount);
+    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat, hrThresholds, hrThresholdsCount);
     mGuiSender.summary(&mSummary);
     mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
 }

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -3,6 +3,7 @@
 
 #include <gui_generated/containers/TrackFaceStatusBase.hpp>
 #include <SDK/GUI/SensorStatusRow.hpp>
+#include <SDK/Messages/CommandMessages.hpp>
 
 /**
  * @brief Track face showing device status: current time of day and battery level.
@@ -21,8 +22,9 @@ public:
      * @brief Display the current time of day.
      * @param h Hour   (0-23).
      * @param m Minute (0-59).
+     * @param format Time-of-day rendering format.
      */
-    void setTime(uint8_t h, uint8_t m);
+    void setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format);
 
     /**
      * @brief Display the battery charge level.

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -78,6 +78,7 @@ public:
 
     // Settings
     bool isUnitsImperial() const;
+    SDK::Message::TimeFormat getTimeFormat() const;
     const uint8_t* getHrThresholds() const;
     uint8_t        getHrThresholdsCount() const;
     const Settings& getSettings() const;
@@ -140,6 +141,7 @@ private:
 
     // Settings (mirrored from Service)
     bool mUnitsImperial = false;
+    SDK::Message::TimeFormat mTimeFormat = SDK::Message::TimeFormat::Hour24;
     uint8_t mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t mHrThresholdsCount = App::Config::kHrThresholdsCount;
     Settings mSettings {};

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
@@ -16,7 +16,7 @@ public:
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 
-    void setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount);
+    void setConfig(bool isImperial, SDK::Message::TimeFormat timeFormat, const uint8_t* thresholds, uint8_t thresholdCount);
     void setTrackData(const Track::Data& data);
 
     void setTime(uint8_t h, uint8_t m);
@@ -35,6 +35,7 @@ protected:
     bool     mIntervalsMode = false;
     uint16_t mCurrentFaceId = 0;
     bool     mIsImperial    = false;
+    SDK::Message::TimeFormat mTimeFormat = SDK::Message::TimeFormat::Hour24;
     uint8_t  mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t  mHrThresholdCount = 0;
     uint8_t  mAccessoryState = 0;  // last SDK::Accessory::State (engaged?)

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -16,9 +16,21 @@ void TrackFaceStatus::initialize()
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
 }
 
-void TrackFaceStatus::setTime(uint8_t h, uint8_t m)
+void TrackFaceStatus::setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format)
 {
-    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+    switch (format) {
+        case SDK::Message::TimeFormat::Hour12: {
+            const uint8_t h12 = (h % 12 == 0) ? 12 : (h % 12);
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h12, m);
+        } break;
+        case SDK::Message::TimeFormat::Military:
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%02u%02u", h, m);
+            break;
+        case SDK::Message::TimeFormat::Hour24:
+        default:
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+            break;
+    }
     dayTimeValue.invalidate();
 }
 

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -1,5 +1,6 @@
 #include <gui/containers/TrackFaceStatus.hpp>
 #include <images/BitmapDatabase.hpp>
+#include <SDK/Utils/TimeFormat.hpp>
 
 TrackFaceStatus::TrackFaceStatus()
 {
@@ -18,19 +19,9 @@ void TrackFaceStatus::initialize()
 
 void TrackFaceStatus::setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format)
 {
-    switch (format) {
-        case SDK::Message::TimeFormat::Hour12: {
-            const uint8_t h12 = (h % 12 == 0) ? 12 : (h % 12);
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h12, m);
-        } break;
-        case SDK::Message::TimeFormat::Military:
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%02u%02u", h, m);
-            break;
-        case SDK::Message::TimeFormat::Hour24:
-        default:
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
-            break;
-    }
+    char text[8];
+    SDK::Utils::formatTimeOfDay(text, sizeof(text), h, m, format);
+    Unicode::strncpy(dayTimeValueBuffer, text, DAYTIMEVALUE_SIZE);
     dayTimeValue.invalidate();
 }
 

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -114,6 +114,11 @@ bool Model::isUnitsImperial() const
     return mUnitsImperial;
 }
 
+SDK::Message::TimeFormat Model::getTimeFormat() const
+{
+    return mTimeFormat;
+}
+
 const uint8_t* Model::getHrThresholds() const
 {
     return mHrThresholds;
@@ -345,6 +350,7 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             auto* msg          = static_cast<CustomMessage::SettingsUpd*>(message);
             mSettings          = msg->settings;
             mUnitsImperial     = msg->unitsImperial;
+            mTimeFormat        = msg->timeFormat;
             memcpy(mHrThresholds, msg->hrThresholds, sizeof(mHrThresholds));
             mHrThresholdsCount = msg->hrThresholdsCount;
             modelListener->onSettings(mSettings);

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
@@ -31,7 +31,7 @@ void TrackPresenter::activate()
 
     view.setPositionId(faceId);
 
-    view.setConfig(model->isUnitsImperial(), model->getHrThresholds(), model->getHrThresholdsCount());
+    view.setConfig(model->isUnitsImperial(), model->getTimeFormat(), model->getHrThresholds(), model->getHrThresholdsCount());
 
     onTrackData(model->getTrackData());
 

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -73,9 +73,10 @@ uint16_t TrackView::getPositionId()
     return mCurrentFaceId;
 }
 
-void TrackView::setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount)
+void TrackView::setConfig(bool isImperial, SDK::Message::TimeFormat timeFormat, const uint8_t* thresholds, uint8_t thresholdCount)
 {
     mIsImperial        = isImperial;
+    mTimeFormat        = timeFormat;
     mHrThresholdCount  = thresholdCount < App::Config::kHrThresholdsCount ? 
                             thresholdCount : static_cast<uint8_t>(App::Config::kHrThresholdsCount);
     memcpy(mHrThresholds, thresholds, mHrThresholdCount);
@@ -124,7 +125,7 @@ void TrackView::setTrackData(const Track::Data& data)
 
 void TrackView::setTime(uint8_t h, uint8_t m)
 {
-    trackFaceStatus.setTime(h, m);
+    trackFaceStatus.setTime(h, m, mTimeFormat);
 }
 
 void TrackView::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Running/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Commands.hpp
@@ -54,12 +54,14 @@ namespace CustomMessage {
 
         // Kernel settings
         bool    unitsImperial;
+        SDK::Message::TimeFormat timeFormat;
         uint8_t hrThresholds[kHrThresholdsCount];
         uint8_t hrThresholdsCount;
 
         SettingsUpd()
             : SDK::MessageBase(SETTINGS_UPDATE)
             , unitsImperial(false)
+            , timeFormat(SDK::Message::TimeFormat::Hour24)
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
@@ -193,12 +195,13 @@ public:
     virtual ~Sender() = default;
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, SDK::Message::TimeFormat timeFormat,
                      const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
     {
         if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
             msg->settings          = settings;
             msg->unitsImperial     = units;
+            msg->timeFormat        = timeFormat;
             memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
             msg->hrThresholdsCount = thresholdCount;
             return msg.send();

--- a/Examples/Apps/Running/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Service.hpp
@@ -54,6 +54,7 @@ private:
 
     Settings                  mSettings;
     bool                      mIsImperial = false;
+    SDK::Message::TimeFormat  mTimeFormat = SDK::Message::TimeFormat::Hour24;
     SettingsSerializer        mSettingsSerializer;
     ActivitySummary           mSummary;
     ActivitySummarySerializer mActivitySummarySerializer;

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -693,6 +693,7 @@ void Service::sendInitialInfoToGui()
     if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
         if (msg.send(100) && msg.ok()) {
             mIsImperial = msg->imperialUnits;
+            mTimeFormat = msg->timeFormat;
 
             if (msg->heartRateCount > CustomMessage::kHrThresholdsCount) {
                 msg->heartRateCount = CustomMessage::kHrThresholdsCount;
@@ -717,7 +718,7 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, hrThresholds, CustomMessage::kHrThresholdsCount);
+    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat, hrThresholds, CustomMessage::kHrThresholdsCount);
     mGuiSender.summary(&mSummary);
     mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
 }

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -3,6 +3,7 @@
 
 #include <gui_generated/containers/TrackFaceStatusBase.hpp>
 #include <SDK/GUI/SensorStatusRow.hpp>
+#include <SDK/Messages/CommandMessages.hpp>
 
 /**
  * @brief Track face showing device status: current time of day and battery level.
@@ -21,8 +22,9 @@ public:
      * @brief Display the current time of day.
      * @param h Hour   (0-23).
      * @param m Minute (0-59).
+     * @param format Time-of-day rendering format.
      */
-    void setTime(uint8_t h, uint8_t m);
+    void setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format);
 
     /**
      * @brief Display the battery charge level.

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -89,6 +89,7 @@ public:
 
     // Settings
     bool isUnitsImperial() const;
+    SDK::Message::TimeFormat getTimeFormat() const;
     const uint8_t* getHrThresholds() const;
     uint8_t        getHrThresholdsCount() const;
     const Settings& getSettings() const;
@@ -175,6 +176,7 @@ private:
 
     // Settings (mirrored from Service)
     bool mUnitsImperial = false;
+    SDK::Message::TimeFormat mTimeFormat = SDK::Message::TimeFormat::Hour24;
     uint8_t mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t mHrThresholdsCount = App::Config::kHrThresholdsCount;
     Settings mSettings {};

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
@@ -16,7 +16,7 @@ public:
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 
-    void setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount);
+    void setConfig(bool isImperial, SDK::Message::TimeFormat timeFormat, const uint8_t* thresholds, uint8_t thresholdCount);
     void setTrackData(const Track::Data& data);
 
     void setTime(uint8_t h, uint8_t m);
@@ -34,6 +34,7 @@ protected:
     bool     mIntervalsMode = false;
     uint16_t mCurrentFaceId = 0;
     bool     mIsImperial    = false;
+    SDK::Message::TimeFormat mTimeFormat = SDK::Message::TimeFormat::Hour24;
     uint8_t  mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t  mHrThresholdCount = 0;
     uint8_t  mAccessoryState = 0;  // last SDK::Accessory::State (engaged?)

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -16,9 +16,21 @@ void TrackFaceStatus::initialize()
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
 }
 
-void TrackFaceStatus::setTime(uint8_t h, uint8_t m)
+void TrackFaceStatus::setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format)
 {
-    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+    switch (format) {
+        case SDK::Message::TimeFormat::Hour12: {
+            const uint8_t h12 = (h % 12 == 0) ? 12 : (h % 12);
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h12, m);
+        } break;
+        case SDK::Message::TimeFormat::Military:
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%02u%02u", h, m);
+            break;
+        case SDK::Message::TimeFormat::Hour24:
+        default:
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+            break;
+    }
     dayTimeValue.invalidate();
 }
 

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -1,5 +1,6 @@
 #include <gui/containers/TrackFaceStatus.hpp>
 #include <images/BitmapDatabase.hpp>
+#include <SDK/Utils/TimeFormat.hpp>
 
 TrackFaceStatus::TrackFaceStatus()
 {
@@ -18,19 +19,9 @@ void TrackFaceStatus::initialize()
 
 void TrackFaceStatus::setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format)
 {
-    switch (format) {
-        case SDK::Message::TimeFormat::Hour12: {
-            const uint8_t h12 = (h % 12 == 0) ? 12 : (h % 12);
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h12, m);
-        } break;
-        case SDK::Message::TimeFormat::Military:
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%02u%02u", h, m);
-            break;
-        case SDK::Message::TimeFormat::Hour24:
-        default:
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
-            break;
-    }
+    char text[8];
+    SDK::Utils::formatTimeOfDay(text, sizeof(text), h, m, format);
+    Unicode::strncpy(dayTimeValueBuffer, text, DAYTIMEVALUE_SIZE);
     dayTimeValue.invalidate();
 }
 

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -119,6 +119,11 @@ bool Model::isUnitsImperial() const
     return mUnitsImperial;
 }
 
+SDK::Message::TimeFormat Model::getTimeFormat() const
+{
+    return mTimeFormat;
+}
+
 const uint8_t* Model::getHrThresholds() const
 {
     return mHrThresholds;
@@ -356,6 +361,7 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             auto* msg          = static_cast<CustomMessage::SettingsUpd*>(message);
             mSettings          = msg->settings;
             mUnitsImperial     = msg->unitsImperial;
+            mTimeFormat        = msg->timeFormat;
             memcpy(mHrThresholds, msg->hrThresholds, sizeof(mHrThresholds));
             mHrThresholdsCount = msg->hrThresholdsCount;
             modelListener->onSettings(mSettings);

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
@@ -31,7 +31,7 @@ void TrackPresenter::activate()
 
     view.setPositionId(faceId);
 
-    view.setConfig(model->isUnitsImperial(), model->getHrThresholds(), model->getHrThresholdsCount());
+    view.setConfig(model->isUnitsImperial(), model->getTimeFormat(), model->getHrThresholds(), model->getHrThresholdsCount());
 
     onTrackData(model->getTrackData());
 

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -73,9 +73,10 @@ uint16_t TrackView::getPositionId()
     return mCurrentFaceId;
 }
 
-void TrackView::setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount)
+void TrackView::setConfig(bool isImperial, SDK::Message::TimeFormat timeFormat, const uint8_t* thresholds, uint8_t thresholdCount)
 {
     mIsImperial        = isImperial;
+    mTimeFormat        = timeFormat;
     mHrThresholdCount  = thresholdCount < App::Config::kHrThresholdsCount ? 
                             thresholdCount : static_cast<uint8_t>(App::Config::kHrThresholdsCount);
     memcpy(mHrThresholds, thresholds, mHrThresholdCount);
@@ -119,7 +120,7 @@ void TrackView::setTrackData(const Track::Data& data)
 
 void TrackView::setTime(uint8_t h, uint8_t m)
 {
-    trackFaceStatus.setTime(h, m);
+    trackFaceStatus.setTime(h, m, mTimeFormat);
 }
 
 void TrackView::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Treadmill/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Header/Commands.hpp
@@ -60,12 +60,14 @@ namespace CustomMessage {
 
         // Kernel settings
         bool    unitsImperial;
+        SDK::Message::TimeFormat timeFormat;
         uint8_t hrThresholds[kHrThresholdsCount];
         uint8_t hrThresholdsCount;
 
         SettingsUpd()
             : SDK::MessageBase(SETTINGS_UPDATE)
             , unitsImperial(false)
+            , timeFormat(SDK::Message::TimeFormat::Hour24)
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
@@ -226,12 +228,13 @@ public:
     virtual ~Sender() = default;
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, SDK::Message::TimeFormat timeFormat,
                      const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
     {
         if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
             msg->settings          = settings;
             msg->unitsImperial     = units;
+            msg->timeFormat        = timeFormat;
             memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
             msg->hrThresholdsCount = thresholdCount;
             return msg.send();

--- a/Examples/Apps/Treadmill/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Header/Service.hpp
@@ -55,6 +55,7 @@ private:
 
     Settings                  mSettings;
     bool                      mIsImperial = false;
+    SDK::Message::TimeFormat  mTimeFormat = SDK::Message::TimeFormat::Hour24;
     SettingsSerializer        mSettingsSerializer;
     ActivitySummary           mSummary;
     ActivitySummarySerializer mActivitySummarySerializer;

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
@@ -651,6 +651,7 @@ void Service::sendInitialInfoToGui()
     if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
         if (msg.send(100) && msg.ok()) {
             mIsImperial = msg->imperialUnits;
+            mTimeFormat = msg->timeFormat;
 
             // Height (cm -> m) drives the phase-1 demographic stride. The model
             // clamps implausible values at session start; only override the
@@ -682,7 +683,7 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, hrThresholds, CustomMessage::kHrThresholdsCount);
+    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat, hrThresholds, CustomMessage::kHrThresholdsCount);
     mGuiSender.summary(&mSummary);
     mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
 }

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -3,6 +3,7 @@
 
 #include <gui_generated/containers/TrackFaceStatusBase.hpp>
 #include <SDK/GUI/SensorStatusRow.hpp>
+#include <SDK/Messages/CommandMessages.hpp>
 
 /**
  * @brief Track face showing device status: current time of day and battery level.
@@ -21,8 +22,9 @@ public:
      * @brief Display the current time of day.
      * @param h Hour   (0-23).
      * @param m Minute (0-59).
+     * @param format Time-of-day rendering format.
      */
-    void setTime(uint8_t h, uint8_t m);
+    void setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format);
 
     /**
      * @brief Display the battery charge level.

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -82,6 +82,7 @@ public:
 
     // Settings
     bool isUnitsImperial() const;
+    SDK::Message::TimeFormat getTimeFormat() const;
     const uint8_t* getHrThresholds() const;
     uint8_t        getHrThresholdsCount() const;
     const Settings& getSettings() const;
@@ -134,6 +135,7 @@ private:
 
     // Settings (mirrored from Service)
     bool mUnitsImperial = false;
+    SDK::Message::TimeFormat mTimeFormat = SDK::Message::TimeFormat::Hour24;
     uint8_t mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t mHrThresholdsCount = App::Config::kHrThresholdsCount;
     Settings mSettings {};

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
@@ -15,7 +15,7 @@ public:
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
 
-    void setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount);
+    void setConfig(bool isImperial, SDK::Message::TimeFormat timeFormat, const uint8_t* thresholds, uint8_t thresholdCount);
     void setTrackData(const Track::Data& data);
 
     void setTime(uint8_t h, uint8_t m);
@@ -32,6 +32,7 @@ protected:
 
     uint16_t mCurrentFaceId = 0;
     bool     mIsImperial    = false;
+    SDK::Message::TimeFormat mTimeFormat = SDK::Message::TimeFormat::Hour24;
     uint8_t  mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t  mHrThresholdCount = 0;
     uint8_t  mAccessoryState = 0;  // last SDK::Accessory::State (engaged?)

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -16,9 +16,21 @@ void TrackFaceStatus::initialize()
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
 }
 
-void TrackFaceStatus::setTime(uint8_t h, uint8_t m)
+void TrackFaceStatus::setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format)
 {
-    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+    switch (format) {
+        case SDK::Message::TimeFormat::Hour12: {
+            const uint8_t h12 = (h % 12 == 0) ? 12 : (h % 12);
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h12, m);
+        } break;
+        case SDK::Message::TimeFormat::Military:
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%02u%02u", h, m);
+            break;
+        case SDK::Message::TimeFormat::Hour24:
+        default:
+            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+            break;
+    }
     dayTimeValue.invalidate();
 }
 

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -1,5 +1,6 @@
 #include <gui/containers/TrackFaceStatus.hpp>
 #include <images/BitmapDatabase.hpp>
+#include <SDK/Utils/TimeFormat.hpp>
 
 TrackFaceStatus::TrackFaceStatus()
 {
@@ -18,19 +19,9 @@ void TrackFaceStatus::initialize()
 
 void TrackFaceStatus::setTime(uint8_t h, uint8_t m, SDK::Message::TimeFormat format)
 {
-    switch (format) {
-        case SDK::Message::TimeFormat::Hour12: {
-            const uint8_t h12 = (h % 12 == 0) ? 12 : (h % 12);
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h12, m);
-        } break;
-        case SDK::Message::TimeFormat::Military:
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%02u%02u", h, m);
-            break;
-        case SDK::Message::TimeFormat::Hour24:
-        default:
-            Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
-            break;
-    }
+    char text[8];
+    SDK::Utils::formatTimeOfDay(text, sizeof(text), h, m, format);
+    Unicode::strncpy(dayTimeValueBuffer, text, DAYTIMEVALUE_SIZE);
     dayTimeValue.invalidate();
 }
 

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -119,6 +119,11 @@ bool Model::isUnitsImperial() const
     return mUnitsImperial;
 }
 
+SDK::Message::TimeFormat Model::getTimeFormat() const
+{
+    return mTimeFormat;
+}
+
 const uint8_t* Model::getHrThresholds() const
 {
     return mHrThresholds;
@@ -264,6 +269,7 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             auto* msg          = static_cast<CustomMessage::SettingsUpd*>(message);
             mSettings          = msg->settings;
             mUnitsImperial     = msg->unitsImperial;
+            mTimeFormat        = msg->timeFormat;
             memcpy(mHrThresholds, msg->hrThresholds, sizeof(mHrThresholds));
             mHrThresholdsCount = msg->hrThresholdsCount;
             modelListener->onSettings(mSettings);

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
@@ -14,7 +14,7 @@ void TrackPresenter::activate()
 
     view.setPositionId(model->menu().track.get());
 
-    view.setConfig(model->isUnitsImperial(), model->getHrThresholds(), model->getHrThresholdsCount());
+    view.setConfig(model->isUnitsImperial(), model->getTimeFormat(), model->getHrThresholds(), model->getHrThresholdsCount());
 
     onTrackData(model->getTrackData());
 

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -59,9 +59,10 @@ uint16_t TrackView::getPositionId()
     return mCurrentFaceId;
 }
 
-void TrackView::setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount)
+void TrackView::setConfig(bool isImperial, SDK::Message::TimeFormat timeFormat, const uint8_t* thresholds, uint8_t thresholdCount)
 {
     mIsImperial        = isImperial;
+    mTimeFormat        = timeFormat;
     mHrThresholdCount  = thresholdCount < App::Config::kHrThresholdsCount ? 
                             thresholdCount : static_cast<uint8_t>(App::Config::kHrThresholdsCount);
     memcpy(mHrThresholds, thresholds, mHrThresholdCount);
@@ -83,7 +84,7 @@ void TrackView::setTrackData(const Track::Data& data)
 
 void TrackView::setTime(uint8_t h, uint8_t m)
 {
-    trackFaceStatus.setTime(h, m);
+    trackFaceStatus.setTime(h, m, mTimeFormat);
 }
 
 void TrackView::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Workout/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Workout/Software/Libs/Header/Commands.hpp
@@ -50,12 +50,14 @@ namespace CustomMessage {
 
         // Kernel settings
         bool    unitsImperial;
+        SDK::Message::TimeFormat timeFormat;
         uint8_t hrThresholds[kHrThresholdsCount];
         uint8_t hrThresholdsCount;
 
         SettingsUpd()
             : SDK::MessageBase(SETTINGS_UPDATE)
             , unitsImperial(false)
+            , timeFormat(SDK::Message::TimeFormat::Hour24)
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
@@ -167,12 +169,13 @@ public:
     virtual ~Sender() = default;
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, SDK::Message::TimeFormat timeFormat,
                      const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
     {
         if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
             msg->settings          = settings;
             msg->unitsImperial     = units;
+            msg->timeFormat        = timeFormat;
             memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
             msg->hrThresholdsCount = thresholdCount;
             return msg.send();

--- a/Examples/Apps/Workout/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Workout/Software/Libs/Header/Service.hpp
@@ -48,6 +48,7 @@ private:
 
     Settings                  mSettings;
     bool                      mIsImperial = false;
+    SDK::Message::TimeFormat  mTimeFormat = SDK::Message::TimeFormat::Hour24;
     SettingsSerializer        mSettingsSerializer;
     ActivitySummary           mSummary;
     ActivitySummarySerializer mActivitySummarySerializer;

--- a/Examples/Apps/Workout/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Workout/Software/Libs/Sources/Service.cpp
@@ -554,6 +554,7 @@ void Service::sendInitialInfoToGui()
     if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
         if (msg.send(100) && msg.ok()) {
             mIsImperial = msg->imperialUnits;
+            mTimeFormat = msg->timeFormat;
 
             if (msg->weightKg > 0.0f) {
                 mWeightKg = msg->weightKg;
@@ -582,7 +583,7 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, hrThresholds, CustomMessage::kHrThresholdsCount);
+    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat, hrThresholds, CustomMessage::kHrThresholdsCount);
     memcpy(mHrThresholds.data(), hrThresholds, sizeof(hrThresholds));
     mHrThresholdCount = CustomMessage::kHrThresholdsCount;
     mGuiSender.summary(&mSummary);

--- a/Libs/Header/SDK/Messages/CommandMessages.hpp
+++ b/Libs/Header/SDK/Messages/CommandMessages.hpp
@@ -188,6 +188,15 @@ static_assert(sizeof(RequestBatteryStatus) == 44, "RequestBatteryStatus size mus
 #endif
 
 /**
+ * @brief Time-of-day display format
+ */
+enum class TimeFormat : uint8_t {
+    Hour24   = 0,  // 17:42 (default)
+    Hour12   = 1,  // 5:42
+    Military = 2,  // 1742
+};
+
+/**
  * @brief System settings request
  *
  * App requests system configuration.
@@ -200,7 +209,7 @@ struct RequestSystemSettings : public MessageBase {
     // Response fields
     uint8_t languageId;      // System language
     bool    imperialUnits;   // Units imperial/metric
-    bool    timeFormat;      // 12/24 hour format
+    TimeFormat timeFormat;   // Time-of-day display format
 
     uint8_t heartRateCount;
     uint8_t heartRateTh[skMaxHearRateTh];
@@ -216,7 +225,7 @@ struct RequestSystemSettings : public MessageBase {
         : MessageBase(MessageType::REQUEST_SYSTEM_SETTINGS)
         , languageId(0)
         , imperialUnits(false)
-        , timeFormat(false)
+        , timeFormat(TimeFormat::Hour24)
         , heartRateCount(0)
         , heartRateTh {}
         , activityMin(0)

--- a/Libs/Header/SDK/Messages/CommandMessages.hpp
+++ b/Libs/Header/SDK/Messages/CommandMessages.hpp
@@ -188,12 +188,14 @@ static_assert(sizeof(RequestBatteryStatus) == 44, "RequestBatteryStatus size mus
 #endif
 
 /**
- * @brief Time-of-day display format
+ * @brief Time-of-day display format.
+ *
+ * Note: mixes two axes -- 12h/24h and, for 24h, ISO-8601 extended vs basic.
  */
 enum class TimeFormat : uint8_t {
-    Hour24   = 0,  // 17:42 (default)
-    Hour12   = 1,  // 5:42
-    Military = 2,  // 1742
+    Hour24        = 0,  // 17:42 (default; ISO-8601 extended)
+    Hour12        = 1,  // 5:42
+    Hour24Compact = 2,  // 1742  (ISO-8601 basic)
 };
 
 /**

--- a/Libs/Header/SDK/Simulator/App/KernelMessageDispatcher.hpp
+++ b/Libs/Header/SDK/Simulator/App/KernelMessageDispatcher.hpp
@@ -10,6 +10,7 @@
 
 #include <cstdint>
 
+#include "SDK/Messages/CommandMessages.hpp"
 #include "SDK/Simulator/App/DualAppComm.hpp"
 #include "SDK/Simulator/App/MessageManager.hpp"
 #include "SDK/Interfaces/IVibro.hpp"
@@ -124,6 +125,12 @@ private:
         bool unitsImperial = false;
 
         /**
+         * @brief   Time-of-day display format preference.
+         * @note    24-hour by default.
+         */
+        SDK::Message::TimeFormat timeFormat = SDK::Message::TimeFormat::Hour24;
+
+        /**
          * @brief Phone-related settings group.
          */
         struct
@@ -145,6 +152,7 @@ private:
         bool operator==(const WatchSettings& other) const
         {
             return (unitsImperial == other.unitsImperial &&
+                    timeFormat == other.timeFormat &&
                     phone.notifications == other.phone.notifications &&
                     watchfaceAppId == other.watchfaceAppId &&
                     heartRateZones == other.heartRateZones &&

--- a/Libs/Header/SDK/Utils/TimeFormat.hpp
+++ b/Libs/Header/SDK/Utils/TimeFormat.hpp
@@ -1,0 +1,65 @@
+/**
+ * @file TimeFormat.hpp
+ * @brief Render a time-of-day into text according to a SDK::Message::TimeFormat.
+ *
+ * Single source of truth for how the status-face clock is formatted across all
+ * apps. Pure (ASCII, no TouchGFX dependency) so it is host-unit-testable; call
+ * sites convert the result to UnicodeChar (e.g. Unicode::strncpy).
+ */
+
+#ifndef SDK_UTILS_TIMEFORMAT_HPP
+#define SDK_UTILS_TIMEFORMAT_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+#include "SDK/Messages/CommandMessages.hpp"
+
+namespace SDK::Utils
+{
+
+/**
+ * @brief Format a 24-hour clock reading (@p h in 0-23, @p m in 0-59) as text.
+ *
+ * Writes a null-terminated ASCII string into @p out (truncated by snprintf if
+ * @p outSize is too small). @p outSize must be at least 6 to hold the longest
+ * valid output ("HH:MM").
+ *
+ *   - Hour24:        zero-padded 24-hour, colon separator  09:05, 17:42
+ *   - Hour12:        1-12 hour, no leading zero, no AM/PM    9:05,  5:42
+ *   - Hour24Compact: zero-padded 24-hour, no separator      0905,  1742
+ *
+ * Hour24 is zero-padded so it stays visually distinct from Hour12 for
+ * single-digit morning hours (09:05 vs 9:05); an unpadded 24-hour reading
+ * would be identical to the 12-hour one for hours 1-9. (Hours 10-12 still
+ * coincide -- only an AM/PM marker could separate those, and there is none.)
+ */
+inline void formatTimeOfDay(char* out, std::size_t outSize,
+                            std::uint8_t h, std::uint8_t m,
+                            SDK::Message::TimeFormat format)
+{
+    const unsigned hh = static_cast<unsigned>(h);
+    const unsigned mm = static_cast<unsigned>(m);
+
+    switch (format)
+    {
+    case SDK::Message::TimeFormat::Hour12:
+    {
+        const unsigned h12 = (hh % 12u == 0u) ? 12u : (hh % 12u);
+        std::snprintf(out, outSize, "%u:%02u", h12, mm);
+        break;
+    }
+    case SDK::Message::TimeFormat::Hour24Compact:
+        std::snprintf(out, outSize, "%02u%02u", hh, mm);
+        break;
+    case SDK::Message::TimeFormat::Hour24:
+    default:
+        std::snprintf(out, outSize, "%02u:%02u", hh, mm);
+        break;
+    }
+}
+
+} // namespace SDK::Utils
+
+#endif // SDK_UTILS_TIMEFORMAT_HPP

--- a/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
+++ b/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
@@ -121,6 +121,7 @@ void KernelMessageDispatcher::appMsgHandler(SDK::MessageBase* msg)
             auto* settings = static_cast<SDK::Message::RequestSystemSettings*>(msg);
 
             settings->imperialUnits = mSettings.unitsImperial;
+            settings->timeFormat    = mSettings.timeFormat;
 
             const uint32_t limit = std::min(
                 SDK::Message::RequestSystemSettings::skMaxHearRateTh,

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -37,6 +37,7 @@ target_include_directories(sdk_host_test_support PUBLIC
 add_executable(una-sdk-host-tests
     apps/Running/Settings_test.cpp
     apps/Running/SettingsSerializer_test.cpp
+    utils/TimeFormat_test.cpp
     calibration/OutdoorStrideCalibrator_test.cpp
     calibration/StrideLut_test.cpp
     calibration/StrideMath_test.cpp

--- a/Tests/Host/utils/TimeFormat_test.cpp
+++ b/Tests/Host/utils/TimeFormat_test.cpp
@@ -1,0 +1,78 @@
+// Unit tests for SDK::Utils::formatTimeOfDay -- the single source of truth for
+// how the status-face clock is rendered across all apps.
+//
+// The behaviour that most needs pinning down: Hour24 is zero-padded so it stays
+// distinct from Hour12 for morning hours (09:05 vs 9:05). An unpadded 24-hour
+// reading would be byte-identical to the 12-hour one for every hour 1..12,
+// making the setting invisible for half the day -- the regression this guards.
+
+#include <gtest/gtest.h>
+
+#include "SDK/Utils/TimeFormat.hpp"
+
+#include <string>
+
+using SDK::Message::TimeFormat;
+
+namespace {
+
+std::string fmt(std::uint8_t h, std::uint8_t m, TimeFormat f)
+{
+    char buf[8];
+    SDK::Utils::formatTimeOfDay(buf, sizeof(buf), h, m, f);
+    return std::string(buf);
+}
+
+} // namespace
+
+TEST(FormatTimeOfDay, Hour24IsZeroPadded)
+{
+    EXPECT_EQ(fmt(0, 0, TimeFormat::Hour24), "00:00");
+    EXPECT_EQ(fmt(9, 5, TimeFormat::Hour24), "09:05");
+    EXPECT_EQ(fmt(17, 42, TimeFormat::Hour24), "17:42");
+    EXPECT_EQ(fmt(23, 59, TimeFormat::Hour24), "23:59");
+}
+
+TEST(FormatTimeOfDay, Hour12HasNoLeadingZeroAndNoMeridiem)
+{
+    // Noon and midnight both display as 12, not 0.
+    EXPECT_EQ(fmt(0, 0, TimeFormat::Hour12), "12:00");   // midnight
+    EXPECT_EQ(fmt(12, 0, TimeFormat::Hour12), "12:00");  // noon
+    EXPECT_EQ(fmt(13, 0, TimeFormat::Hour12), "1:00");
+    EXPECT_EQ(fmt(9, 5, TimeFormat::Hour12), "9:05");
+    EXPECT_EQ(fmt(17, 42, TimeFormat::Hour12), "5:42");
+    EXPECT_EQ(fmt(23, 59, TimeFormat::Hour12), "11:59");
+}
+
+TEST(FormatTimeOfDay, Hour24CompactIsZeroPaddedWithNoSeparator)
+{
+    EXPECT_EQ(fmt(0, 0, TimeFormat::Hour24Compact), "0000");
+    EXPECT_EQ(fmt(9, 5, TimeFormat::Hour24Compact), "0905");
+    EXPECT_EQ(fmt(17, 42, TimeFormat::Hour24Compact), "1742");
+    EXPECT_EQ(fmt(23, 59, TimeFormat::Hour24Compact), "2359");
+}
+
+// The core reason Hour24 is zero-padded: without it, the 12/24 options are
+// indistinguishable for single-digit morning hours (would both be "9:05").
+// Hours 10-12 unavoidably coincide -- only an AM/PM marker could separate
+// them, and the status face has no such glyphs.
+TEST(FormatTimeOfDay, Hour24AndHour12DifferForSingleDigitMorningHours)
+{
+    for (std::uint8_t h = 1; h <= 9; ++h) {
+        EXPECT_NE(fmt(h, 5, TimeFormat::Hour24), fmt(h, 5, TimeFormat::Hour12))
+            << "hour " << static_cast<int>(h) << " renders identically in 24h and 12h";
+    }
+    // Documented coincidence for the two-digit morning hours.
+    for (std::uint8_t h = 10; h <= 12; ++h) {
+        EXPECT_EQ(fmt(h, 5, TimeFormat::Hour24), fmt(h, 5, TimeFormat::Hour12));
+    }
+}
+
+// An out-of-range/unknown enum value degrades gracefully to Hour24 rather than
+// producing garbage -- matches the switch default the call sites rely on.
+TEST(FormatTimeOfDay, UnknownFormatFallsBackToHour24)
+{
+    const auto bogus = static_cast<TimeFormat>(99);
+    EXPECT_EQ(fmt(9, 5, bogus), "09:05");
+    EXPECT_EQ(fmt(17, 42, bogus), "17:42");
+}


### PR DESCRIPTION
Americans are starting to get watches (so jealous!) and the very first reactions I've seen are unfortunately incredulity around lack of support for different time formats.

This is intended to be backward compatible so I think should Just Work. Setting the actual configuration for 24h compact will need to be implemented in UNA's closed source firmware, but that gap has no negative impact on current users. The `RequestSystemSettings.timeFormat` field existed but was dead plumbing: the kernel dispatcher never populated it, no app read it, and every clock rendered hardcoded 24-hour time.

Replace the bool (which could only express two formats and had ambiguous polarity) with an explicit uint8_t-backed enum, SDK::Message::TimeFormat: Hour24 (0, default, '17:42'), Hour12 ('5:42'), Hour12Extended ('1742'). Same size as the bool, so RequestSystemSettings stays 64 bytes. When we're changing this, making it extensible is cheap - I am not aware of anyone voicing a desire to see 24 hour compact time but I leveraged it as an avenue to show how more formats could be supported (are there more than these 3?).

- Simulator: add `timeFormat` to `WatchSettings` and copy it into `REQUEST_SYSTEM_SETTINGS` responses in `KernelMessageDispatcher`.
- Apps (Cycling, Hiking, Running, Treadmill, Workout): carry the format through `SettingsUpd` -> `Service` -> `Mode`l -> `TrackView`, and render the status-face clock accordingly in `TrackFaceStatus::setTime`.

12-hour mode shows no AM/PM suffix: the status-face wildcard buffer and generated fonts have no A/P/M glyphs, and adding them means regenerating TouchGFX assets for every app. I am not set up to do so presently, so all formats use digits already present.

The Alarm app is untouched, the time wheel remains 24-hour. It is not wired up for settings at all, doing so feels like a different effort than this. On top of that, a 12-hour picker needs an AM/PM wheel and TouchGFX Designer layout changes.

### Default (24 hour, ISO-8601 extended)
<img width="480" height="480" alt="time-format-24h-single-digit" src="https://github.com/user-attachments/assets/fda94f63-e0fb-42bf-9906-e9fe34e69c8e" />
<img width="480" height="480" alt="time-format-24h" src="https://github.com/user-attachments/assets/32b0565d-fa71-4ecd-a408-17f3e16f36d2" />

### 12 hour
<img width="480" height="480" alt="time-format-12h" src="https://github.com/user-attachments/assets/591c7258-930f-4044-9c92-edba995644e2" />

### 24 hour, ISO-8601 Compact
<img width="480" height="480" alt="time-format-military" src="https://github.com/user-attachments/assets/ae72adc4-8fc6-4ed4-9f46-6f34ca80ca75" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configurable 12-hour, 24-hour, and compact time displays.
  * Time-format settings now flow from device settings to the Cycling, Hiking, Running, Treadmill, and Workout interfaces.
  * Track screens display times using the selected format.

* **Bug Fixes**
  * Corrected time displays that previously always used a fixed 24-hour format.

* **Tests**
  * Added coverage for supported formats, edge cases, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->