### PR TITLE
fix(sims): track gcc app.mk instead of ignoring it

### DIFF
--- a/Docs/Tutorials/Buttons/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Docs/Tutorials/Buttons/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 /touchgfx/
 
 # GUI generated files

--- a/Docs/Tutorials/Buttons/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Docs/Tutorials/Buttons/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx

--- a/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 
 # GUI generated files
 /generated/*.config

--- a/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx

--- a/Docs/Tutorials/HelloWorld/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Docs/Tutorials/HelloWorld/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 /touchgfx/
 
 # GUI generated files

--- a/Docs/Tutorials/HelloWorld/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Docs/Tutorials/HelloWorld/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx

--- a/Docs/Tutorials/Images/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Docs/Tutorials/Images/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 /touchgfx/
 
 # GUI generated files

--- a/Docs/Tutorials/Images/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Docs/Tutorials/Images/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx

--- a/Docs/Tutorials/ScrollMenu/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Docs/Tutorials/ScrollMenu/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 /touchgfx/
 
 # GUI generated files

--- a/Docs/Tutorials/ScrollMenu/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Docs/Tutorials/ScrollMenu/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx

--- a/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 
 # GUI generated files
 /generated/*.config

--- a/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 
 # GUI generated files
 /generated/*.config

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 
 # GUI generated files
 /generated/*.config

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx

--- a/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 
 # GUI generated files
 /generated/*.config

--- a/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 
 # GUI generated files
 /generated/*.config

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 
 # GUI generated files
 /generated/*.config

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 
 # GUI generated files
 /generated/*.config

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/.gitignore
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/.gitignore
@@ -7,6 +7,10 @@
 /simulator/msvs/.vs/*
 /simulator/msvs/screenshots/*
 /config/gcc/*
+# app.mk is a required, constant build input (repo-relative touchgfx_path,
+# mirrors target.config) — keep it tracked even though Designer regenerates
+# the rest of config/gcc/.
+!/config/gcc/app.mk
 
 # GUI generated files
 /generated/*.config

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/config/gcc/app.mk
@@ -1,0 +1,1 @@
+touchgfx_path := ../../../../../../ThirdParty/touchgfx


### PR DESCRIPTION
Every TouchGFX-GUI project inherits Designer's stock .gitignore, which ignores `config/gcc/` wholesale as regenerated output. This doesn't quite fit as `app.mk` is hard-included by `una/Makefile` and holds only a constant repo-relative `touchgfx_path` (already in `target.config`), so ignoring it breaks clean simulator checkouts while the msvs sibling stays tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated TouchGFX tutorial and example projects to consistently locate the bundled TouchGFX installation.
  * Preserved required build configuration files in version control, preventing them from being excluded by ignore rules.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->