### PR TITLE
fix(fit): close the recovered .fit after a successful boot-time recovery

### DIFF
--- a/Libs/Header/SDK/Fit/FitWriter.hpp
+++ b/Libs/Header/SDK/Fit/FitWriter.hpp
@@ -128,6 +128,10 @@ public:
     /// records -- it trusts @p dataEnd as a record boundary) and must satisfy
     /// 14 <= dataEnd <= file.size(). Returns false WITHOUT modifying the file on
     /// a bad/non-FIT header or an out-of-range @p dataEnd.
+    ///
+    /// On success @p file is left OPEN in write mode (mirroring finish(), whose
+    /// caller owns and closes the writer's file); the caller must close() it --
+    /// destroying the handle does not. On failure the file is closed.
     static bool recover(SDK::Interface::IFile& file, uint32_t dataEnd);
 
 private:

--- a/Libs/Header/SDK/Fit/RecordingMarker.hpp
+++ b/Libs/Header/SDK/Fit/RecordingMarker.hpp
@@ -70,8 +70,12 @@ public:
 
     /// Full recover orchestration: if the marker exists, open the .fit it names
     /// and finalize it via FitWriter::recover(file, offset). The marker is
-    /// ALWAYS removed afterwards (recovery is one-shot; give up cleanly on a
-    /// missing file or a failed recover). Safe to call with no marker present.
+    /// removed afterwards (recovery is one-shot; give up cleanly on a missing
+    /// file or a failed recover) -- EXCEPT when the finalized file's close()
+    /// fails: the bytes are durable but the handle (and its FatFs lock) stays
+    /// held, so the marker is kept and failure reported; the next boot retries
+    /// (FitWriter::recover() is idempotent on an already-finalized file).
+    /// Safe to call with no marker present.
     RecoverResult recover();
 
 private:

--- a/Libs/Source/Fit/RecordingMarker.cpp
+++ b/Libs/Source/Fit/RecordingMarker.cpp
@@ -175,13 +175,21 @@ RecordingMarker::RecoverResult RecordingMarker::recover()
         // write-mode open pins a FatFs lock-table slot until reboot, making
         // every later open/rename/delete of the just-recovered activity fail
         // with FR_LOCKED. (Failed recovers close on every path themselves.)
-        file->close();
+        if (!file->close()) {
+            // f_close can fail on its final sync and then keeps the handle
+            // (and its lock) held. The recovered bytes are already durable,
+            // but the file is unusable this session -- and the kernel only
+            // registers a .fit on a successful close -- so KEEP the marker
+            // and report failure: the next boot retries, which is safe
+            // because recover() is idempotent on an already-finalized file.
+            return result;
+        }
         result.recovered = true;
         result.path      = fitPath;
     }
 
-    // One-shot: always clear the marker (a missing file or failed recover is
-    // given up on cleanly so the next boot does not retry forever).
+    // One-shot otherwise: clear the marker (a missing file or failed recover
+    // is given up on cleanly so the next boot does not retry forever).
     remove();
     return result;
 }

--- a/Libs/Source/Fit/RecordingMarker.cpp
+++ b/Libs/Source/Fit/RecordingMarker.cpp
@@ -170,6 +170,12 @@ RecordingMarker::RecoverResult RecordingMarker::recover()
 
     auto file = mFs.file(fitPath.c_str());
     if (file && file->exist() && FitWriter::recover(*file, dataEnd)) {
+        // A successful recover() leaves the file open in write mode, and
+        // destroying the handle does NOT close it. Close it here: a leaked
+        // write-mode open pins a FatFs lock-table slot until reboot, making
+        // every later open/rename/delete of the just-recovered activity fail
+        // with FR_LOCKED. (Failed recovers close on every path themselves.)
+        file->close();
         result.recovered = true;
         result.path      = fitPath;
     }

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(una-sdk-host-tests
     simulator/FileSystemMock_test.cpp
     sensorlayer/GyroscopeParser_test.cpp
     metrics/MonotonicCounter_test.cpp
+    support/KernelTestDoubles_test.cpp
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/SettingsSerializer.cpp"
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/Calibration/OutdoorStrideCalibrator.cpp"

--- a/Tests/Host/fit/RecordingMarker_test.cpp
+++ b/Tests/Host/fit/RecordingMarker_test.cpp
@@ -110,6 +110,9 @@ TEST(RecordingMarker, RecoverFinalizesTornFit)
     EXPECT_TRUE(res.recovered);
     EXPECT_EQ(res.path, fitPath);
     EXPECT_FALSE(fs.exist("Activity/.recording")) << "marker cleared after recovery";
+    EXPECT_EQ(fs.openHandles[fitPath], 0u)
+        << "recovered .fit must be closed (a leaked write handle pins a FatFs "
+           "lock slot until reboot, blocking sync/delete of the activity)";
 
     const std::vector<uint8_t> b = bytesOf(fs, fitPath);
     testfit::FitReader r(b);
@@ -208,6 +211,7 @@ TEST(RecordingMarker, CrashDuringUpdateFallsBackToBak)
     EXPECT_EQ(res.path, fitPath);
     EXPECT_FALSE(fs.exist("Activity/.recording"));
     EXPECT_FALSE(fs.exist("Activity/.recording.bak"));
+    EXPECT_EQ(fs.openHandles[fitPath], 0u) << "recovered .fit must be closed";
 
     const std::vector<uint8_t> b = bytesOf(fs, fitPath);
     testfit::FitReader r(b);

--- a/Tests/Host/fit/RecordingMarker_test.cpp
+++ b/Tests/Host/fit/RecordingMarker_test.cpp
@@ -159,6 +159,58 @@ TEST(RecordingMarker, RecoverBadOffsetGivesUpWithoutClobber)
     EXPECT_EQ(bytesOf(fs, fitPath), before) << "out-of-range offset must not clobber the .fit";
 }
 
