### PR TITLE
fix(files): link FitWriter into the simulator

### DIFF
--- a/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -50,6 +50,8 @@ Libs/Source/Simulator/Kernel/Mock/System.cpp\
 ThirdParty/coreJSON/source/core_json.c\
 Libs/Source/JSON/JsonStreamReader.cpp\
 Libs/Source/JSON/JsonStreamWriter.cpp\
+Libs/Source/Fit/FitCrc.cpp\
+Libs/Source/Fit/FitWriter.cpp\
 ADDITIONAL_SOURCES :=
 ADDITIONAL_INCLUDE_PATHS := $(SDK)/Libs/Header\
 ../../Libs/Header\


### PR DESCRIPTION
ActivityWriter.cpp calls SDK::Fit::FitWriter, but the sim Makefile never compiled FitWriter.cpp/FitCrc.cpp, so the GCC/Linux build failed with undefined FitWriter references. Add both to ADDITIONAL_SOURCES_UNA.