### PR TITLE
fix(workout): correct sim TouchGFXEnvPath so textconvert finds Ruby

### DIFF
--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <UseBPP>8</UseBPP>
     <TouchGFXReleasePath>..\..\..\..\..\..\..\..\ThirdParty\touchgfx</TouchGFXReleasePath>
-    <TouchGFXEnvPath>..\..\..\..\..\..\..\..\..\..\..\..\TouchGFX\4.26.1\env</TouchGFXEnvPath>
+    <TouchGFXEnvPath>..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\TouchGFX\4.26.1\env</TouchGFXEnvPath>
     <ApplicationRoot>..\..</ApplicationRoot>
   </PropertyGroup>
   <PropertyGroup/>


### PR DESCRIPTION
## Problem

Follow-up to #196. The Workout TouchGFX **simulator** couldn't be built: the `GenerateTextsAndFontsFiles` prebuild step failed with `MSB3073` (Ruby `textconvert` "exited with code 3"), before any compilation.

## Root cause

The prebuild invokes `"$(TouchGFXEnvPath)\MinGW\msys\1.0\Ruby30-x64\bin\ruby.exe"`, and the `<Exec>` runs from the project directory (`simulator/msvs`), which is 13 levels below `C:\`. Workout's `config/msvs/Application.props` set:

```xml
<TouchGFXEnvPath>..\..\..\..\..\..\..\..\..\..\..\..\TouchGFX\4.26.1\env</TouchGFXEnvPath>
```

That's only **12** `..\` segments → resolves to `C:\Users\…\TouchGFX\4.26.1\env` (one level short of the drive root), so `ruby.exe` isn't found and `textconvert` fails.

The activity-app siblings use **16** `..\` segments, which over-shoot and clamp at the drive root (`C:\`), resolving correctly:

| App | `TouchGFXEnvPath` |
|-----|-------------------|
| Cycling / Treadmill / Hiking | `..`×16 `\TouchGFX\4.26.1\env` ✅ |
| Running / HRMonitor | `C:\TouchGFX\4.26.1\env` (absolute) ✅ |
| **Workout (before)** | `..`×**12** `\TouchGFX\4.26.1\env` ❌ |

## Fix

Change Workout's `TouchGFXEnvPath` to 16 `..\` segments, matching its Cycling/Treadmill/Hiking siblings. One-line change.

## Verification

Clean rebuild (`/t:Rebuild`) of the Workout simulator (MSVC, Debug/x86): `Converting texts and fonts` now succeeds and the build links to `Application.exe` (the `RecordingMarker.cpp` link gap was already fixed in #196).

## Note

All apps still hardcode a TouchGFX install at `C:\TouchGFX\4.26.1` (whether absolutely or via root-clamping relatives). That's a pre-existing, machine-specific assumption across the whole simulator set and is out of scope here — this PR only unbreaks Workout by making it consistent with its siblings.
