### PR TITLE
fix(hrmonitor): make the GCC/Linux simulator build

### DIFF
--- a/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -11,7 +11,9 @@
 
 #if defined(SIMULATOR)
     #include "touchgfx/canvas_widget_renderer/CanvasWidgetRenderer.hpp"
-    #include "Windows.h"
+    #ifdef _WIN32
+        #include "Windows.h"
+    #endif
     #include <chrono>
     #include <ctime>
 #endif

--- a/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -77,6 +77,8 @@ Libs/Source/Simulator/Components/SensorDriver.cpp\
 Libs/Source/Fit/FitCrc.cpp\
 Libs/Source/Fit/FitWriter.cpp\
 Libs/Source/Fit/FitRecordCadence.cpp\
+Libs/Source/Fit/RecordingMarker.cpp\
+Libs/Source/Timer/Timer.cpp\
 ../../Libs/Sources/ActivityWriter.cpp\
 ../../Libs/Sources/Service.cpp\
 ADDITIONAL_SOURCES :=


### PR DESCRIPTION
The HRMonitor GCC simulator had never been exercised, so two problems were latent:

- Model.cpp included Windows.h unconditionally inside #if defined(SIMULATOR), assuming the simulator only builds on Windows; it uses no Win32 symbols. Guard it with #ifdef _WIN32 (the Windows build is unchanged).
- The sim Makefile omitted SDK sources the app calls, so linking failed with undefined references to SDK::Fit::RecordingMarker (Fit/RecordingMarker.cpp) and SDK::Timer (Timer/Timer.cpp). Add both to ADDITIONAL_SOURCES_UNA.