### PR TITLE
fix(treadmill): link the calibration sources into the simulator

### DIFF
--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -41,6 +41,9 @@ ThirdParty/coreJSON/source/core_json.c\
 Libs/Source/JSON/JsonStreamReader.cpp\
 Libs/Source/JSON/JsonStreamWriter.cpp\
 Libs/Source/Calibration/OutdoorStrideCalibrator.cpp\
+Libs/Source/Calibration/StrideLut.cpp\
+Libs/Source/Calibration/CadenceStrideModel.cpp\
+Libs/Source/Calibration/TreadmillSpeedEstimator.cpp\
 Libs/Source/TrackMap/TrackMapBuilder.cpp\
 Libs/Source/Kernel/KernelBuilder.cpp\
 Libs/Source/Timer/Timer.cpp\


### PR DESCRIPTION
Service.cpp and OutdoorStrideCalibrator.cpp use StrideLut, CadenceStrideModel and TreadmillSpeedEstimator, but the sim Makefile never compiled them, so the GCC/Linux build failed with undefined Calibration references. Add the three to ADDITIONAL_SOURCES_UNA.