### PR TITLE
build(sims): make TouchGFXEnvPath overridable via environment variable

### DIFF
--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <UseBPP>8</UseBPP>
     <TouchGFXReleasePath>..\..\..\..\..\..\..\..\ThirdParty\touchgfx</TouchGFXReleasePath>
-    <TouchGFXEnvPath>C:\TouchGFX\4.26.1\env</TouchGFXEnvPath>
+    <TouchGFXEnvPath Condition="'$(TouchGFXEnvPath)'==''">C:\TouchGFX\4.26.1\env</TouchGFXEnvPath>
     <ApplicationRoot>..\..</ApplicationRoot>
   </PropertyGroup>
   <PropertyGroup/>

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <UseBPP>8</UseBPP>
     <TouchGFXReleasePath>..\..\..\..\..\..\..\..\ThirdParty\touchgfx</TouchGFXReleasePath>
-    <TouchGFXEnvPath>..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\TouchGFX\4.26.1\env</TouchGFXEnvPath>
+    <TouchGFXEnvPath Condition="'$(TouchGFXEnvPath)'==''">C:\TouchGFX\4.26.1\env</TouchGFXEnvPath>
     <ApplicationRoot>..\..</ApplicationRoot>
   </PropertyGroup>
   <PropertyGroup/>

--- a/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
+++ b/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <UseBPP>8</UseBPP>
     <TouchGFXReleasePath>..\..\..\..\..\..\..\..\ThirdParty\touchgfx</TouchGFXReleasePath>
-    <TouchGFXEnvPath>C:\TouchGFX\4.26.1\env</TouchGFXEnvPath>
+    <TouchGFXEnvPath Condition="'$(TouchGFXEnvPath)'==''">C:\TouchGFX\4.26.1\env</TouchGFXEnvPath>
     <ApplicationRoot>..\..</ApplicationRoot>
   </PropertyGroup>
   <PropertyGroup/>

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <UseBPP>8</UseBPP>
     <TouchGFXReleasePath>..\..\..\..\..\..\..\..\ThirdParty\touchgfx</TouchGFXReleasePath>
-    <TouchGFXEnvPath>..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\TouchGFX\4.26.1\env</TouchGFXEnvPath>
+    <TouchGFXEnvPath Condition="'$(TouchGFXEnvPath)'==''">C:\TouchGFX\4.26.1\env</TouchGFXEnvPath>
     <ApplicationRoot>..\..</ApplicationRoot>
   </PropertyGroup>
   <PropertyGroup/>

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <UseBPP>8</UseBPP>
     <TouchGFXReleasePath>..\..\..\..\..\..\..\..\ThirdParty\touchgfx</TouchGFXReleasePath>
-    <TouchGFXEnvPath>C:\TouchGFX\4.26.1\env</TouchGFXEnvPath>
+    <TouchGFXEnvPath Condition="'$(TouchGFXEnvPath)'==''">C:\TouchGFX\4.26.1\env</TouchGFXEnvPath>
     <ApplicationRoot>..\..</ApplicationRoot>
   </PropertyGroup>
   <PropertyGroup/>

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <UseBPP>8</UseBPP>
     <TouchGFXReleasePath>..\..\..\..\..\..\..\..\ThirdParty\touchgfx</TouchGFXReleasePath>
-    <TouchGFXEnvPath>..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\TouchGFX\4.26.1\env</TouchGFXEnvPath>
+    <TouchGFXEnvPath Condition="'$(TouchGFXEnvPath)'==''">C:\TouchGFX\4.26.1\env</TouchGFXEnvPath>
     <ApplicationRoot>..\..</ApplicationRoot>
   </PropertyGroup>
   <PropertyGroup/>

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/config/msvs/Application.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros">
     <UseBPP>8</UseBPP>
     <TouchGFXReleasePath>..\..\..\..\..\..\..\..\ThirdParty\touchgfx</TouchGFXReleasePath>
-    <TouchGFXEnvPath>..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\TouchGFX\4.26.1\env</TouchGFXEnvPath>
+    <TouchGFXEnvPath Condition="'$(TouchGFXEnvPath)'==''">C:\TouchGFX\4.26.1\env</TouchGFXEnvPath>
     <ApplicationRoot>..\..</ApplicationRoot>
   </PropertyGroup>
   <PropertyGroup/>


### PR DESCRIPTION
## Motivation

Follow-up to #197. The app TouchGFX **simulators** locate the TouchGFX-bundled Ruby interpreter via `$(TouchGFXEnvPath)` (`…\MinGW\msys\1.0\Ruby30-x64\bin\ruby.exe`), used by the `textconvert`/`videoconvert` prebuild steps. Each app's `config/msvs/Application.props` **hardcoded** that to the local TouchGFX Designer install, and the values had drifted inconsistently:

- Running / HRMonitor / Alarm: `C:\TouchGFX\4.26.1\env` (absolute)
- Cycling / Treadmill / Hiking / Workout: `..`×16 `\TouchGFX\4.26.1\env` (root-clamping relative)

Because these files are TouchGFX-Designer-generated (and usually reverted after `tgfx generate`), that drift is how the Workout sim broke in #197 (a short `..`×12).

Note: only the **Ruby interpreter** path was machine-specific. The framework and the convert tools are already resolved from the vendored `ThirdParty/touchgfx` via the relative `TouchGFXReleasePath`.

## Change

Two parts, applied to all seven app simulators:

1. **Overridable** — guard the value so an environment variable wins when present:
   ```xml
   <TouchGFXEnvPath Condition="'$(TouchGFXEnvPath)'==''">C:\TouchGFX\4.26.1\env</TouchGFXEnvPath>
   ```
   MSBuild seeds properties from environment variables; env-seeded properties are otherwise silently clobbered by an unconditional project assignment, so the `Condition` is what actually lets the env var win. When `TouchGFXEnvPath` isn't set, the fallback is used.

2. **Standardized fallback** — all seven now fall back to the same string: TouchGFX's default Windows install path `C:\TouchGFX\4.26.1\env`. No more per-app divergence.

## Verification

On the Workout and Cycling simulators (MSVC, Debug/x86, `/t:Rebuild`):

| Scenario | Result |
|----------|--------|
| No `TouchGFXEnvPath` env var | ✅ builds (uses the standardized `C:\TouchGFX\4.26.1\env` fallback) |
| `TouchGFXEnvPath=C:\bogus_touchgfx\env` | ❌ `MSB3073` — Ruby invoked from `C:\bogus_touchgfx\env\…` (env var overrode the fallback → precedence confirmed) |
| `TouchGFXEnvPath=C:\TouchGFX\4.26.1\env` | ✅ builds |

All seven changed lines are byte-identical (verified same git blob), LF, one line each; no other property or file touched.

## Caveats
- **Regeneration strips the `Condition`.** `Application.props` is TouchGFX-Designer-generated, so `tgfx generate` (or editing macros via the VS Property Manager) will rewrite this line and drop the override — same class as the existing "revert `Application.props` after regen" workflow. Doesn't break the committed build; just re-apply if regenerating.
- **Setting the env var for the VS IDE requires restarting `devenv`** (it reads the environment at launch). Command-line MSBuild picks it up per invocation.
- **Drive portability:** the old `..`×16 relative clamped to the *checkout's* drive root, so a non-`C:` checkout with TouchGFX on that drive worked without config; it now uses the `C:` default and relies on the env var otherwise. Net improvement, since Designer default-installs to `C:\TouchGFX` and three apps were already hardcoded to `C:`.

## Scope
`Examples/Apps/*` only. The `Docs/Tutorials/*` apps use the same pattern (pinned to 4.26.0) and are left out.
