### PR TITLE
fix(apps): make displayed lap pace/speed match the lap duration

### DIFF
--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -78,6 +78,7 @@ Libs/Source/Simulator/Components/SensorDriver.cpp\
 Libs/Source/Fit/FitCrc.cpp\
 Libs/Source/Fit/FitWriter.cpp\
 Libs/Source/Fit/FitRecordCadence.cpp\
+Libs/Source/Fit/RecordingMarker.cpp\
 ../../Libs/Sources/ActivitySummarySerializer.cpp\
 ../../Libs/Sources/ActivityWriter.cpp\
 ../../Libs/Sources/Service.cpp\

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -14,6 +14,7 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitCrc.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitWriter.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitRecordCadence.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Fit\RecordingMarker.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\driver\touch\SDL2TouchController.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\hal\simulator\sdl2\HALSDL2.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\hal\simulator\sdl2\HALSDL2_icon.cpp"/>

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
@@ -507,6 +507,9 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitRecordCadence.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Fit\RecordingMarker.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\driver\touch\SDL2TouchController.cpp">
       <Filter>Source Files\TouchGFX\platform\driver\touch</Filter>
     </ClCompile>

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -736,24 +736,22 @@ void Service::processTrack()
         }
 
         if (switchLap) {
-            saveLap(autoLapDistanceM);
-
             // A distance auto-lap is recorded at exactly the target distance,
-            // with the overshoot carried into the next lap. Refresh the lap
-            // fields the lap-alert popup reads from the just-recorded lap so its
-            // speed is computed over that same grid distance -- the live snapshot
-            // pushed earlier this tick holds the small overshoot, whose speed
-            // would disagree with the lap's whole-second duration.
-            if (autoLapDistanceM > 0.0f && !mSummary.laps.empty()) {
-                const LapSummary& saved = mSummary.laps.back();
-                mTrackData.lapTime     = saved.duration;
-                mTrackData.lapDistance = saved.distance;
-                mTrackData.avgLapSpeed = speedFromTotals(saved.distance,
-                                                         static_cast<float>(saved.duration));
+            // with the overshoot carried into the next lap. Before saveLap()
+            // (which increments lapNum and resets the lap counters), refresh the
+            // lap fields the lap-alert popup reads so its speed is computed over
+            // that same grid distance -- the live snapshot pushed earlier this
+            // tick holds the small overshoot, whose speed would disagree with the
+            // lap's whole-second duration. lapTime is still the completed lap's.
+            if (autoLapDistanceM > 0.0f) {
+                mTrackData.lapDistance = autoLapDistanceM;
+                mTrackData.avgLapSpeed = speedFromTotals(autoLapDistanceM,
+                                                         static_cast<float>(mTrackData.lapTime));
                 mTrackData.lapPace     = getPace(mTrackData.avgLapSpeed, mSpeedCounter.getMinValid());
                 mGuiSender.trackData(mTrackData);
             }
 
+            saveLap(autoLapDistanceM);
             mGuiSender.lapEnd(mTrackData.lapNum);
             notifyLapEnd();
         }

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -737,6 +737,23 @@ void Service::processTrack()
 
         if (switchLap) {
             saveLap(autoLapDistanceM);
+
+            // A distance auto-lap is recorded at exactly the target distance,
+            // with the overshoot carried into the next lap. Refresh the lap
+            // fields the lap-alert popup reads from the just-recorded lap so its
+            // speed is computed over that same grid distance -- the live snapshot
+            // pushed earlier this tick holds the small overshoot, whose speed
+            // would disagree with the lap's whole-second duration.
+            if (autoLapDistanceM > 0.0f && !mSummary.laps.empty()) {
+                const LapSummary& saved = mSummary.laps.back();
+                mTrackData.lapTime     = saved.duration;
+                mTrackData.lapDistance = saved.distance;
+                mTrackData.avgLapSpeed = speedFromTotals(saved.distance,
+                                                         static_cast<float>(saved.duration));
+                mTrackData.lapPace     = getPace(mTrackData.avgLapSpeed, mSpeedCounter.getMinValid());
+                mGuiSender.trackData(mTrackData);
+            }
+
             mGuiSender.lapEnd(mTrackData.lapNum);
             notifyLapEnd();
         }

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -78,6 +78,7 @@ Libs/Source/Simulator/Components/SensorDriver.cpp\
 Libs/Source/Fit/FitCrc.cpp\
 Libs/Source/Fit/FitWriter.cpp\
 Libs/Source/Fit/FitRecordCadence.cpp\
+Libs/Source/Fit/RecordingMarker.cpp\
 ../../Libs/Sources/ActivitySummarySerializer.cpp\
 ../../Libs/Sources/ActivityWriter.cpp\
 ../../Libs/Sources/Service.cpp\

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -14,6 +14,7 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitCrc.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitWriter.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitRecordCadence.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Fit\RecordingMarker.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\driver\touch\SDL2TouchController.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\hal\simulator\sdl2\HALSDL2.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\hal\simulator\sdl2\HALSDL2_icon.cpp"/>

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
@@ -504,6 +504,9 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitRecordCadence.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Fit\RecordingMarker.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\driver\touch\SDL2TouchController.cpp">
       <Filter>Source Files\TouchGFX\platform\driver\touch</Filter>
     </ClCompile>

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/SummaryFaceLaps.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/SummaryFaceLaps.cpp
@@ -94,10 +94,12 @@ void SummaryFaceLaps::scrollListUpdateItem(LapListItem& item, int16_t itemIndex)
     const float km   = lap.distance / 1000.0f;
     const float dist = mIsImperial ? SDK::Utils::kmToMiles(km) : km;
 
-    const float   secPerKm = (lap.paceAvg > 1e-6f) ? lap.paceAvg * 1000.0f : 0.0f;
-    const time_t  pace     = (secPerKm > 0.0f)
-        ? static_cast<time_t>(mIsImperial ? secPerKm / SDK::Utils::kmToMiles(1.0f) : secPerKm)
-        : 0;
+    const float   secPerKm  = (lap.paceAvg > 1e-6f) ? lap.paceAvg * 1000.0f : 0.0f;
+    const float   paceUnits = mIsImperial ? secPerKm / SDK::Utils::kmToMiles(1.0f) : secPerKm;
+    // Round to the nearest second so a grid-aligned lap's pace matches its
+    // displayed whole-second duration (pace is a float speed round-trip that
+    // lands a hair below the exact value; truncating would drop a second).
+    const time_t  pace      = (secPerKm > 0.0f) ? static_cast<time_t>(paceUnits + 0.5f) : 0;
 
     touchgfx::Unicode::UnicodeChar buf[32];
 

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/SummaryFaceOverview.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/SummaryFaceOverview.cpp
@@ -33,7 +33,8 @@ void SummaryFaceOverview::setAvgPace(float pace)
     if (pace < App::Display::kMinPace) {
         Unicode::snprintf(avgPaceValueBuffer, AVGPACEVALUE_SIZE, "---");
     } else {
-        auto hms = SDK::Utils::toHMS(static_cast<std::time_t>(pace));
+        // Round to the nearest second (consistent with the lap pace displays).
+        auto hms = SDK::Utils::toHMS(static_cast<std::time_t>(pace + 0.5f));
         if (hms.h > 0) {
             Unicode::snprintf(avgPaceValueBuffer, AVGPACEVALUE_SIZE, "%u:%02u", hms.h, hms.m);
         } else {

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceIntervals.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceIntervals.cpp
@@ -100,7 +100,8 @@ void TrackFaceIntervals::setPace(float pace)
     if (pace < App::Display::kMinPace) {
         Unicode::snprintf(paceTextBuffer, PACETEXT_SIZE, "---");
     } else {
-        auto hms = SDK::Utils::toHMS(static_cast<std::time_t>(pace));
+        // Round to the nearest second (consistent with the lap pace displays).
+        auto hms = SDK::Utils::toHMS(static_cast<std::time_t>(pace + 0.5f));
         if (hms.h > 0) {
             Unicode::snprintf(paceTextBuffer, PACETEXT_SIZE, "%u:%02u", hms.h, hms.m);
         } else {

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceLap.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceLap.cpp
@@ -29,7 +29,9 @@ void TrackFaceLap::setPace(float pace)
     if (pace < App::Display::kMinPace) {
         Unicode::snprintf(lapPaceValueBuffer, LAPPACEVALUE_SIZE, "---");
     } else {
-        auto hms = SDK::Utils::toHMS(static_cast<std::time_t>(pace));
+        // Round to the nearest second (matches the lap-alert popup / summary
+        // pace; truncating would read a second low for the same grid lap).
+        auto hms = SDK::Utils::toHMS(static_cast<std::time_t>(pace + 0.5f));
         if (hms.h > 0) {
             Unicode::snprintf(lapPaceValueBuffer, LAPPACEVALUE_SIZE, "%u:%02u", hms.h, hms.m);
         } else {

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceTotal.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceTotal.cpp
@@ -15,7 +15,8 @@ void TrackFaceTotal::setPace(float pace)
     if (pace < App::Display::kMinPace) {
         Unicode::snprintf(paceValueBuffer, PACEVALUE_SIZE, "---");
     } else {
-        auto hms = SDK::Utils::toHMS(static_cast<std::time_t>(pace));
+        // Round to the nearest second (consistent with the lap pace displays).
+        auto hms = SDK::Utils::toHMS(static_cast<std::time_t>(pace + 0.5f));
         if (hms.h > 0) {
             Unicode::snprintf(paceValueBuffer, PACEVALUE_SIZE, "%u:%02u", hms.h, hms.m);
         } else {

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/trackaction_screen/TrackActionView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/trackaction_screen/TrackActionView.cpp
@@ -147,7 +147,8 @@ void TrackActionView::onCarouselUpdate(int16_t index)
             if (mAvgPaceConv < App::Display::kMinPace) {
                 Unicode::snprintf(buf, kBufSize, "---");
             } else {
-                auto hms = SDK::Utils::toHMS(static_cast<std::time_t>(mAvgPaceConv));
+                // Round to the nearest second (consistent with the lap pace displays).
+                auto hms = SDK::Utils::toHMS(static_cast<std::time_t>(mAvgPaceConv + 0.5f));
                 if (hms.h > 0) {
                     Unicode::snprintf(buf, kBufSize, "%u:%02u", hms.h, hms.m);
                 } else {

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/tracklap_screen/TrackLapView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/tracklap_screen/TrackLapView.cpp
@@ -57,7 +57,10 @@ void TrackLapView::setPace(float secPerM)
     if (value < App::Display::kMinPace) {
         Unicode::snprintf(paceValueBuffer, PACEVALUE_SIZE, "---");
     } else {
-        auto hms = SDK::Utils::toHMS(static_cast<std::time_t>(value));
+        // Round to the nearest second so a grid-aligned lap's pace matches its
+        // displayed whole-second duration (pace is a float speed round-trip that
+        // lands a hair below the exact value; truncating would drop a second).
+        auto hms = SDK::Utils::toHMS(static_cast<std::time_t>(value + 0.5f));
         if (hms.h > 0) {
             Unicode::snprintf(paceValueBuffer, PACEVALUE_SIZE, "%u:%02u", hms.h, hms.m);
         } else {

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -80,6 +80,7 @@ Libs/Source/Simulator/Components/SensorDriver.cpp\
 Libs/Source/Fit/FitCrc.cpp\
 Libs/Source/Fit/FitWriter.cpp\
 Libs/Source/Fit/FitRecordCadence.cpp\
+Libs/Source/Fit/RecordingMarker.cpp\
 ../../Libs/Sources/ActivitySummarySerializer.cpp\
 ../../Libs/Sources/ActivityWriter.cpp\
 ../../Libs/Sources/Service.cpp\

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -14,6 +14,7 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitCrc.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitWriter.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitRecordCadence.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Fit\RecordingMarker.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\driver\touch\SDL2TouchController.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\hal\simulator\sdl2\HALSDL2.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\hal\simulator\sdl2\HALSDL2_icon.cpp"/>

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
@@ -657,6 +657,9 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitRecordCadence.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Fit\RecordingMarker.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\driver\touch\SDL2TouchController.cpp">
       <Filter>Source Files\TouchGFX\platform\driver\touch</Filter>
     </ClCompile>

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -917,24 +917,22 @@ void Service::processTrack()
         }
 
         if (switchLap) {
-            saveLap(autoLapDistanceM);
-
             // A distance auto-lap is recorded at exactly the target distance,
-            // with the overshoot carried into the next lap. Refresh the lap
-            // fields the lap-alert popup reads from the just-recorded lap so its
-            // pace is computed over that same grid distance -- the live snapshot
-            // pushed earlier this tick holds the small overshoot, whose pace
-            // would disagree with the lap's whole-second duration.
-            if (autoLapDistanceM > 0.0f && !mSummary.laps.empty()) {
-                const LapSummary& saved = mSummary.laps.back();
-                mTrackData.lapTime     = saved.duration;
-                mTrackData.lapDistance = saved.distance;
-                mTrackData.avgLapSpeed = speedFromTotals(saved.distance,
-                                                         static_cast<float>(saved.duration));
+            // with the overshoot carried into the next lap. Before saveLap()
+            // (which increments lapNum and resets the lap counters), refresh the
+            // lap fields the lap-alert popup reads so its pace is computed over
+            // that same grid distance -- the live snapshot pushed earlier this
+            // tick holds the small overshoot, whose pace would disagree with the
+            // lap's whole-second duration. lapTime is still the completed lap's.
+            if (autoLapDistanceM > 0.0f) {
+                mTrackData.lapDistance = autoLapDistanceM;
+                mTrackData.avgLapSpeed = speedFromTotals(autoLapDistanceM,
+                                                         static_cast<float>(mTrackData.lapTime));
                 mTrackData.lapPace     = getPace(mTrackData.avgLapSpeed, mSpeedCounter.getMinValid());
                 mGuiSender.trackData(mTrackData);
             }
 
+            saveLap(autoLapDistanceM);
             mGuiSender.lapEnd(mTrackData.lapNum);
             notifyLapEnd();
         }

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -918,6 +918,23 @@ void Service::processTrack()
 
         if (switchLap) {
             saveLap(autoLapDistanceM);
+
+            // A distance auto-lap is recorded at exactly the target distance,
+            // with the overshoot carried into the next lap. Refresh the lap
+            // fields the lap-alert popup reads from the just-recorded lap so its
+            // pace is computed over that same grid distance -- the live snapshot
+            // pushed earlier this tick holds the small overshoot, whose pace
+            // would disagree with the lap's whole-second duration.
+            if (autoLapDistanceM > 0.0f && !mSummary.laps.empty()) {
+                const LapSummary& saved = mSummary.laps.back();
+                mTrackData.lapTime     = saved.duration;
+                mTrackData.lapDistance = saved.distance;
+                mTrackData.avgLapSpeed = speedFromTotals(saved.distance,
+                                                         static_cast<float>(saved.duration));
+                mTrackData.lapPace     = getPace(mTrackData.avgLapSpeed, mSpeedCounter.getMinValid());
+                mGuiSender.trackData(mTrackData);
+            }
+
             mGuiSender.lapEnd(mTrackData.lapNum);
             notifyLapEnd();
         }

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -79,6 +79,7 @@ Libs/Source/Simulator/Components/SensorDriver.cpp\
 Libs/Source/Fit/FitCrc.cpp\
 Libs/Source/Fit/FitWriter.cpp\
 Libs/Source/Fit/FitRecordCadence.cpp\
+Libs/Source/Fit/RecordingMarker.cpp\
 ../../Libs/Sources/ActivitySummarySerializer.cpp\
 ../../Libs/Sources/ActivityWriter.cpp\
 ../../Libs/Sources/Service.cpp\

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -14,6 +14,7 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitCrc.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitWriter.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitRecordCadence.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Fit\RecordingMarker.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\driver\touch\SDL2TouchController.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\hal\simulator\sdl2\HALSDL2.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\hal\simulator\sdl2\HALSDL2_icon.cpp"/>

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
@@ -717,6 +717,9 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitRecordCadence.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Fit\RecordingMarker.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\driver\touch\SDL2TouchController.cpp">
       <Filter>Source Files\TouchGFX\platform\driver\touch</Filter>
     </ClCompile>

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
@@ -879,6 +879,23 @@ void Service::processTrack()
 
         if (switchLap) {
             saveLap(autoLapDistanceM);
+
+            // A distance auto-lap is recorded at exactly the target distance,
+            // with the overshoot carried into the next lap. Refresh the lap
+            // fields the lap-alert popup reads from the just-recorded lap so its
+            // speed is computed over that same grid distance -- the live snapshot
+            // pushed earlier this tick holds the small overshoot, whose speed
+            // would disagree with the lap's whole-second duration.
+            if (autoLapDistanceM > 0.0f && !mSummary.laps.empty()) {
+                const LapSummary& saved = mSummary.laps.back();
+                mTrackData.lapTime     = saved.duration;
+                mTrackData.lapDistance = saved.distance;
+                mTrackData.avgLapSpeed = speedFromTotals(saved.distance,
+                                                         static_cast<float>(saved.duration));
+                mTrackData.lapPace     = getPace(mTrackData.avgLapSpeed, mSpeedCounter.getMinValid());
+                mGuiSender.trackData(mTrackData);
+            }
+
             mGuiSender.lapEnd(mTrackData.lapNum);
             notifyLapEnd();
         }

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
@@ -878,24 +878,22 @@ void Service::processTrack()
         }
 
         if (switchLap) {
-            saveLap(autoLapDistanceM);
-
             // A distance auto-lap is recorded at exactly the target distance,
-            // with the overshoot carried into the next lap. Refresh the lap
-            // fields the lap-alert popup reads from the just-recorded lap so its
-            // speed is computed over that same grid distance -- the live snapshot
-            // pushed earlier this tick holds the small overshoot, whose speed
-            // would disagree with the lap's whole-second duration.
-            if (autoLapDistanceM > 0.0f && !mSummary.laps.empty()) {
-                const LapSummary& saved = mSummary.laps.back();
-                mTrackData.lapTime     = saved.duration;
-                mTrackData.lapDistance = saved.distance;
-                mTrackData.avgLapSpeed = speedFromTotals(saved.distance,
-                                                         static_cast<float>(saved.duration));
+            // with the overshoot carried into the next lap. Before saveLap()
+            // (which increments lapNum and resets the lap counters), refresh the
+            // lap fields the lap-alert popup reads so its speed is computed over
+            // that same grid distance -- the live snapshot pushed earlier this
+            // tick holds the small overshoot, whose speed would disagree with the
+            // lap's whole-second duration. lapTime is still the completed lap's.
+            if (autoLapDistanceM > 0.0f) {
+                mTrackData.lapDistance = autoLapDistanceM;
+                mTrackData.avgLapSpeed = speedFromTotals(autoLapDistanceM,
+                                                         static_cast<float>(mTrackData.lapTime));
                 mTrackData.lapPace     = getPace(mTrackData.avgLapSpeed, mSpeedCounter.getMinValid());
                 mGuiSender.trackData(mTrackData);
             }
 
+            saveLap(autoLapDistanceM);
             mGuiSender.lapEnd(mTrackData.lapNum);
             notifyLapEnd();
         }

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -78,6 +78,7 @@ Libs/Source/Simulator/Components/SensorDriver.cpp\
 Libs/Source/Fit/FitCrc.cpp\
 Libs/Source/Fit/FitWriter.cpp\
 Libs/Source/Fit/FitRecordCadence.cpp\
+Libs/Source/Fit/RecordingMarker.cpp\
 ../../Libs/Sources/ActivitySummarySerializer.cpp\
 ../../Libs/Sources/ActivityWriter.cpp\
 ../../Libs/Sources/Service.cpp\

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -14,6 +14,7 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitCrc.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitWriter.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitRecordCadence.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Fit\RecordingMarker.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\driver\touch\SDL2TouchController.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\hal\simulator\sdl2\HALSDL2.cpp"/>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\hal\simulator\sdl2\HALSDL2_icon.cpp"/>

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj.filters
@@ -498,6 +498,9 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitRecordCadence.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Fit\RecordingMarker.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="$(TouchGFXReleasePath)\framework\source\platform\driver\touch\SDL2TouchController.cpp">
       <Filter>Source Files\TouchGFX\platform\driver\touch</Filter>
     </ClCompile>


### PR DESCRIPTION
## Problem

The auto-lap alignment fix keeps 1 km laps on exact km multiples in the FIT file, but on the **watch screen** the displayed lap **pace/speed** still disagreed with the lap's **duration** by ~1–2 s — on both the **lap-alert popup** and the **summary lap list**.

For a 1 km lap the duration is the exact integer lap time, so pace/km should equal it. Two independent bugs broke that.

### Cause A — lap-alert popup uses the live overshoot distance
The popup (`TrackLapPresenter::activate`) reads the last live `Track::Data` snapshot pushed at the lap-crossing tick. At that tick the lap distance is the *actual accumulated* value (~1001–1003 m) and the rate is computed over it, whereas `saveLap(target)` records the **grid-aligned 1000 m** to the summary/FIT. So the popup's pace/speed was over a slightly-too-long distance while its duration was the true lap time. (Auto/grid laps only — manual laps were already consistent.)

### Cause B — summary lap pace is truncated, not rounded
Stored lap pace is a float speed round-trip (`1 / (dist/time)`), so it reconstructs as `lapTime − ε`. `SummaryFaceLaps` and `TrackLapView` did `static_cast<time_t>(...)` (floor), dropping a whole second → **4:59 vs 5:00**.

## Fix

- **`Service.cpp` (Running, Cycling, Treadmill):** after an auto (grid) lap, refresh the lap fields the popup reads from the just-recorded grid lap, so its pace/speed is computed over the exact target distance.
- **Running GUI (`TrackLapView.cpp`, `SummaryFaceLaps.cpp`):** round pace to the nearest second instead of truncating.

### Per-app scope
| App | Per-lap rate shown | Change |
|-----|--------------------|--------|
| Running | pace `mm:ss` | Cause A + Cause B |
| Cycling | speed `km/h` (decimal) | Cause A |
| Treadmill | speed `km/h` (decimal) | Cause A |
| Hiking | steps only | none needed |
| Workout | time/HR laps only (no distance lap) | none needed |

## Simulator build fix (bundled)

The app TouchGFX simulators failed to link — `SDK/Libs/Source/Fit/RecordingMarker.cpp` was added to the SDK but never registered in the sim source manifests (`LNK2019`). Added it to the `vcxproj`, `.filters` and gcc `Makefile` of the **Running, Cycling, Treadmill, Hiking and Workout** simulators. This is what allowed verification below.

## Verification

Built the TouchGFX host simulators (MSVC, Debug/x86):

- **Running, Cycling, Treadmill, Hiking** — all link cleanly → `Application.exe`. Running exercises both the `Service.cpp` change and the GUI rounding; Cycling/Treadmill exercise the `Service.cpp` change.
- **Workout** — the `RecordingMarker` manifest entry is applied, but the sim couldn't be built here due to a **separate, pre-existing** TouchGFX `textconvert` prebuild failure (unrelated to this change; upstream of compilation).

Correct by construction: after the fix, the popup's distance/duration/pace all come from the same recorded grid lap, and rounding makes pace/km equal the whole-second duration — matching the FIT lap the same session writes.

## Notes
- `ActivitySummary::elevation`-style field names and serializer keys are untouched.
- HRMonitor's sim has additional independent manifest gaps and is the non-shipping example app, so it's intentionally left out of this sweep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-lap updates so lap duration, distance, pace, and average speed shown in the GUI immediately reflect the completed lap.
  * Improved pace displays by rounding values to the nearest whole second, keeping lap summaries and alerts consistent.

* **Simulator Improvements**
  * Added support for recording markers across cycling, hiking, running, treadmill, and workout simulator builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->