+// A close() that fails AFTER a successful FitWriter::recover() (FatFs f_close:
+// a sync failure keeps the FIL valid and its lock held) must NOT report
+// success or consume the marker: the bytes are durable but the file is
+// unusable this session (and the kernel only registers a .fit on a successful
+// close), so recover() defers to a next-boot retry -- safe because
+// FitWriter::recover() is idempotent on an already-finalized file.
+TEST(RecordingMarker, CloseFailureKeepsMarkerForNextBootRetry)
+{
+    InMemoryFileSystem fs;
+    const char* fitPath = "Activity/202606/activity.fit";
+    const uint32_t dataEnd = seedTornFit(fs, fitPath);
+
+    RecordingMarker m(fs, "Activity");
+    ASSERT_TRUE(m.write(fitPath, dataEnd));
+
+    // Fail exactly the post-recover close: every earlier close on the .fit
+    // happens while it is still torn / CRC-less, so gate on the on-disk bytes
+    // already forming a complete, CRC-valid FIT.
+    fs.closeGate = [&fs, fitPath](const std::string& path) {
+        if (path != fitPath) {
+            return true;   // marker/sibling closes are unaffected
+        }
+        const std::vector<uint8_t> b = bytesOf(fs, path);
+        testfit::FitReader r(b);
+        return !(r.ok() && r.crcValid());
+    };
+
+    const auto res = m.recover();
+    EXPECT_FALSE(res.recovered) << "a failed close must not report success";
+    EXPECT_TRUE(res.path.empty());
+    EXPECT_TRUE(fs.exist("Activity/.recording")) << "marker kept for next-boot retry";
+    EXPECT_EQ(fs.openHandles[fitPath], 1u) << "handle (and its lock) still held";
+
+    // The recovered bytes themselves are already durable and finalized.
+    const std::vector<uint8_t> before = bytesOf(fs, fitPath);
+    {
+        testfit::FitReader r(before);
+        EXPECT_TRUE(r.ok());
+        EXPECT_TRUE(r.crcValid());
+    }
+
+    // "Next boot": closes work again; the idempotent re-finalize succeeds,
+    // the marker set is cleared and the bytes are untouched.
+    fs.closeGate = nullptr;
+    RecordingMarker m2(fs, "Activity");
+    const auto res2 = m2.recover();
+    EXPECT_TRUE(res2.recovered);
+    EXPECT_EQ(res2.path, fitPath);
+    EXPECT_FALSE(fs.exist("Activity/.recording"));
+    EXPECT_EQ(bytesOf(fs, fitPath), before) << "retry is an idempotent no-op on the bytes";
+}
+
 // Fix 1: a crash during update() can leave the primary marker torn (empty).
 // read()/recover() must fall back to the .bak (the previous, slightly older but
 // still record-aligned offset) so the fully-flushed .fit is NOT orphaned/lost.

--- a/Tests/Host/support/KernelTestDoubles.cpp
+++ b/Tests/Host/support/KernelTestDoubles.cpp
@@ -129,6 +129,13 @@ bool InMemoryFileSystem::InMemoryFile::rename(const char* newPath)
     if (!mFs.rename(mPath.c_str(), newPath)) {
         return false;
     }
