### PR TITLE
fix(workout): stop HR-zone summary time clipping past one hour

### DIFF
--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/ZoneInfo.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/ZoneInfo.hpp
@@ -42,6 +42,10 @@ protected:
     static constexpr int16_t kBarFullEndX = 48;
     /// Bar y coordinate (from generated base).
     static constexpr int16_t kBarY = 10;
+    /// Right edge (local x) the time text is right-aligned to.  Just inside the
+    /// 180-wide container so a wide H:MM:SS grows leftward without being clipped
+    /// by the container bounds; still clears the progress bar (ends near x=120).
+    static constexpr int16_t kZoneTimeRightEdgeX = 179;
 };
 
 #endif // ZONEINFO_HPP

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/ZoneInfo.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/ZoneInfo.cpp
@@ -35,6 +35,14 @@ void ZoneInfo::setRow(uint8_t zoneNumber1to5,
                           static_cast<unsigned>(hms.m),
                           static_cast<unsigned>(hms.s));
     }
+    // The generated base sizes/places zoneTime for a short "M:SS" placeholder,
+    // and the parent container clips children at its right edge, so a wider
+    // H:MM:SS value (a zone time over an hour) would be cut off.  Re-fit the
+    // widget to the current text and right-align it to the row's right edge so
+    // it grows leftward and stays within the container bounds.
+    zoneTime.invalidate();
+    zoneTime.resizeToCurrentText();
+    zoneTime.setX(static_cast<int16_t>(kZoneTimeRightEdgeX - zoneTime.getWidth()));
     zoneTime.invalidate();
 
     const float clampedPct = std::clamp(percent0to100, 0.0f, 100.0f);


### PR DESCRIPTION
## Problem

On the Workout app's **HR ZONES** activity-summary screen, a zone time longer than one hour is clipped — e.g. `1:24:58` renders as `1:24:5` (reported from a real session).

## Root cause

`ZoneInfoBase` (generated) positions the `zoneTime` text at local x=135 and calls `resizeToCurrentText()` **once at init** against a short `M:SS` placeholder, locking its width/position for ~4 characters. Two things then combine:

1. A `TextArea` clips text to its own rectangle, and
2. the parent `ZoneInfo` container clips its children at its right edge (local x=180).

Left-aligned at x=135, only ~45px is available before the container edge — not enough for a `H:MM:SS` string. Sub-hour rows (`0:00`) fit, which is why only the over-an-hour value is affected.

## Fix

In `ZoneInfo::setRow`, re-fit `zoneTime` to its current string on every update and **right-align** it to the row's right edge so it grows leftward and stays within the container bounds:

```cpp
zoneTime.invalidate();
zoneTime.resizeToCurrentText();
zoneTime.setX(kZoneTimeRightEdgeX - zoneTime.getWidth());
zoneTime.invalidate();
```

The right edge (local x=179) sits just inside the 180-wide container and clears the progress bar (ends near local x=120). As a bonus the numeric time column is now consistently right-aligned across all five rows.

## Scope

The `ZoneInfo` / `SummaryFaceZones` HR-zones summary is unique to the Workout app; no sibling activity apps share this container, so no parallel fix is needed.

## Testing

Verified in the Workout TouchGFX simulator by temporarily forcing zone 1 to `1:24:58` and navigating to the HR ZONES summary face:

- **Before** the fix: rendered `1:24:5`, cut off exactly at the container's right edge.
- **After** the fix: full `1:24:58` renders, right-aligned and clear of the bar; `0:00` rows unaffected.

(The temporary data hack used only for this check was reverted; the sim builds clean with the final change.)