+    // Keep the open-handle instrumentation keyed by the handle's current path:
+    // without the migration a rename-while-open leaves the old bucket nonzero
+    // forever and the eventual close() would drain the wrong (new) bucket.
+    if (mOpen) {
+        --mFs.openHandles[mPath];
+        ++mFs.openHandles[newPath];
+    }
     mPath = newPath;
     return true;
 }

--- a/Tests/Host/support/KernelTestDoubles.cpp
+++ b/Tests/Host/support/KernelTestDoubles.cpp
@@ -174,6 +174,9 @@ bool InMemoryFileSystem::InMemoryFile::open(bool wMode, bool override)
         }
     }
 
+    if (!mOpen) {
+        ++mFs.openHandles[mPath];
+    }
     mOpen = true;
     mPos = 0;
     return true;
@@ -186,6 +189,9 @@ bool InMemoryFileSystem::InMemoryFile::isOpen() const
 
 bool InMemoryFileSystem::InMemoryFile::close()
 {
+    if (mOpen) {
+        --mFs.openHandles[mPath];
+    }
     mOpen = false;
     return true;
 }

--- a/Tests/Host/support/KernelTestDoubles.cpp
+++ b/Tests/Host/support/KernelTestDoubles.cpp
@@ -189,6 +189,11 @@ bool InMemoryFileSystem::InMemoryFile::isOpen() const
 
 bool InMemoryFileSystem::InMemoryFile::close()
 {
+    // Injected close failure (FatFs f_close semantics: a sync failure keeps
+    // the FIL valid and its lock-table entry held): the handle stays open.
+    if (mOpen && mFs.closeGate && !mFs.closeGate(mPath)) {
+        return false;
+    }
     if (mOpen) {
         --mFs.openHandles[mPath];
     }

--- a/Tests/Host/support/KernelTestDoubles.hpp
+++ b/Tests/Host/support/KernelTestDoubles.hpp
@@ -131,6 +131,11 @@ public:
     // -- Test instrumentation -------------------------------------------------
     /// Number of successful flush() calls, keyed by file path.
     std::unordered_map<std::string, size_t> flushCounts;
+    /// Currently-open handle count, keyed by file path: a successful open()
+    /// increments, close() of an open handle decrements. Destroying a handle
+    /// does NOT decrement (mirrors IFile: destructors do not close), so tests
+    /// can assert no handle -- and thus no FatFs lock slot -- is leaked.
+    std::unordered_map<std::string, size_t> openHandles;
     /// Total bytes written across all files (successful writes only).
     size_t bytesWritten = 0;
     /// Once bytesWritten reaches this threshold, subsequent write() calls fail

--- a/Tests/Host/support/KernelTestDoubles.hpp
+++ b/Tests/Host/support/KernelTestDoubles.hpp
@@ -3,6 +3,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -145,6 +146,11 @@ public:
     /// creating/touching the entry (simulates a storage error scoped to one file
     /// kind, e.g. the auxiliary ".json" summary). Empty = never fail.
     std::string failWriteOpenSuffix;
+    /// Fault hook: when set, consulted before an open handle's close() with the
+    /// file path; returning false makes that close() fail and leaves the handle
+    /// OPEN (FatFs f_close semantics: a sync failure keeps the FIL valid and
+    /// its lock-table entry held). Unset = closes never fail.
+    std::function<bool(const std::string& path)> closeGate;
 };
 
 struct KernelFixture {

--- a/Tests/Host/support/KernelTestDoubles_test.cpp
+++ b/Tests/Host/support/KernelTestDoubles_test.cpp
@@ -1,0 +1,67 @@
+/**
+ ******************************************************************************
+ * @file    KernelTestDoubles_test.cpp
+ * @brief   Tests for the shared host-test doubles' instrumentation, so the
+ *          assertions other suites build on it stay trustworthy.
+ ******************************************************************************
+ */
+
+#include "KernelTestDoubles.hpp"
+
+#include <gtest/gtest.h>
+
+using SDK::TestSupport::InMemoryFileSystem;
+
+// The open-handle instrumentation is keyed by path: an IFile::rename() on an
+// OPEN handle must migrate the count to the new path. Without the migration
+// the old bucket stays nonzero forever (a phantom leak) and the eventual
+// close() drains the new bucket it never incremented.
+TEST(InMemoryFileSystem, RenameWhileOpenMigratesOpenHandleCount)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("dir/a.txt", "payload");
+
+    auto f = fs.file("dir/a.txt");
+    ASSERT_TRUE(f->open(/*wMode=*/false));
+    EXPECT_EQ(fs.openHandles["dir/a.txt"], 1u);
+
+    ASSERT_TRUE(f->rename("dir/b.txt"));
+    EXPECT_EQ(fs.openHandles["dir/a.txt"], 0u) << "old bucket released";
+    EXPECT_EQ(fs.openHandles["dir/b.txt"], 1u) << "count follows the handle";
+
+    EXPECT_TRUE(f->close());
+    EXPECT_EQ(fs.openHandles["dir/b.txt"], 0u) << "no underflow after close";
+}
+
+// A rename of a CLOSED handle must leave the instrumentation untouched.
+TEST(InMemoryFileSystem, RenameWhileClosedLeavesHandleCountsAlone)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("dir/a.txt", "payload");
+
+    auto f = fs.file("dir/a.txt");
+    ASSERT_TRUE(f->rename("dir/b.txt"));
+    EXPECT_EQ(fs.openHandles["dir/a.txt"], 0u);
+    EXPECT_EQ(fs.openHandles["dir/b.txt"], 0u);
+}
+
+// The closeGate fault hook fails an open handle's close() and leaves it open
+// (FatFs f_close semantics: a failed sync keeps the FIL valid and its
+// lock-table entry held); once the gate is lifted, close() drains normally.
+TEST(InMemoryFileSystem, CloseGateFailsCloseAndKeepsHandleOpen)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("dir/a.txt", "payload");
+
+    auto f = fs.file("dir/a.txt");
+    ASSERT_TRUE(f->open(/*wMode=*/false));
+
+    fs.closeGate = [](const std::string&) { return false; };
+    EXPECT_FALSE(f->close());
+    EXPECT_TRUE(f->isOpen()) << "a failed close keeps the handle open";
+    EXPECT_EQ(fs.openHandles["dir/a.txt"], 1u) << "lock still held";
+
+    fs.closeGate = nullptr;
+    EXPECT_TRUE(f->close());
+    EXPECT_EQ(fs.openHandles["dir/a.txt"], 0u);
+}


### PR DESCRIPTION
## What

Fixes the fourth ship-blocker from the 2026-07-18 robustness re-audit (finding S1, HIGH, confirmed twice — full write-up in the kernel repo's `Docs/Robustness-Audit-2026-07.md`, PR in una-kernel: `docs/robustness-audit-2026-07`).

**Bug:** after a successful boot-time crash recovery of an interrupted activity, the recovered `.fit` was left open in write mode until reboot. `FitWriter::finalize()`'s success path ends truncate → flush → return without closing (every failure path closes), `FitWriter::recover()` tail-calls it, and `RecordingMarker::recover()` destroyed its `unique_ptr<IFile>` without closing — no file-wrapper destructor closes. With the kernel's `FF_FS_LOCK 10`, the leaked write-mode open holds an exclusive FatFs lock-table entry that only `f_close` releases: **phone sync and deletion of exactly the rescued workout return `FR_LOCKED` all boot**, and each recovered file permanently consumes one of ten global lock slots.

**Fix:** close the file in `RecordingMarker::recover()` on the success path — the boot-recovery owner of the handle and its only production caller. Closing inside `finalize()` instead would regress the normal save path in all six apps: `ActivityWriter::stop()` flushes after `finish()`, and `flush()` on an already-closed handle returns false, so every successful save would report failure. All `FitWriter::recover()`/`finalize()` failure paths already close, so no double-close and no leak-on-failure. `FitWriter.hpp` now documents the leave-open-on-success contract.

## Verification

- New regression assertions: `InMemoryFileSystem` now tracks per-path open handles (open/close/destructor semantics mirror the real `IFile`), and `RecoverFinalizesTornFit` + `CrashDuringUpdateFallsBackToBak` assert zero leaked handles. With the fix reverted, both fail with `openHandles == 1`.
- Full host suite green (160 tests / 17 suites, MSVC), re-run independently during review.
- Independent adversarial code review: **approved**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FIT recovery to properly close recovered files, preventing subsequent file operations from being blocked.
  * Improved reliability when recovering activities after interrupted updates.

* **Tests**
  * Added coverage to verify recovered files are fully closed.
  * Enhanced test filesystem tracking for open file handles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->