### PR TITLE
feat: follow the 12/24-hour clock setting in the example apps

### DIFF
--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/common/TimeFormat.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/common/TimeFormat.hpp
@@ -1,0 +1,34 @@
+#ifndef TIMEFORMAT_HPP
+#define TIMEFORMAT_HPP
+
+#include <cstdint>
+
+/**
+ * @brief Helpers for converting between the stored 24-hour time and the
+ *        12-hour clock shown when the system clock-format setting is 12H.
+ *
+ * Alarms are always stored as a 0-23 hour; only the presentation and the
+ * edit wheels switch to 12-hour.
+ */
+namespace App::TimeFormat {
+
+/** @brief Split a 0-23 hour into a 1-12 hour and an AM/PM flag. */
+inline void split12(uint8_t hour24, uint8_t& hour12, bool& pm)
+{
+    pm     = (hour24 >= 12);
+    hour12 = static_cast<uint8_t>(hour24 % 12);
+    if (hour12 == 0) {
+        hour12 = 12;
+    }
+}
+
+/** @brief Combine a 1-12 hour and an AM/PM flag back into a 0-23 hour. */
+inline uint8_t to24(uint8_t hour12, bool pm)
+{
+    const uint8_t base = static_cast<uint8_t>(hour12 % 12);   // 12 -> 0
+    return static_cast<uint8_t>(base + (pm ? 12 : 0));
+}
+
+} // namespace App::TimeFormat
+
+#endif // TIMEFORMAT_HPP

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/OptionWheelCenterItem.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/OptionWheelCenterItem.hpp
@@ -23,6 +23,12 @@ public:
 
     /** @brief Apply a configuration to this item (called from the screen's update callback). */
     void apply(const OptionWheelConfig& cfg);
+
+protected:
+    // The generated base buffer is only 10 chars, which clips longer labels
+    // (e.g. "Beep & Vibrate"); render into this wider one instead.
+    static const uint16_t kTextSize = 24;
+    touchgfx::Unicode::UnicodeChar mTextBuffer[kTextSize];
 };
 
 #endif // OPTIONWHEELCENTERITEM_HPP

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/OptionWheelConfig.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/OptionWheelConfig.hpp
@@ -2,6 +2,7 @@
 #define OPTIONWHEELCONFIG_HPP
 
 #include <texts/TextKeysAndLanguages.hpp>
+#include <touchgfx/Unicode.hpp>
 
 /**
  * @brief Configuration passed to OptionWheelItem / OptionWheelCenterItem via apply().
@@ -21,6 +22,7 @@ struct OptionWheelConfig
 
     Style       style       = SIMPLE;
     TypedTextId msgId       = TYPED_TEXT_INVALID;  ///< Label text             (SIMPLE)
+    const touchgfx::Unicode::UnicodeChar* rawText = nullptr;  ///< Literal label, overrides msgId (SIMPLE)
     TypedTextId msgIdLeft   = TYPED_TEXT_INVALID;  ///< Left label             (TOGGLE)
     TypedTextId msgIdRight  = TYPED_TEXT_INVALID;  ///< Right label            (TOGGLE)
     bool        toggleState = false;               ///< Current switch state   (TOGGLE)

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/OptionWheelItem.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/OptionWheelItem.hpp
@@ -20,6 +20,12 @@ public:
 
     /** @brief Apply a configuration to this item (called from the screen's update callback). */
     void apply(const OptionWheelConfig& cfg);
+
+protected:
+    // The generated base buffer is only 10 chars, which clips longer labels
+    // (e.g. "Beep & Vibrate"); render into this wider one instead.
+    static const uint16_t kTextSize = 24;
+    touchgfx::Unicode::UnicodeChar mTextBuffer[kTextSize];
 };
 
 #endif // OPTIONWHEELITEM_HPP

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TimeWheel.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TimeWheel.hpp
@@ -27,9 +27,18 @@ public:
 
     virtual void initialize();
 
-    /** @brief Pre-set the wheels to the given time. */
+    /**
+     * @brief Select 12- or 24-hour mode for the hours wheel.
+     *
+     * 12-hour shows 1-12 (wrapping); 24-hour shows 0-23. Call before setTime().
+     * getTime() then returns the displayed hour (1-12 or 0-23); the caller pairs
+     * it with a separate AM/PM choice to recover the stored 0-23 hour.
+     */
+    void setFormat(bool is12Hour);
+
+    /** @brief Pre-set the wheels to the given time (@p h is 0-23). */
     void setTime(uint8_t h, uint8_t m);
-    /** @brief Read the currently selected time. */
+    /** @brief Read the currently selected time (@p h is 1-12 in 12-hour mode). */
     void getTime(uint8_t& h, uint8_t& m);
 
     /** @brief Show the hours wheel and hide the minutes wheel. */
@@ -44,6 +53,7 @@ public:
 
 protected:
     bool mMinutesActive{};  ///< true while the minutes wheel is active
+    bool mIs12Hour{};       ///< true while the hours wheel shows 1-12
 
     virtual void hoursWheelUpdateItem(TimeWheelHoursItem& item, int16_t itemIndex) override;
     virtual void hoursWheelUpdateCenterItem(TimeWheelHoursCenterItem& item, int16_t itemIndex) override;

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/edit_screen/EditView.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/edit_screen/EditView.hpp
@@ -22,23 +22,41 @@ public:
     virtual void setupScreen();
     virtual void tearDownScreen();
 
-    /** @brief Pre-fill all wheels with the given alarm values. */
+    /** @brief Pre-fill all wheels with the given alarm values (@p h is 0-23). */
     void set(uint8_t h, uint8_t m, Alarm::Repeat repeat, Alarm::Effect effect);
 
+    /** @brief Select 12- or 24-hour editing. Call before set(). */
+    void setTimeFormat(bool is12Hour) { mIs12Hour = is12Hour; }
+
 protected:
-    /** @brief Editing step; determines which wheel is visible. */
-    enum Position { HOURS = 0, MINUTES, REPEAT, EFFECT };
+    /**
+     * @brief Editing step; determines which wheel is visible.
+     *
+     * AMPM is only visited in 12-hour mode; in 24-hour mode it is skipped by
+     * the R1/R2 navigation.
+     */
+    enum Position { HOURS = 0, MINUTES, AMPM, REPEAT, EFFECT };
     Position mPosition{};
+
+    /// 12-hour editing (hours wheel shows 1-12 plus a separate AM/PM step).
+    bool mIs12Hour = false;
+
+    /// AM/PM step wheel (hand-added; 12-hour mode only). Shares the (20,55) slot.
+    OptionWheel mAmPmMenu;
 
     touchgfx::Callback<EditView, OptionWheelItem&,       int16_t> mRepeatItemCb;
     touchgfx::Callback<EditView, OptionWheelCenterItem&, int16_t> mRepeatCenterItemCb;
     touchgfx::Callback<EditView, OptionWheelItem&,       int16_t> mEffectItemCb;
     touchgfx::Callback<EditView, OptionWheelCenterItem&, int16_t> mEffectCenterItemCb;
+    touchgfx::Callback<EditView, OptionWheelItem&,       int16_t> mAmPmItemCb;
+    touchgfx::Callback<EditView, OptionWheelCenterItem&, int16_t> mAmPmCenterItemCb;
 
     void updateRepeatItem(OptionWheelItem& item, int16_t index);
     void updateRepeatCenterItem(OptionWheelCenterItem& item, int16_t index);
     void updateEffectItem(OptionWheelItem& item, int16_t index);
     void updateEffectCenterItem(OptionWheelCenterItem& item, int16_t index);
+    void updateAmPmItem(OptionWheelItem& item, int16_t index);
+    void updateAmPmCenterItem(OptionWheelCenterItem& item, int16_t index);
 
     /** @brief Switch the visible wheel and header label to the given @p id. */
     void setPosition(Position id);

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
@@ -26,6 +26,9 @@ public:
     /** @brief Highlight the alarm at @p id without replacing the list. */
     void setSelectedAlarm(size_t id);
 
+    /** @brief Select 12- or 24-hour presentation of the alarm time. */
+    void setTimeFormat(bool is12Hour) { mIs12Hour = is12Hour; }
+
 protected:
     /// Current alarm index. Equals pList->size() when the "New Alarm" slot is selected.
     size_t mAlarmId = 0;
@@ -37,6 +40,21 @@ protected:
 
     /** @brief Rebuild all visible widgets from the current mAlarmId. */
     void show();
+
+    /// 12-hour presentation of the alarm time (from the system clock setting).
+    bool mIs12Hour = false;
+
+    // AM/PM suffix drawn beside the big time in 12-hour mode. The time and the
+    // suffix are centred as one group (a two-digit hour widens the group).
+    touchgfx::TextAreaWithOneWildcard mMeridiem;
+    static const uint16_t MERIDIEM_SIZE = 3;                 // "AM"/"PM" + NUL
+    touchgfx::Unicode::UnicodeChar mMeridiemBuffer[MERIDIEM_SIZE];
+
+    static const int16_t kTimeY       = 82;   // matches the generated timeValue Y
+    static const int16_t kTimeH       = 77;
+    static const int16_t kMeridiemY   = 122;  // SemiBold-60 baseline 60, -20 for 18/20px
+    static const int16_t kMeridiemH   = 30;
+    static const int16_t kMeridiemGap = 5;
 };
 
 #endif // MAINVIEW_HPP

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -55,6 +55,7 @@ public:
     void                stopAlarm();
     void                snoozeAlarm();
     std::vector<Alarm>& getAlarmList();
+    bool                is12HourFormat() const { return mTimeFormat12h; }
     void                setAlarmEditId(size_t id);
     size_t              getAlarmEditId();
     void                saveAlarm(size_t id, Alarm alarm);
@@ -88,6 +89,7 @@ private:
     Alarm              mActiveAlarm  {};
     std::vector<Alarm> mAlarmList;
     size_t             mEditAlarmId  = 0;
+    bool               mTimeFormat12h = false;
 };
 
 #endif // MODEL_HPP

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/ringing_screen/RingingView.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/ringing_screen/RingingView.hpp
@@ -23,7 +23,7 @@ public:
     virtual void setupScreen();
     virtual void tearDownScreen();
 
-    void setTime(uint8_t h, uint8_t );
+    void setTime(uint8_t h, uint8_t m, bool is12Hour);
 
 protected:
     virtual void handleKeyEvent(uint8_t key) override;

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelCenterItem.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelCenterItem.cpp
@@ -2,6 +2,7 @@
 
 OptionWheelCenterItem::OptionWheelCenterItem()
 {
+    mTextBuffer[0] = 0;
 }
 
 void OptionWheelCenterItem::initialize()

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelCenterItem.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelCenterItem.cpp
@@ -13,10 +13,11 @@ void OptionWheelCenterItem::apply(const OptionWheelConfig& cfg)
 {
     switch (cfg.style) {
     case OptionWheelConfig::SIMPLE:
+        text.setWildcard(mTextBuffer);
         if (cfg.rawText != nullptr) {
-            Unicode::snprintf(textBuffer, TEXT_SIZE, "%s", cfg.rawText);
+            Unicode::snprintf(mTextBuffer, kTextSize, "%s", cfg.rawText);
         } else if (cfg.msgId != TYPED_TEXT_INVALID) {
-            Unicode::snprintf(textBuffer, TEXT_SIZE, "%s", touchgfx::TypedText(cfg.msgId).getText());
+            Unicode::snprintf(mTextBuffer, kTextSize, "%s", touchgfx::TypedText(cfg.msgId).getText());
         }
         text.setVisible(true);
         toggle.setVisible(false);

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelCenterItem.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelCenterItem.cpp
@@ -13,7 +13,9 @@ void OptionWheelCenterItem::apply(const OptionWheelConfig& cfg)
 {
     switch (cfg.style) {
     case OptionWheelConfig::SIMPLE:
-        if (cfg.msgId != TYPED_TEXT_INVALID) {
+        if (cfg.rawText != nullptr) {
+            Unicode::snprintf(textBuffer, TEXT_SIZE, "%s", cfg.rawText);
+        } else if (cfg.msgId != TYPED_TEXT_INVALID) {
             Unicode::snprintf(textBuffer, TEXT_SIZE, "%s", touchgfx::TypedText(cfg.msgId).getText());
         }
         text.setVisible(true);

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelItem.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelItem.cpp
@@ -11,7 +11,9 @@ void OptionWheelItem::initialize()
 
 void OptionWheelItem::apply(const OptionWheelConfig& cfg)
 {
-    if (cfg.msgId != TYPED_TEXT_INVALID) {
+    if (cfg.rawText != nullptr) {
+        Unicode::snprintf(textBuffer, TEXT_SIZE, "%s", cfg.rawText);
+    } else if (cfg.msgId != TYPED_TEXT_INVALID) {
         Unicode::snprintf(textBuffer, TEXT_SIZE, "%s", touchgfx::TypedText(cfg.msgId).getText());
     }
     text.invalidate();

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelItem.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelItem.cpp
@@ -11,10 +11,11 @@ void OptionWheelItem::initialize()
 
 void OptionWheelItem::apply(const OptionWheelConfig& cfg)
 {
+    text.setWildcard(mTextBuffer);
     if (cfg.rawText != nullptr) {
-        Unicode::snprintf(textBuffer, TEXT_SIZE, "%s", cfg.rawText);
+        Unicode::snprintf(mTextBuffer, kTextSize, "%s", cfg.rawText);
     } else if (cfg.msgId != TYPED_TEXT_INVALID) {
-        Unicode::snprintf(textBuffer, TEXT_SIZE, "%s", touchgfx::TypedText(cfg.msgId).getText());
+        Unicode::snprintf(mTextBuffer, kTextSize, "%s", touchgfx::TypedText(cfg.msgId).getText());
     }
     text.invalidate();
 }

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelItem.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelItem.cpp
@@ -2,6 +2,7 @@
 
 OptionWheelItem::OptionWheelItem()
 {
+    mTextBuffer[0] = 0;
 }
 
 void OptionWheelItem::initialize()

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/TimeWheel.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/TimeWheel.cpp
@@ -11,11 +11,28 @@ void TimeWheel::initialize()
     TimeWheelBase::initialize();
 }
 
+void TimeWheel::setFormat(bool is12Hour)
+{
+    mIs12Hour = is12Hour;
+    hoursWheel.setNumberOfItems(is12Hour ? 12 : 24);
+    hoursWheel.invalidate();
+}
+
 void TimeWheel::setTime(uint8_t h, uint8_t m)
 {
     if (h < 24 && m < 60) {
-        hoursWheel.animateToItem(h, 0);
-        setHours(h);
+        // In 12-hour mode item index 0..11 maps to displayed hour 1..12.
+        int16_t hourIndex = h;
+        if (mIs12Hour) {
+            uint8_t h12 = h % 12;
+            if (h12 == 0) {
+                h12 = 12;
+            }
+            hourIndex = static_cast<int16_t>(h12 - 1);
+        }
+
+        hoursWheel.animateToItem(hourIndex, 0);
+        setHours(hourIndex);
 
         minutesWheel.animateToItem(m, 0);
         setMinutes(m);
@@ -24,7 +41,8 @@ void TimeWheel::setTime(uint8_t h, uint8_t m)
 
 void TimeWheel::getTime(uint8_t& h, uint8_t& m)
 {
-    h = hoursWheel.getSelectedItem();
+    const int16_t hourIndex = hoursWheel.getSelectedItem();
+    h = static_cast<uint8_t>(mIs12Hour ? hourIndex + 1 : hourIndex);
     m = minutesWheel.getSelectedItem();
 }
 
@@ -100,12 +118,12 @@ void TimeWheel::decValue()
 
 void TimeWheel::hoursWheelUpdateItem(TimeWheelHoursItem& item, int16_t itemIndex)
 {
-    item.setValue(itemIndex);
+    item.setValue(mIs12Hour ? itemIndex + 1 : itemIndex);
 }
 
 void TimeWheel::hoursWheelUpdateCenterItem(TimeWheelHoursCenterItem& item, int16_t itemIndex)
 {
-    item.setValue(itemIndex);
+    item.setValue(mIs12Hour ? itemIndex + 1 : itemIndex);
 }
 
 void TimeWheel::minutesWheelUpdateItem(TimeWheelMinutesItem& item, int16_t itemIndex)
@@ -118,9 +136,11 @@ void TimeWheel::minutesWheelUpdateCenterItem(TimeWheelMinutesCenterItem& item, i
     item.setValue(itemIndex);
 }
 
-void TimeWheel::setHours(int16_t h)
+void TimeWheel::setHours(int16_t index)
 {
-    Unicode::snprintf(hoursInactiveBuffer, HOURSINACTIVE_SIZE, "%02d", h);
+    // The inactive label mirrors the active wheel: display the mapped hour value.
+    const int16_t value = mIs12Hour ? index + 1 : index;
+    Unicode::snprintf(hoursInactiveBuffer, HOURSINACTIVE_SIZE, "%02d", value);
     hoursInactive.invalidate();
 }
 

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/edit_screen/EditPresenter.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/edit_screen/EditPresenter.cpp
@@ -11,6 +11,10 @@ void EditPresenter::activate()
 {
     // Reset idle timer
     model->resetIdleTimer();
+
+    // Must precede set() so the hours wheel and AM/PM step are configured.
+    view.setTimeFormat(model->is12HourFormat());
+
     size_t id = model->getAlarmEditId();
     if (id < model->getAlarmList().size()) {
         const Alarm& alarm = model->getAlarmList()[id];

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/edit_screen/EditView.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/edit_screen/EditView.cpp
@@ -1,11 +1,20 @@
 #include <gui/edit_screen/EditView.hpp>
 #include <gui/common/AlarmLabels.hpp>
+#include <gui/common/TimeFormat.hpp>
+
+// AM/PM labels drawn in the AM/PM wheel and step name (literals avoid adding
+// new TypedTexts; the OptionWheel/messageText fonts already carry the letters).
+static const touchgfx::Unicode::UnicodeChar kAmText[]   = {'A', 'M', 0};
+static const touchgfx::Unicode::UnicodeChar kPmText[]   = {'P', 'M', 0};
+static const touchgfx::Unicode::UnicodeChar kAmPmName[] = {'A', 'M', '/', 'P', 'M', 0};
 
 EditView::EditView() :
     mRepeatItemCb(this,       &EditView::updateRepeatItem),
     mRepeatCenterItemCb(this, &EditView::updateRepeatCenterItem),
     mEffectItemCb(this,       &EditView::updateEffectItem),
-    mEffectCenterItemCb(this, &EditView::updateEffectCenterItem)
+    mEffectCenterItemCb(this, &EditView::updateEffectCenterItem),
+    mAmPmItemCb(this,         &EditView::updateAmPmItem),
+    mAmPmCenterItemCb(this,   &EditView::updateAmPmCenterItem)
 {
 }
 
@@ -29,6 +38,16 @@ void EditView::setupScreen()
     effectMenu.setUpdateCenterItemCallback(mEffectCenterItemCb);
     effectMenu.setNumberOfItems(Alarm::EFFECT_COUNT);
     effectMenu.invalidate();
+
+    // AM/PM wheel: hand-added so it shares the (20,55) slot with the other
+    // wheels without a designer change. Only used in 12-hour mode.
+    mAmPmMenu.initialize();
+    mAmPmMenu.setXY(20, 55);
+    mAmPmMenu.setUpdateItemCallback(mAmPmItemCb);
+    mAmPmMenu.setUpdateCenterItemCallback(mAmPmCenterItemCb);
+    mAmPmMenu.setNumberOfItems(2);   // 0 = AM, 1 = PM
+    mAmPmMenu.setVisible(false);
+    add(mAmPmMenu);
 }
 
 void EditView::tearDownScreen()
@@ -38,7 +57,16 @@ void EditView::tearDownScreen()
 
 void EditView::set(uint8_t h, uint8_t m, Alarm::Repeat repeat, Alarm::Effect effect)
 {
+    timeMenu.setFormat(mIs12Hour);
     timeMenu.setTime(h, m);
+
+    if (mIs12Hour) {
+        uint8_t h12;
+        bool    pm;
+        App::TimeFormat::split12(h, h12, pm);
+        mAmPmMenu.selectItem(pm ? 1 : 0);
+    }
+
     repeatMenu.selectItem(static_cast<int16_t>(repeat));
     effectMenu.selectItem(static_cast<int16_t>(effect));
 }
@@ -71,6 +99,20 @@ void EditView::updateEffectCenterItem(OptionWheelCenterItem& item, int16_t index
     item.apply(cfg);
 }
 
+void EditView::updateAmPmItem(OptionWheelItem& item, int16_t index)
+{
+    OptionWheelConfig cfg;
+    cfg.rawText = (index == 1) ? kPmText : kAmText;
+    item.apply(cfg);
+}
+
+void EditView::updateAmPmCenterItem(OptionWheelCenterItem& item, int16_t index)
+{
+    OptionWheelConfig cfg;
+    cfg.rawText = (index == 1) ? kPmText : kAmText;
+    item.apply(cfg);
+}
+
 void EditView::setPosition(Position id)
 {
     switch (id) {
@@ -81,6 +123,7 @@ void EditView::setPosition(Position id)
         timeMenu.setActiveHours();
         repeatMenu.setVisible(false);
         effectMenu.setVisible(false);
+        mAmPmMenu.setVisible(false);
         tick.setVisible(false);
         break;
     case Position::MINUTES:
@@ -90,6 +133,18 @@ void EditView::setPosition(Position id)
         timeMenu.setActiveMinutes();
         repeatMenu.setVisible(false);
         effectMenu.setVisible(false);
+        mAmPmMenu.setVisible(false);
+        tick.setVisible(false);
+        tick.invalidate();
+        break;
+    case Position::AMPM:
+        title.set(T_TEXT_ALARM_UC);
+        Unicode::snprintf(messageTextBuffer, MESSAGETEXT_SIZE, "%s", kAmPmName);
+        messageText.invalidate();
+        timeMenu.setVisible(false);
+        repeatMenu.setVisible(false);
+        effectMenu.setVisible(false);
+        mAmPmMenu.setVisible(true);
         tick.setVisible(false);
         tick.invalidate();
         break;
@@ -99,6 +154,7 @@ void EditView::setPosition(Position id)
         timeMenu.setVisible(false);
         repeatMenu.setVisible(true);
         effectMenu.setVisible(false);
+        mAmPmMenu.setVisible(false);
         tick.setVisible(false);
         tick.invalidate();
         break;
@@ -107,6 +163,7 @@ void EditView::setPosition(Position id)
         setActiveName(T_TEXT_ALERT);
         timeMenu.setVisible(false);
         repeatMenu.setVisible(false);
+        mAmPmMenu.setVisible(false);
         effectMenu.setVisible(true);
         tick.setVisible(true);
         tick.invalidate();
@@ -119,6 +176,7 @@ void EditView::setPosition(Position id)
     timeMenu.invalidate();
     repeatMenu.invalidate();
     effectMenu.invalidate();
+    mAmPmMenu.invalidate();
     tick.invalidate();
 }
 
@@ -133,6 +191,8 @@ void EditView::handleKeyEvent(uint8_t key)
     if (key == SDK::GUI::Button::L1) {
         if (mPosition == Position::HOURS || mPosition == Position::MINUTES) {
             timeMenu.decValue();
+        } else if (mPosition == Position::AMPM) {
+            mAmPmMenu.selectPrev();
         } else if (mPosition == Position::REPEAT) {
             repeatMenu.selectPrev();
         } else if (mPosition == Position::EFFECT) {
@@ -143,6 +203,8 @@ void EditView::handleKeyEvent(uint8_t key)
     if (key == SDK::GUI::Button::L2) {
         if (mPosition == Position::HOURS || mPosition == Position::MINUTES) {
             timeMenu.incValue();
+        } else if (mPosition == Position::AMPM) {
+            mAmPmMenu.selectNext();
         } else if (mPosition == Position::REPEAT) {
             repeatMenu.selectNext();
         } else if (mPosition == Position::EFFECT) {
@@ -155,6 +217,10 @@ void EditView::handleKeyEvent(uint8_t key)
             uint8_t h = 0;
             uint8_t m = 0;
             timeMenu.getTime(h, m);
+            if (mIs12Hour) {
+                // getTime() gave a 1-12 hour; fold in the AM/PM choice.
+                h = App::TimeFormat::to24(h, mAmPmMenu.getSelectedItem() == 1);
+            }
             presenter->save(h, m,
                 static_cast<Alarm::Repeat>(repeatMenu.getSelectedItem()),
                 static_cast<Alarm::Effect>(effectMenu.getSelectedItem()));
@@ -162,6 +228,10 @@ void EditView::handleKeyEvent(uint8_t key)
         }
         else {
             mPosition = static_cast<Position>(static_cast<uint8_t>(mPosition) + 1);
+            // The AM/PM step only exists in 12-hour mode.
+            if (mPosition == Position::AMPM && !mIs12Hour) {
+                mPosition = Position::REPEAT;
+            }
             setPosition(mPosition);
         }
     }
@@ -172,6 +242,9 @@ void EditView::handleKeyEvent(uint8_t key)
         }
         else {
             mPosition = static_cast<Position>(static_cast<uint8_t>(mPosition) - 1);
+            if (mPosition == Position::AMPM && !mIs12Hour) {
+                mPosition = Position::MINUTES;
+            }
             setPosition(mPosition);
         }
     }

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainPresenter.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainPresenter.cpp
@@ -12,6 +12,7 @@ void MainPresenter::activate()
     // Reset idle timer
     model->resetIdleTimer();
 
+    view.setTimeFormat(model->is12HourFormat());
     view.updateAlarmList(model->getAlarmList());
     view.setSelectedAlarm(model->getAlarmEditId());
 }
@@ -21,8 +22,9 @@ void MainPresenter::deactivate()
 
 }
 
-void MainPresenter::onAlarmListUpdated(const std::vector<Alarm>& list) 
+void MainPresenter::onAlarmListUpdated(const std::vector<Alarm>& list)
 {
+    view.setTimeFormat(model->is12HourFormat());
     view.updateAlarmList(list);
 }
 

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
@@ -202,6 +202,7 @@ void MainView::show()
     alarmValue.invalidate();
     toggle.invalidate();
     timeValue.invalidate();
+    mMeridiem.invalidate();
     repeatText.invalidate();
     repeatValue.invalidate();
 }

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
@@ -1,5 +1,7 @@
 #include <gui/main_screen/MainView.hpp>
 #include <gui/common/AlarmLabels.hpp>
+#include <gui/common/TimeFormat.hpp>
+#include <touchgfx/Color.hpp>
 
 MainView::MainView()
 {
@@ -16,6 +18,17 @@ void MainView::setupScreen()
     buttons.setR2(Buttons::WHITE);
 
     title.set(T_TEXT_ALARM_UC);
+
+    // Draw the time left-aligned so the AM/PM suffix can follow it; show()
+    // re-centres the whole group. (The generated base centres timeValue.)
+    timeValue.setTypedText(touchgfx::TypedText(T_TMP_SEMIBOLD_60_L));
+
+    mMeridiem.setColor(touchgfx::Color::getColorFromRGB(192, 192, 192));
+    mMeridiem.setLinespacing(0);
+    mMeridiem.setTypedText(touchgfx::TypedText(T_TMP_SEMIBOLD_20_L));
+    mMeridiem.setWildcard(mMeridiemBuffer);
+    mMeridiem.setVisible(false);
+    add(mMeridiem);
 }
 
 void MainView::tearDownScreen()
@@ -109,6 +122,7 @@ void MainView::show()
         alarmValue.setVisible(false);
         toggle.setVisible(false);
         timeValue.setVisible(false);
+        mMeridiem.setVisible(false);
         repeatText.setVisible(false);
         repeatValue.setVisible(false);
     }
@@ -127,8 +141,48 @@ void MainView::show()
 
         toggle.setState((*pList)[mAlarmId].on);
 
-        Unicode::snprintf(timeValueBuffer, TIMEVALUE_SIZE, "%02d:%02d",
-            (*pList)[mAlarmId].timeHours, (*pList)[mAlarmId].timeMinutes);
+        const uint8_t h = (*pList)[mAlarmId].timeHours;
+        const uint8_t m = (*pList)[mAlarmId].timeMinutes;
+
+        timeValue.invalidate();   // clear the old glyph rect before the group moves
+        mMeridiem.invalidate();
+
+        if (mIs12Hour) {
+            uint8_t h12;
+            bool    pm;
+            App::TimeFormat::split12(h, h12, pm);
+            Unicode::snprintf(timeValueBuffer, TIMEVALUE_SIZE, "%d:%02d", h12, m);
+
+            mMeridiemBuffer[0] = pm ? 'P' : 'A';
+            mMeridiemBuffer[1] = 'M';
+            mMeridiemBuffer[2] = 0;
+            mMeridiem.setWildcard(mMeridiemBuffer);
+        } else {
+            Unicode::snprintf(timeValueBuffer, TIMEVALUE_SIZE, "%02d:%02d", h, m);
+        }
+        timeValue.setWildcard(timeValueBuffer);
+
+        // Centre the time (+ AM/PM suffix) as one group on the 240px screen.
+        const uint16_t timeW = timeValue.getTextWidth();
+        uint16_t       merW  = 0;
+        uint16_t       groupW = timeW;
+        if (mIs12Hour) {
+            merW   = mMeridiem.getTextWidth();
+            groupW = static_cast<uint16_t>(timeW + kMeridiemGap + merW);
+        }
+        const int16_t groupLeft = static_cast<int16_t>((240 - groupW) / 2);
+
+        timeValue.setPosition(groupLeft, kTimeY, static_cast<int16_t>(timeW + 4), kTimeH);
+        timeValue.invalidate();
+
+        if (mIs12Hour) {
+            mMeridiem.setPosition(static_cast<int16_t>(groupLeft + timeW + kMeridiemGap),
+                                  kMeridiemY, static_cast<int16_t>(merW + 4), kMeridiemH);
+            mMeridiem.setVisible(true);
+            mMeridiem.invalidate();
+        } else {
+            mMeridiem.setVisible(false);
+        }
 
         Unicode::snprintf(repeatValueBuffer, REPEATVALUE_SIZE, "%s",
             touchgfx::TypedText(App::Labels::kRepeatLabels[(*pList)[mAlarmId].repeat]).getText());

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -243,6 +243,7 @@ bool Model::customMessageHandler(SDK::MessageBase* msg)
             LOG_DEBUG("ALARM_LIST\n");
             auto* m = static_cast<CustomMessage::AlarmList*>(msg);
             mAlarmList.assign(m->alarms, m->alarms + m->count);
+            mTimeFormat12h = m->timeFormat12h;
             modelListener->onAlarmListUpdated(mAlarmList);
         } break;
 

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/ringing_screen/RingingPresenter.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/ringing_screen/RingingPresenter.cpp
@@ -11,7 +11,8 @@ void RingingPresenter::activate()
 {
     play();
     
-    view.setTime(model->getActiveAlarm().timeHours, model->getActiveAlarm().timeMinutes);
+    view.setTime(model->getActiveAlarm().timeHours, model->getActiveAlarm().timeMinutes,
+                 model->is12HourFormat());
 }
 
 void RingingPresenter::deactivate()

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/ringing_screen/RingingView.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/ringing_screen/RingingView.cpp
@@ -1,4 +1,6 @@
 #include <gui/ringing_screen/RingingView.hpp>
+#include <gui/common/TimeFormat.hpp>
+#include <texts/TextKeysAndLanguages.hpp>
 
 static constexpr uint16_t kSnoozeTicks = SDK::Utils::secToTicks(120, App::Config::kFrameRate);
 static constexpr uint16_t kPlayTicks = SDK::Utils::secToTicks(5, App::Config::kFrameRate);
@@ -33,9 +35,25 @@ void RingingView::tearDownScreen()
     RingingViewBase::tearDownScreen();
 }
 
-void RingingView::setTime(uint8_t h, uint8_t m)
+void RingingView::setTime(uint8_t h, uint8_t m, bool is12Hour)
 {
-    Unicode::snprintf(timeValueBuffer, TIMEVALUE_SIZE, "%02u:%02u", h, m);
+    if (is12Hour) {
+        // " AM"/" PM" as a Unicode suffix so snprintf's %s can consume it.
+        static const touchgfx::Unicode::UnicodeChar kAm[] = {' ', 'A', 'M', 0};
+        static const touchgfx::Unicode::UnicodeChar kPm[] = {' ', 'P', 'M', 0};
+
+        uint8_t h12;
+        bool    pm;
+        App::TimeFormat::split12(h, h12, pm);
+
+        // Left-align and widen the box so "12:45 PM" fits (the base centres it
+        // in a 75px box sized for "HH:MM").
+        timeValue.setTypedText(touchgfx::TypedText(T_TMP_SEMIBOLD_25_L));
+        timeValue.setPosition(15, 105, 150, 32);
+        Unicode::snprintf(timeValueBuffer, TIMEVALUE_SIZE, "%u:%02u%s", h12, m, pm ? kPm : kAm);
+    } else {
+        Unicode::snprintf(timeValueBuffer, TIMEVALUE_SIZE, "%02u:%02u", h, m);
+    }
     timeValue.invalidate();
 }
 

--- a/Examples/Apps/Alarm/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Alarm/Software/Libs/Header/Commands.hpp
@@ -38,7 +38,7 @@ namespace CustomMessage {
     // Service <-> GUI
     //
     // Fixed-size array avoids heap allocation in the message pool path.
-    // sizeof(AlarmList) = 32 (MessageBase) + kMaxAlarms*sizeof(Alarm) + 1 = 133 bytes
+    // sizeof(AlarmList) = 32 (MessageBase) + kMaxAlarms*sizeof(Alarm) + 2 = 134 bytes
     // -> allocated from Pool 3 (256 bytes), zero dynamic allocations.
     struct AlarmList : public SDK::MessageBase {
         Alarm   alarms[kMaxAlarms];

--- a/Examples/Apps/Alarm/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Alarm/Software/Libs/Header/Commands.hpp
@@ -43,10 +43,12 @@ namespace CustomMessage {
     struct AlarmList : public SDK::MessageBase {
         Alarm   alarms[kMaxAlarms];
         uint8_t count;
+        bool    timeFormat12h;   // Service -> GUI: true = 12-hour clock
         AlarmList()
             : SDK::MessageBase(ALARM_LIST)
             , alarms{}
             , count(0)
+            , timeFormat12h(false)
         {}
     };
 
@@ -107,7 +109,10 @@ public:
     virtual ~Sender() = default;
 
     // Service <-> GUI
-    bool listUpd(const std::vector<Alarm> &list)
+    //
+    // timeFormat12h is only meaningful Service -> GUI; the GUI -> Service
+    // direction leaves it at the default (the Service ignores it there).
+    bool listUpd(const std::vector<Alarm> &list, bool timeFormat12h = false)
     {
         bool status = false;
         auto *msg = mKernel.comm.allocateMessage<CustomMessage::AlarmList>();
@@ -117,6 +122,7 @@ public:
             for (uint8_t i = 0; i < msg->count; ++i) {
                 msg->alarms[i] = list[i];
             }
+            msg->timeFormat12h = timeFormat12h;
             status = mKernel.comm.sendMessage(msg);
             mKernel.comm.releaseMessage(msg);
         }

--- a/Examples/Apps/Alarm/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Alarm/Software/Libs/Header/Service.hpp
@@ -26,11 +26,15 @@ private:
 
     AlarmManager    mAlarmManager;
     Alarm           mActiveAlarm;
+    bool            mTimeFormat12h = false;  // cached system clock-format setting
 
     // -- Lifecycle ------------------------------------------------------------
 
     void onStartGUI();
     void onStopGUI();
+
+    /** @brief Query the kernel for the current 12/24-hour clock setting. */
+    void refreshTimeFormat();
 
     // -- Ringing control ------------------------------------------------------
 

--- a/Examples/Apps/Alarm/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Alarm/Software/Libs/Sources/Service.cpp
@@ -1,6 +1,8 @@
 
 #include "Service.hpp"
 
+#include "SDK/Messages/MessageGuard.hpp"
+
 #include <cstdio>
 
 #define LOG_MODULE_PRX      "Service"
@@ -120,9 +122,21 @@ void Service::run()
     }
 }
 
+void Service::refreshTimeFormat()
+{
+    if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
+        if (msg.send(100) && msg.ok()) {
+            mTimeFormat12h = msg->timeFormat;
+        }
+    }
+}
+
 void Service::onStartGUI()
 {
     mGuiStarted = true;
+
+    // Pick up the current clock-format setting so the list carries it to the GUI.
+    refreshTimeFormat();
 
     // If there is an active alarm, send it to GUI first
     if (mActiveAlarm.on) {
@@ -131,7 +145,7 @@ void Service::onStartGUI()
     }
 
     // Send current alarm list to GUI
-    mGuiSender.listUpd(mAlarmManager.getAlarmList());
+    mGuiSender.listUpd(mAlarmManager.getAlarmList(), mTimeFormat12h);
 }
 
 void Service::onStopGUI()
@@ -256,7 +270,7 @@ void Service::onAlarm(const Alarm& alarm)
 void Service::onListChanged(const std::vector<Alarm>& list)
 {
     if (mGuiStarted) {
-        mGuiSender.listUpd(list);
+        mGuiSender.listUpd(list, mTimeFormat12h);
     }
 }
 

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -19,10 +19,12 @@ public:
 
     /**
      * @brief Display the current time of day.
-     * @param h Hour   (0-23).
-     * @param m Minute (0-59).
+     * @param h        Hour   (0-23).
+     * @param m        Minute (0-59).
+     * @param is12Hour When true, draw a 12-hour clock with an AM/PM suffix;
+     *                 otherwise draw 24-hour time.
      */
-    void setTime(uint8_t h, uint8_t m);
+    void setTime(uint8_t h, uint8_t m, bool is12Hour);
 
     /**
      * @brief Display the battery charge level.
@@ -36,6 +38,29 @@ public:
 
 protected:
     SDK::Gui::SensorStatusRow mSensorRow;
+
+    // AM/PM suffix drawn next to the time in 12-hour format. Added here (rather
+    // than in the generated base) so the layout stays in hand-written code; the
+    // full ASCII wildcard range of every typography means the letters are
+    // already present in the generated fonts, so no asset regeneration is needed.
+    touchgfx::TextAreaWithOneWildcard mMeridiem;
+    static const uint16_t MERIDIEM_SIZE = 3;                 // "AM"/"PM" + NUL
+    touchgfx::Unicode::UnicodeChar mMeridiemBuffer[MERIDIEM_SIZE];
+
+    // Time-of-day geometry (matches the clock-format design). The digits and the
+    // AM/PM suffix are laid out as one group centred on the 240px-wide face, so a
+    // two-digit hour widens the group and pushes the suffix to the right.
+    //
+    // kTimeY centres the 60px digit block vertically between the two dividers
+    // (drawn at y=62 and y=136): the digit glyphs render across [Y+16, Y+60], so
+    // Y=63 lands the block midway in the gap. kMeridiemY puts the 18px AM/PM
+    // suffix on the same baseline as the digits: SemiBold-60 baseline is 60 and
+    // Medium-18 baseline is 18, so the suffix box sits kTimeY + (60 - 18) = +42.
+    static const int16_t  kTimeY       = 63;
+    static const int16_t  kTimeH       = 77;
+    static const int16_t  kMeridiemY   = 105;
+    static const int16_t  kMeridiemH   = 27;
+    static const int16_t  kMeridiemGap = 5;   // digits -> AM/PM spacing (px)
 };
 
 #endif // TRACKFACESTATUS_HPP

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -79,6 +79,7 @@ public:
 
     // Settings
     bool isUnitsImperial() const;
+    bool is12HourFormat() const;
     const uint8_t* getHrThresholds() const;
     uint8_t        getHrThresholdsCount() const;
     const Settings& getSettings() const;
@@ -136,6 +137,7 @@ private:
 
     // Settings (mirrored from Service)
     bool    mUnitsImperial     = false;
+    bool    mTimeFormat12h     = false;
     uint8_t mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t mHrThresholdsCount = App::Config::kHrThresholdsCount;
     Settings mSettings {};

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
@@ -16,6 +16,7 @@ public:
     uint16_t getPositionId();
 
     void setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount);
+    void setTimeFormat(bool is12Hour);
     void setTrackData(const Track::Data& data);
 
     void setTime(uint8_t h, uint8_t m);
@@ -33,6 +34,7 @@ protected:
 
     uint16_t mCurrentFaceId = 0;
     bool     mIsImperial = false;
+    bool     mIs12Hour      = false;
     uint8_t  mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t  mHrThresholdCount = 0;
     uint8_t  mAccessoryState = 0;  // last SDK::Accessory::State (engaged?)

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -1,5 +1,7 @@
 #include <gui/containers/TrackFaceStatus.hpp>
 #include <images/BitmapDatabase.hpp>
+#include <texts/TextKeysAndLanguages.hpp>
+#include <touchgfx/Color.hpp>
 
 TrackFaceStatus::TrackFaceStatus()
 {
@@ -9,6 +11,19 @@ void TrackFaceStatus::initialize()
 {
     TrackFaceStatusBase::initialize();
 
+    // Draw the time left-aligned (the generated base centres it) so the AM/PM
+    // suffix can follow the digits; setTime() re-centres the whole group.
+    dayTimeValue.setTypedText(touchgfx::TypedText(T_TMP_SEMIBOLD_60_L));
+    dayTimeValue.setY(kTimeY);
+
+    // AM/PM suffix, shown only in 12-hour format.
+    mMeridiem.setColor(touchgfx::Color::getColorFromRGB(192, 192, 192));
+    mMeridiem.setLinespacing(0);
+    mMeridiem.setTypedText(touchgfx::TypedText(T_TMP_MEDIUM_18_L));
+    mMeridiem.setWildcard(mMeridiemBuffer);
+    mMeridiem.setVisible(false);
+    add(mMeridiem);
+
     // Sensor-status row (GPS + external HR) above the time of day.
     add(mSensorRow);
     mSensorRow.setPosition(0, 20, 240, 24);
@@ -16,10 +31,51 @@ void TrackFaceStatus::initialize()
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
 }
 
-void TrackFaceStatus::setTime(uint8_t h, uint8_t m)
+void TrackFaceStatus::setTime(uint8_t h, uint8_t m, bool is12Hour)
 {
-    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+    // Invalidate the old glyph rectangles before the text and positions move.
     dayTimeValue.invalidate();
+    mMeridiem.invalidate();
+
+    uint8_t hour = h;
+    bool    pm   = false;
+    if (is12Hour) {
+        pm   = (h >= 12);
+        hour = h % 12;
+        if (hour == 0) {
+            hour = 12;
+        }
+    }
+
+    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", hour, m);
+    dayTimeValue.setWildcard(dayTimeValueBuffer);
+    const uint16_t timeW = dayTimeValue.getTextWidth();
+
+    uint16_t merW   = 0;
+    uint16_t groupW = timeW;
+    if (is12Hour) {
+        mMeridiemBuffer[0] = pm ? 'P' : 'A';
+        mMeridiemBuffer[1] = 'M';
+        mMeridiemBuffer[2] = 0;
+        mMeridiem.setWildcard(mMeridiemBuffer);
+        merW   = mMeridiem.getTextWidth();
+        groupW = static_cast<uint16_t>(timeW + kMeridiemGap + merW);
+    }
+
+    // Centre the digits (+ suffix) as one group on the 240px face.
+    const int16_t groupLeft = static_cast<int16_t>((getWidth() - groupW) / 2);
+
+    dayTimeValue.setPosition(groupLeft, kTimeY, static_cast<int16_t>(timeW + 4), kTimeH);
+    dayTimeValue.invalidate();
+
+    if (is12Hour) {
+        mMeridiem.setPosition(static_cast<int16_t>(groupLeft + timeW + kMeridiemGap),
+                              kMeridiemY, static_cast<int16_t>(merW + 4), kMeridiemH);
+        mMeridiem.setVisible(true);
+        mMeridiem.invalidate();
+    } else {
+        mMeridiem.setVisible(false);
+    }
 }
 
 void TrackFaceStatus::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -115,6 +115,11 @@ bool Model::isUnitsImperial() const
     return mUnitsImperial;
 }
 
+bool Model::is12HourFormat() const
+{
+    return mTimeFormat12h;
+}
+
 const uint8_t* Model::getHrThresholds() const
 {
     return mHrThresholds;
@@ -273,6 +278,7 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             auto* msg          = static_cast<CustomMessage::SettingsUpd*>(message);
             mSettings          = msg->settings;
             mUnitsImperial     = msg->unitsImperial;
+            mTimeFormat12h     = msg->timeFormat12h;
             memcpy(mHrThresholds, msg->hrThresholds, sizeof(mHrThresholds));
             mHrThresholdsCount = msg->hrThresholdsCount;
             modelListener->onSettings(mSettings);

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
@@ -15,6 +15,7 @@ void TrackPresenter::activate()
     view.setPositionId(model->menu().track.get());
 
     view.setConfig(model->isUnitsImperial(), model->getHrThresholds(), model->getHrThresholdsCount());
+    view.setTimeFormat(model->is12HourFormat());
 
     onTrackData(model->getTrackData());
 

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -68,6 +68,11 @@ void TrackView::setConfig(bool isImperial, const uint8_t* thresholds, uint8_t th
     memcpy(mHrThresholds, thresholds, mHrThresholdCount);
 }
 
+void TrackView::setTimeFormat(bool is12Hour)
+{
+    mIs12Hour = is12Hour;
+}
+
 void TrackView::setTrackData(const Track::Data& data)
 {
     auto distConv = [this](float metres) -> float {
@@ -102,7 +107,7 @@ void TrackView::setTrackData(const Track::Data& data)
 
 void TrackView::setTime(uint8_t h, uint8_t m)
 {
-    trackFaceStatus.setTime(h, m);
+    trackFaceStatus.setTime(h, m, mIs12Hour);
 }
 
 void TrackView::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Cycling/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Commands.hpp
@@ -51,12 +51,14 @@ namespace CustomMessage {
 
         // Kernel settings
         bool    unitsImperial;
+        bool    timeFormat12h;   // true = 12-hour clock, false = 24-hour
         uint8_t hrThresholds[kHrThresholdsCount];
         uint8_t hrThresholdsCount;
 
         SettingsUpd()
             : SDK::MessageBase(SETTINGS_UPDATE)
             , unitsImperial(false)
+            , timeFormat12h(false)
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
@@ -176,12 +178,13 @@ public:
     virtual ~Sender() = default;
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, bool timeFormat12h,
                      const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
     {
         if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
             msg->settings          = settings;
             msg->unitsImperial     = units;
+            msg->timeFormat12h     = timeFormat12h;
             memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
             msg->hrThresholdsCount = thresholdCount;
             return msg.send();

--- a/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
@@ -46,6 +46,7 @@ private:
 
     Settings                  mSettings;
     bool                      mIsImperial = false;
+    bool                      mTimeFormat12h = false;
     SettingsSerializer        mSettingsSerializer;
     ActivitySummary           mSummary;
     ActivitySummarySerializer mActivitySummarySerializer;

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -586,6 +586,7 @@ void Service::sendInitialInfoToGui()
     if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
         if (msg.send(100) && msg.ok()) {
             mIsImperial = msg->imperialUnits;
+            mTimeFormat12h = msg->timeFormat;
 
             if (msg->heartRateCount > CustomMessage::kHrThresholdsCount) {
                 msg->heartRateCount = CustomMessage::kHrThresholdsCount;
@@ -610,7 +611,7 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, hrThresholds, hrThresholdsCount);
+    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat12h, hrThresholds, hrThresholdsCount);
     mGuiSender.summary(&mSummary);
     mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
 }

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -19,10 +19,12 @@ public:
 
     /**
      * @brief Display the current time of day.
-     * @param h Hour   (0-23).
-     * @param m Minute (0-59).
+     * @param h        Hour   (0-23).
+     * @param m        Minute (0-59).
+     * @param is12Hour When true, draw a 12-hour clock with an AM/PM suffix;
+     *                 otherwise draw 24-hour time.
      */
-    void setTime(uint8_t h, uint8_t m);
+    void setTime(uint8_t h, uint8_t m, bool is12Hour);
 
     /**
      * @brief Display the battery charge level.
@@ -36,6 +38,29 @@ public:
 
 protected:
     SDK::Gui::SensorStatusRow mSensorRow;
+
+    // AM/PM suffix drawn next to the time in 12-hour format. Added here (rather
+    // than in the generated base) so the layout stays in hand-written code; the
+    // full ASCII wildcard range of every typography means the letters are
+    // already present in the generated fonts, so no asset regeneration is needed.
+    touchgfx::TextAreaWithOneWildcard mMeridiem;
+    static const uint16_t MERIDIEM_SIZE = 3;                 // "AM"/"PM" + NUL
+    touchgfx::Unicode::UnicodeChar mMeridiemBuffer[MERIDIEM_SIZE];
+
+    // Time-of-day geometry (matches the clock-format design). The digits and the
+    // AM/PM suffix are laid out as one group centred on the 240px-wide face, so a
+    // two-digit hour widens the group and pushes the suffix to the right.
+    //
+    // kTimeY centres the 60px digit block vertically between the two dividers
+    // (drawn at y=62 and y=136): the digit glyphs render across [Y+16, Y+60], so
+    // Y=63 lands the block midway in the gap. kMeridiemY puts the 18px AM/PM
+    // suffix on the same baseline as the digits: SemiBold-60 baseline is 60 and
+    // Medium-18 baseline is 18, so the suffix box sits kTimeY + (60 - 18) = +42.
+    static const int16_t  kTimeY       = 63;
+    static const int16_t  kTimeH       = 77;
+    static const int16_t  kMeridiemY   = 105;
+    static const int16_t  kMeridiemH   = 27;
+    static const int16_t  kMeridiemGap = 5;   // digits -> AM/PM spacing (px)
 };
 
 #endif // TRACKFACESTATUS_HPP

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -78,6 +78,7 @@ public:
 
     // Settings
     bool isUnitsImperial() const;
+    bool is12HourFormat() const;
     const uint8_t* getHrThresholds() const;
     uint8_t        getHrThresholdsCount() const;
     const Settings& getSettings() const;
@@ -136,6 +137,7 @@ private:
 
     // Settings (mirrored from Service)
     bool    mUnitsImperial     = false;
+    bool mTimeFormat12h = false;
     uint8_t mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t mHrThresholdsCount = App::Config::kHrThresholdsCount;
     Settings mSettings {};

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
@@ -16,6 +16,7 @@ public:
     uint16_t getPositionId();
 
     void setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount);
+    void setTimeFormat(bool is12Hour);
     void setTrackData(const Track::Data& data);
 
     void setTime(uint8_t h, uint8_t m);
@@ -33,6 +34,7 @@ protected:
 
     uint16_t mCurrentFaceId = 0;
     bool     mIsImperial = false;
+    bool     mIs12Hour      = false;
     uint8_t  mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t  mHrThresholdCount = 0;
     uint8_t  mAccessoryState = 0;  // last SDK::Accessory::State (engaged?)

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -1,5 +1,7 @@
 #include <gui/containers/TrackFaceStatus.hpp>
 #include <images/BitmapDatabase.hpp>
+#include <texts/TextKeysAndLanguages.hpp>
+#include <touchgfx/Color.hpp>
 
 TrackFaceStatus::TrackFaceStatus()
 {}
@@ -8,6 +10,19 @@ void TrackFaceStatus::initialize()
 {
     TrackFaceStatusBase::initialize();
 
+    // Draw the time left-aligned (the generated base centres it) so the AM/PM
+    // suffix can follow the digits; setTime() re-centres the whole group.
+    dayTimeValue.setTypedText(touchgfx::TypedText(T_TMP_SEMIBOLD_60_L));
+    dayTimeValue.setY(kTimeY);
+
+    // AM/PM suffix, shown only in 12-hour format.
+    mMeridiem.setColor(touchgfx::Color::getColorFromRGB(192, 192, 192));
+    mMeridiem.setLinespacing(0);
+    mMeridiem.setTypedText(touchgfx::TypedText(T_TMP_MEDIUM_18_L));
+    mMeridiem.setWildcard(mMeridiemBuffer);
+    mMeridiem.setVisible(false);
+    add(mMeridiem);
+
     // Sensor-status row (GPS + external HR) above the time of day.
     add(mSensorRow);
     mSensorRow.setPosition(0, 20, 240, 24);
@@ -15,10 +30,51 @@ void TrackFaceStatus::initialize()
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
 }
 
-void TrackFaceStatus::setTime(uint8_t h, uint8_t m)
+void TrackFaceStatus::setTime(uint8_t h, uint8_t m, bool is12Hour)
 {
-    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+    // Invalidate the old glyph rectangles before the text and positions move.
     dayTimeValue.invalidate();
+    mMeridiem.invalidate();
+
+    uint8_t hour = h;
+    bool    pm   = false;
+    if (is12Hour) {
+        pm   = (h >= 12);
+        hour = h % 12;
+        if (hour == 0) {
+            hour = 12;
+        }
+    }
+
+    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", hour, m);
+    dayTimeValue.setWildcard(dayTimeValueBuffer);
+    const uint16_t timeW = dayTimeValue.getTextWidth();
+
+    uint16_t merW   = 0;
+    uint16_t groupW = timeW;
+    if (is12Hour) {
+        mMeridiemBuffer[0] = pm ? 'P' : 'A';
+        mMeridiemBuffer[1] = 'M';
+        mMeridiemBuffer[2] = 0;
+        mMeridiem.setWildcard(mMeridiemBuffer);
+        merW   = mMeridiem.getTextWidth();
+        groupW = static_cast<uint16_t>(timeW + kMeridiemGap + merW);
+    }
+
+    // Centre the digits (+ suffix) as one group on the 240px face.
+    const int16_t groupLeft = static_cast<int16_t>((getWidth() - groupW) / 2);
+
+    dayTimeValue.setPosition(groupLeft, kTimeY, static_cast<int16_t>(timeW + 4), kTimeH);
+    dayTimeValue.invalidate();
+
+    if (is12Hour) {
+        mMeridiem.setPosition(static_cast<int16_t>(groupLeft + timeW + kMeridiemGap),
+                              kMeridiemY, static_cast<int16_t>(merW + 4), kMeridiemH);
+        mMeridiem.setVisible(true);
+        mMeridiem.invalidate();
+    } else {
+        mMeridiem.setVisible(false);
+    }
 }
 
 void TrackFaceStatus::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -115,6 +115,11 @@ bool Model::isUnitsImperial() const
     return mUnitsImperial;
 }
 
+bool Model::is12HourFormat() const
+{
+    return mTimeFormat12h;
+}
+
 const uint8_t* Model::getHrThresholds() const
 {
     return mHrThresholds;
@@ -273,6 +278,7 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             auto* msg          = static_cast<CustomMessage::SettingsUpd*>(message);
             mSettings          = msg->settings;
             mUnitsImperial     = msg->unitsImperial;
+            mTimeFormat12h     = msg->timeFormat12h;
             memcpy(mHrThresholds, msg->hrThresholds, sizeof(mHrThresholds));
             mHrThresholdsCount = msg->hrThresholdsCount;
             modelListener->onSettings(mSettings);

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
@@ -15,6 +15,7 @@ void TrackPresenter::activate()
     view.setPositionId(model->menu().track.get());
 
     view.setConfig(model->isUnitsImperial(), model->getHrThresholds(), model->getHrThresholdsCount());
+    view.setTimeFormat(model->is12HourFormat());
 
     onTrackData(model->getTrackData());
 

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -68,6 +68,11 @@ void TrackView::setConfig(bool isImperial, const uint8_t* thresholds, uint8_t th
     memcpy(mHrThresholds, thresholds, mHrThresholdCount);
 }
 
+void TrackView::setTimeFormat(bool is12Hour)
+{
+    mIs12Hour = is12Hour;
+}
+
 void TrackView::setTrackData(const Track::Data& data)
 {
     auto paceConv = [this](float secPerM) -> float {
@@ -104,7 +109,7 @@ void TrackView::setTrackData(const Track::Data& data)
 
 void TrackView::setTime(uint8_t h, uint8_t m)
 {
-    trackFaceStatus.setTime(h, m);
+    trackFaceStatus.setTime(h, m, mIs12Hour);
 }
 
 void TrackView::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Hiking/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Commands.hpp
@@ -51,12 +51,14 @@ namespace CustomMessage {
 
         // Kernel settings
         bool    unitsImperial;
+        bool    timeFormat12h;   // true = 12-hour clock, false = 24-hour
         uint8_t hrThresholds[kHrThresholdsCount];
         uint8_t hrThresholdsCount;
 
         SettingsUpd()
             : SDK::MessageBase(SETTINGS_UPDATE)
             , unitsImperial(false)
+            , timeFormat12h(false)
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
@@ -176,12 +178,13 @@ public:
     virtual ~Sender() = default;
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, bool timeFormat12h,
                      const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
     {
         if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
             msg->settings          = settings;
             msg->unitsImperial     = units;
+            msg->timeFormat12h     = timeFormat12h;
             memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
             msg->hrThresholdsCount = thresholdCount;
             return msg.send();

--- a/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
@@ -47,6 +47,7 @@ private:
 
     Settings                  mSettings;
     bool                      mIsImperial = false;
+    bool                      mTimeFormat12h = false;
     SettingsSerializer        mSettingsSerializer;
     ActivitySummary           mSummary;
     ActivitySummarySerializer mActivitySummarySerializer;

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -609,6 +609,7 @@ void Service::sendInitialInfoToGui()
     if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
         if (msg.send(100) && msg.ok()) {
             mIsImperial = msg->imperialUnits;
+            mTimeFormat12h = msg->timeFormat;
 
             if (msg->heartRateCount > CustomMessage::kHrThresholdsCount) {
                 msg->heartRateCount = CustomMessage::kHrThresholdsCount;
@@ -633,7 +634,7 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, hrThresholds, hrThresholdsCount);
+    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat12h, hrThresholds, hrThresholdsCount);
     mGuiSender.summary(&mSummary);
     mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
 }

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -19,10 +19,12 @@ public:
 
     /**
      * @brief Display the current time of day.
-     * @param h Hour   (0-23).
-     * @param m Minute (0-59).
+     * @param h        Hour   (0-23).
+     * @param m        Minute (0-59).
+     * @param is12Hour When true, draw a 12-hour clock with an AM/PM suffix;
+     *                 otherwise draw 24-hour time.
      */
-    void setTime(uint8_t h, uint8_t m);
+    void setTime(uint8_t h, uint8_t m, bool is12Hour);
 
     /**
      * @brief Display the battery charge level.
@@ -36,6 +38,29 @@ public:
 
 protected:
     SDK::Gui::SensorStatusRow mSensorRow;
+
+    // AM/PM suffix drawn next to the time in 12-hour format. Added here (rather
+    // than in the generated base) so the layout stays in hand-written code; the
+    // full ASCII wildcard range of every typography means the letters are
+    // already present in the generated fonts, so no asset regeneration is needed.
+    touchgfx::TextAreaWithOneWildcard mMeridiem;
+    static const uint16_t MERIDIEM_SIZE = 3;                 // "AM"/"PM" + NUL
+    touchgfx::Unicode::UnicodeChar mMeridiemBuffer[MERIDIEM_SIZE];
+
+    // Time-of-day geometry (matches the clock-format design). The digits and the
+    // AM/PM suffix are laid out as one group centred on the 240px-wide face, so a
+    // two-digit hour widens the group and pushes the suffix to the right.
+    //
+    // kTimeY centres the 60px digit block vertically between the two dividers
+    // (drawn at y=62 and y=136): the digit glyphs render across [Y+16, Y+60], so
+    // Y=63 lands the block midway in the gap. kMeridiemY puts the 18px AM/PM
+    // suffix on the same baseline as the digits: SemiBold-60 baseline is 60 and
+    // Medium-18 baseline is 18, so the suffix box sits kTimeY + (60 - 18) = +42.
+    static const int16_t  kTimeY       = 63;
+    static const int16_t  kTimeH       = 77;
+    static const int16_t  kMeridiemY   = 105;
+    static const int16_t  kMeridiemH   = 27;
+    static const int16_t  kMeridiemGap = 5;   // digits -> AM/PM spacing (px)
 };
 
 #endif // TRACKFACESTATUS_HPP

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -78,6 +78,7 @@ public:
 
     // Settings
     bool isUnitsImperial() const;
+    bool is12HourFormat() const;
     const uint8_t* getHrThresholds() const;
     uint8_t        getHrThresholdsCount() const;
     const Settings& getSettings() const;
@@ -140,6 +141,7 @@ private:
 
     // Settings (mirrored from Service)
     bool mUnitsImperial = false;
+    bool mTimeFormat12h = false;
     uint8_t mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t mHrThresholdsCount = App::Config::kHrThresholdsCount;
     Settings mSettings {};

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
@@ -17,6 +17,7 @@ public:
     uint16_t getPositionId();
 
     void setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount);
+    void setTimeFormat(bool is12Hour);
     void setTrackData(const Track::Data& data);
 
     void setTime(uint8_t h, uint8_t m);
@@ -35,6 +36,7 @@ protected:
     bool     mIntervalsMode = false;
     uint16_t mCurrentFaceId = 0;
     bool     mIsImperial    = false;
+    bool     mIs12Hour      = false;
     uint8_t  mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t  mHrThresholdCount = 0;
     uint8_t  mAccessoryState = 0;  // last SDK::Accessory::State (engaged?)

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -1,5 +1,7 @@
 #include <gui/containers/TrackFaceStatus.hpp>
 #include <images/BitmapDatabase.hpp>
+#include <texts/TextKeysAndLanguages.hpp>
+#include <touchgfx/Color.hpp>
 
 TrackFaceStatus::TrackFaceStatus()
 {
@@ -9,6 +11,19 @@ void TrackFaceStatus::initialize()
 {
     TrackFaceStatusBase::initialize();
 
+    // Draw the time left-aligned (the generated base centres it) so the AM/PM
+    // suffix can follow the digits; setTime() re-centres the whole group.
+    dayTimeValue.setTypedText(touchgfx::TypedText(T_TMP_SEMIBOLD_60_L));
+    dayTimeValue.setY(kTimeY);
+
+    // AM/PM suffix, shown only in 12-hour format.
+    mMeridiem.setColor(touchgfx::Color::getColorFromRGB(192, 192, 192));
+    mMeridiem.setLinespacing(0);
+    mMeridiem.setTypedText(touchgfx::TypedText(T_TMP_MEDIUM_18_L));
+    mMeridiem.setWildcard(mMeridiemBuffer);
+    mMeridiem.setVisible(false);
+    add(mMeridiem);
+
     // Sensor-status row (GPS + external HR) above the time of day.
     add(mSensorRow);
     mSensorRow.setPosition(0, 20, 240, 24);
@@ -16,10 +31,51 @@ void TrackFaceStatus::initialize()
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
 }
 
-void TrackFaceStatus::setTime(uint8_t h, uint8_t m)
+void TrackFaceStatus::setTime(uint8_t h, uint8_t m, bool is12Hour)
 {
-    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+    // Invalidate the old glyph rectangles before the text and positions move.
     dayTimeValue.invalidate();
+    mMeridiem.invalidate();
+
+    uint8_t hour = h;
+    bool    pm   = false;
+    if (is12Hour) {
+        pm   = (h >= 12);
+        hour = h % 12;
+        if (hour == 0) {
+            hour = 12;
+        }
+    }
+
+    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", hour, m);
+    dayTimeValue.setWildcard(dayTimeValueBuffer);
+    const uint16_t timeW = dayTimeValue.getTextWidth();
+
+    uint16_t merW   = 0;
+    uint16_t groupW = timeW;
+    if (is12Hour) {
+        mMeridiemBuffer[0] = pm ? 'P' : 'A';
+        mMeridiemBuffer[1] = 'M';
+        mMeridiemBuffer[2] = 0;
+        mMeridiem.setWildcard(mMeridiemBuffer);
+        merW   = mMeridiem.getTextWidth();
+        groupW = static_cast<uint16_t>(timeW + kMeridiemGap + merW);
+    }
+
+    // Centre the digits (+ suffix) as one group on the 240px face.
+    const int16_t groupLeft = static_cast<int16_t>((getWidth() - groupW) / 2);
+
+    dayTimeValue.setPosition(groupLeft, kTimeY, static_cast<int16_t>(timeW + 4), kTimeH);
+    dayTimeValue.invalidate();
+
+    if (is12Hour) {
+        mMeridiem.setPosition(static_cast<int16_t>(groupLeft + timeW + kMeridiemGap),
+                              kMeridiemY, static_cast<int16_t>(merW + 4), kMeridiemH);
+        mMeridiem.setVisible(true);
+        mMeridiem.invalidate();
+    } else {
+        mMeridiem.setVisible(false);
+    }
 }
 
 void TrackFaceStatus::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -114,6 +114,11 @@ bool Model::isUnitsImperial() const
     return mUnitsImperial;
 }
 
+bool Model::is12HourFormat() const
+{
+    return mTimeFormat12h;
+}
+
 const uint8_t* Model::getHrThresholds() const
 {
     return mHrThresholds;
@@ -345,6 +350,7 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             auto* msg          = static_cast<CustomMessage::SettingsUpd*>(message);
             mSettings          = msg->settings;
             mUnitsImperial     = msg->unitsImperial;
+            mTimeFormat12h     = msg->timeFormat12h;
             memcpy(mHrThresholds, msg->hrThresholds, sizeof(mHrThresholds));
             mHrThresholdsCount = msg->hrThresholdsCount;
             modelListener->onSettings(mSettings);

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
@@ -32,6 +32,7 @@ void TrackPresenter::activate()
     view.setPositionId(faceId);
 
     view.setConfig(model->isUnitsImperial(), model->getHrThresholds(), model->getHrThresholdsCount());
+    view.setTimeFormat(model->is12HourFormat());
 
     onTrackData(model->getTrackData());
 

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -81,6 +81,11 @@ void TrackView::setConfig(bool isImperial, const uint8_t* thresholds, uint8_t th
     memcpy(mHrThresholds, thresholds, mHrThresholdCount);
 }
 
+void TrackView::setTimeFormat(bool is12Hour)
+{
+    mIs12Hour = is12Hour;
+}
+
 void TrackView::setTrackData(const Track::Data& data)
 {
     auto paceConv = [this](float secPerM) -> float {
@@ -124,7 +129,7 @@ void TrackView::setTrackData(const Track::Data& data)
 
 void TrackView::setTime(uint8_t h, uint8_t m)
 {
-    trackFaceStatus.setTime(h, m);
+    trackFaceStatus.setTime(h, m, mIs12Hour);
 }
 
 void TrackView::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Running/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Commands.hpp
@@ -54,12 +54,14 @@ namespace CustomMessage {
 
         // Kernel settings
         bool    unitsImperial;
+        bool    timeFormat12h;   // true = 12-hour clock, false = 24-hour
         uint8_t hrThresholds[kHrThresholdsCount];
         uint8_t hrThresholdsCount;
 
         SettingsUpd()
             : SDK::MessageBase(SETTINGS_UPDATE)
             , unitsImperial(false)
+            , timeFormat12h(false)
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
@@ -193,12 +195,13 @@ public:
     virtual ~Sender() = default;
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, bool timeFormat12h,
                      const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
     {
         if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
             msg->settings          = settings;
             msg->unitsImperial     = units;
+            msg->timeFormat12h     = timeFormat12h;
             memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
             msg->hrThresholdsCount = thresholdCount;
             return msg.send();

--- a/Examples/Apps/Running/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Service.hpp
@@ -54,6 +54,7 @@ private:
 
     Settings                  mSettings;
     bool                      mIsImperial = false;
+    bool                      mTimeFormat12h = false;
     SettingsSerializer        mSettingsSerializer;
     ActivitySummary           mSummary;
     ActivitySummarySerializer mActivitySummarySerializer;

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -693,6 +693,7 @@ void Service::sendInitialInfoToGui()
     if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
         if (msg.send(100) && msg.ok()) {
             mIsImperial = msg->imperialUnits;
+            mTimeFormat12h = msg->timeFormat;
 
             if (msg->heartRateCount > CustomMessage::kHrThresholdsCount) {
                 msg->heartRateCount = CustomMessage::kHrThresholdsCount;
@@ -717,7 +718,7 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, hrThresholds, CustomMessage::kHrThresholdsCount);
+    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat12h, hrThresholds, CustomMessage::kHrThresholdsCount);
     mGuiSender.summary(&mSummary);
     mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
 }

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -19,10 +19,12 @@ public:
 
     /**
      * @brief Display the current time of day.
-     * @param h Hour   (0-23).
-     * @param m Minute (0-59).
+     * @param h        Hour   (0-23).
+     * @param m        Minute (0-59).
+     * @param is12Hour When true, draw a 12-hour clock with an AM/PM suffix;
+     *                 otherwise draw 24-hour time.
      */
-    void setTime(uint8_t h, uint8_t m);
+    void setTime(uint8_t h, uint8_t m, bool is12Hour);
 
     /**
      * @brief Display the battery charge level.
@@ -36,6 +38,29 @@ public:
 
 protected:
     SDK::Gui::SensorStatusRow mSensorRow;
+
+    // AM/PM suffix drawn next to the time in 12-hour format. Added here (rather
+    // than in the generated base) so the layout stays in hand-written code; the
+    // full ASCII wildcard range of every typography means the letters are
+    // already present in the generated fonts, so no asset regeneration is needed.
+    touchgfx::TextAreaWithOneWildcard mMeridiem;
+    static const uint16_t MERIDIEM_SIZE = 3;                 // "AM"/"PM" + NUL
+    touchgfx::Unicode::UnicodeChar mMeridiemBuffer[MERIDIEM_SIZE];
+
+    // Time-of-day geometry (matches the clock-format design). The digits and the
+    // AM/PM suffix are laid out as one group centred on the 240px-wide face, so a
+    // two-digit hour widens the group and pushes the suffix to the right.
+    //
+    // kTimeY centres the 60px digit block vertically between the two dividers
+    // (drawn at y=62 and y=136): the digit glyphs render across [Y+16, Y+60], so
+    // Y=63 lands the block midway in the gap. kMeridiemY puts the 18px AM/PM
+    // suffix on the same baseline as the digits: SemiBold-60 baseline is 60 and
+    // Medium-18 baseline is 18, so the suffix box sits kTimeY + (60 - 18) = +42.
+    static const int16_t  kTimeY       = 63;
+    static const int16_t  kTimeH       = 77;
+    static const int16_t  kMeridiemY   = 105;
+    static const int16_t  kMeridiemH   = 27;
+    static const int16_t  kMeridiemGap = 5;   // digits -> AM/PM spacing (px)
 };
 
 #endif // TRACKFACESTATUS_HPP

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -89,6 +89,7 @@ public:
 
     // Settings
     bool isUnitsImperial() const;
+    bool is12HourFormat() const;
     const uint8_t* getHrThresholds() const;
     uint8_t        getHrThresholdsCount() const;
     const Settings& getSettings() const;
@@ -175,6 +176,7 @@ private:
 
     // Settings (mirrored from Service)
     bool mUnitsImperial = false;
+    bool mTimeFormat12h = false;
     uint8_t mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t mHrThresholdsCount = App::Config::kHrThresholdsCount;
     Settings mSettings {};

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
@@ -17,6 +17,7 @@ public:
     uint16_t getPositionId();
 
     void setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount);
+    void setTimeFormat(bool is12Hour);
     void setTrackData(const Track::Data& data);
 
     void setTime(uint8_t h, uint8_t m);
@@ -34,6 +35,7 @@ protected:
     bool     mIntervalsMode = false;
     uint16_t mCurrentFaceId = 0;
     bool     mIsImperial    = false;
+    bool     mIs12Hour      = false;
     uint8_t  mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t  mHrThresholdCount = 0;
     uint8_t  mAccessoryState = 0;  // last SDK::Accessory::State (engaged?)

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -1,5 +1,7 @@
 #include <gui/containers/TrackFaceStatus.hpp>
 #include <images/BitmapDatabase.hpp>
+#include <texts/TextKeysAndLanguages.hpp>
+#include <touchgfx/Color.hpp>
 
 TrackFaceStatus::TrackFaceStatus()
 {
@@ -9,6 +11,19 @@ void TrackFaceStatus::initialize()
 {
     TrackFaceStatusBase::initialize();
 
+    // Draw the time left-aligned (the generated base centres it) so the AM/PM
+    // suffix can follow the digits; setTime() re-centres the whole group.
+    dayTimeValue.setTypedText(touchgfx::TypedText(T_TMP_SEMIBOLD_60_L));
+    dayTimeValue.setY(kTimeY);
+
+    // AM/PM suffix, shown only in 12-hour format.
+    mMeridiem.setColor(touchgfx::Color::getColorFromRGB(192, 192, 192));
+    mMeridiem.setLinespacing(0);
+    mMeridiem.setTypedText(touchgfx::TypedText(T_TMP_MEDIUM_18_L));
+    mMeridiem.setWildcard(mMeridiemBuffer);
+    mMeridiem.setVisible(false);
+    add(mMeridiem);
+
     // Sensor-status row (external HR only — Treadmill has no GPS) above the time of day.
     add(mSensorRow);
     mSensorRow.setPosition(0, 20, 240, 24);
@@ -16,10 +31,51 @@ void TrackFaceStatus::initialize()
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
 }
 
-void TrackFaceStatus::setTime(uint8_t h, uint8_t m)
+void TrackFaceStatus::setTime(uint8_t h, uint8_t m, bool is12Hour)
 {
-    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+    // Invalidate the old glyph rectangles before the text and positions move.
     dayTimeValue.invalidate();
+    mMeridiem.invalidate();
+
+    uint8_t hour = h;
+    bool    pm   = false;
+    if (is12Hour) {
+        pm   = (h >= 12);
+        hour = h % 12;
+        if (hour == 0) {
+            hour = 12;
+        }
+    }
+
+    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", hour, m);
+    dayTimeValue.setWildcard(dayTimeValueBuffer);
+    const uint16_t timeW = dayTimeValue.getTextWidth();
+
+    uint16_t merW   = 0;
+    uint16_t groupW = timeW;
+    if (is12Hour) {
+        mMeridiemBuffer[0] = pm ? 'P' : 'A';
+        mMeridiemBuffer[1] = 'M';
+        mMeridiemBuffer[2] = 0;
+        mMeridiem.setWildcard(mMeridiemBuffer);
+        merW   = mMeridiem.getTextWidth();
+        groupW = static_cast<uint16_t>(timeW + kMeridiemGap + merW);
+    }
+
+    // Centre the digits (+ suffix) as one group on the 240px face.
+    const int16_t groupLeft = static_cast<int16_t>((getWidth() - groupW) / 2);
+
+    dayTimeValue.setPosition(groupLeft, kTimeY, static_cast<int16_t>(timeW + 4), kTimeH);
+    dayTimeValue.invalidate();
+
+    if (is12Hour) {
+        mMeridiem.setPosition(static_cast<int16_t>(groupLeft + timeW + kMeridiemGap),
+                              kMeridiemY, static_cast<int16_t>(merW + 4), kMeridiemH);
+        mMeridiem.setVisible(true);
+        mMeridiem.invalidate();
+    } else {
+        mMeridiem.setVisible(false);
+    }
 }
 
 void TrackFaceStatus::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -119,6 +119,11 @@ bool Model::isUnitsImperial() const
     return mUnitsImperial;
 }
 
+bool Model::is12HourFormat() const
+{
+    return mTimeFormat12h;
+}
+
 const uint8_t* Model::getHrThresholds() const
 {
     return mHrThresholds;
@@ -356,6 +361,7 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             auto* msg          = static_cast<CustomMessage::SettingsUpd*>(message);
             mSettings          = msg->settings;
             mUnitsImperial     = msg->unitsImperial;
+            mTimeFormat12h     = msg->timeFormat12h;
             memcpy(mHrThresholds, msg->hrThresholds, sizeof(mHrThresholds));
             mHrThresholdsCount = msg->hrThresholdsCount;
             modelListener->onSettings(mSettings);

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
@@ -32,6 +32,7 @@ void TrackPresenter::activate()
     view.setPositionId(faceId);
 
     view.setConfig(model->isUnitsImperial(), model->getHrThresholds(), model->getHrThresholdsCount());
+    view.setTimeFormat(model->is12HourFormat());
 
     onTrackData(model->getTrackData());
 

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -81,6 +81,11 @@ void TrackView::setConfig(bool isImperial, const uint8_t* thresholds, uint8_t th
     memcpy(mHrThresholds, thresholds, mHrThresholdCount);
 }
 
+void TrackView::setTimeFormat(bool is12Hour)
+{
+    mIs12Hour = is12Hour;
+}
+
 void TrackView::setTrackData(const Track::Data& data)
 {
     auto distConv = [this](float metres) -> float {
@@ -119,7 +124,7 @@ void TrackView::setTrackData(const Track::Data& data)
 
 void TrackView::setTime(uint8_t h, uint8_t m)
 {
-    trackFaceStatus.setTime(h, m);
+    trackFaceStatus.setTime(h, m, mIs12Hour);
 }
 
 void TrackView::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Treadmill/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Header/Commands.hpp
@@ -60,12 +60,14 @@ namespace CustomMessage {
 
         // Kernel settings
         bool    unitsImperial;
+        bool    timeFormat12h;   // true = 12-hour clock, false = 24-hour
         uint8_t hrThresholds[kHrThresholdsCount];
         uint8_t hrThresholdsCount;
 
         SettingsUpd()
             : SDK::MessageBase(SETTINGS_UPDATE)
             , unitsImperial(false)
+            , timeFormat12h(false)
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
@@ -226,12 +228,13 @@ public:
     virtual ~Sender() = default;
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, bool timeFormat12h,
                      const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
     {
         if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
             msg->settings          = settings;
             msg->unitsImperial     = units;
+            msg->timeFormat12h     = timeFormat12h;
             memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
             msg->hrThresholdsCount = thresholdCount;
             return msg.send();

--- a/Examples/Apps/Treadmill/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Header/Service.hpp
@@ -55,6 +55,7 @@ private:
 
     Settings                  mSettings;
     bool                      mIsImperial = false;
+    bool                      mTimeFormat12h = false;
     SettingsSerializer        mSettingsSerializer;
     ActivitySummary           mSummary;
     ActivitySummarySerializer mActivitySummarySerializer;

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
@@ -651,6 +651,7 @@ void Service::sendInitialInfoToGui()
     if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
         if (msg.send(100) && msg.ok()) {
             mIsImperial = msg->imperialUnits;
+            mTimeFormat12h = msg->timeFormat;
 
             // Height (cm -> m) drives the phase-1 demographic stride. The model
             // clamps implausible values at session start; only override the
@@ -682,7 +683,7 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, hrThresholds, CustomMessage::kHrThresholdsCount);
+    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat12h, hrThresholds, CustomMessage::kHrThresholdsCount);
     mGuiSender.summary(&mSummary);
     mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
 }

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -19,10 +19,12 @@ public:
 
     /**
      * @brief Display the current time of day.
-     * @param h Hour   (0-23).
-     * @param m Minute (0-59).
+     * @param h        Hour   (0-23).
+     * @param m        Minute (0-59).
+     * @param is12Hour When true, draw a 12-hour clock with an AM/PM suffix;
+     *                 otherwise draw 24-hour time.
      */
-    void setTime(uint8_t h, uint8_t m);
+    void setTime(uint8_t h, uint8_t m, bool is12Hour);
 
     /**
      * @brief Display the battery charge level.
@@ -35,6 +37,29 @@ public:
 
 protected:
     SDK::Gui::SensorStatusRow mSensorRow;
+
+    // AM/PM suffix drawn next to the time in 12-hour format. Added here (rather
+    // than in the generated base) so the layout stays in hand-written code; the
+    // full ASCII wildcard range of every typography means the letters are
+    // already present in the generated fonts, so no asset regeneration is needed.
+    touchgfx::TextAreaWithOneWildcard mMeridiem;
+    static const uint16_t MERIDIEM_SIZE = 3;                 // "AM"/"PM" + NUL
+    touchgfx::Unicode::UnicodeChar mMeridiemBuffer[MERIDIEM_SIZE];
+
+    // Time-of-day geometry (matches the clock-format design). The digits and the
+    // AM/PM suffix are laid out as one group centred on the 240px-wide face, so a
+    // two-digit hour widens the group and pushes the suffix to the right.
+    //
+    // kTimeY centres the 60px digit block vertically between the two dividers
+    // (drawn at y=62 and y=136): the digit glyphs render across [Y+16, Y+60], so
+    // Y=63 lands the block midway in the gap. kMeridiemY puts the 18px AM/PM
+    // suffix on the same baseline as the digits: SemiBold-60 baseline is 60 and
+    // Medium-18 baseline is 18, so the suffix box sits kTimeY + (60 - 18) = +42.
+    static const int16_t  kTimeY       = 63;
+    static const int16_t  kTimeH       = 77;
+    static const int16_t  kMeridiemY   = 105;
+    static const int16_t  kMeridiemH   = 27;
+    static const int16_t  kMeridiemGap = 5;   // digits -> AM/PM spacing (px)
 };
 
 #endif // TRACKFACESTATUS_HPP

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -82,6 +82,7 @@ public:
 
     // Settings
     bool isUnitsImperial() const;
+    bool is12HourFormat() const;
     const uint8_t* getHrThresholds() const;
     uint8_t        getHrThresholdsCount() const;
     const Settings& getSettings() const;
@@ -134,6 +135,7 @@ private:
 
     // Settings (mirrored from Service)
     bool mUnitsImperial = false;
+    bool mTimeFormat12h = false;
     uint8_t mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t mHrThresholdsCount = App::Config::kHrThresholdsCount;
     Settings mSettings {};

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
@@ -16,6 +16,7 @@ public:
     uint16_t getPositionId();
 
     void setConfig(bool isImperial, const uint8_t* thresholds, uint8_t thresholdCount);
+    void setTimeFormat(bool is12Hour);
     void setTrackData(const Track::Data& data);
 
     void setTime(uint8_t h, uint8_t m);
@@ -32,6 +33,7 @@ protected:
 
     uint16_t mCurrentFaceId = 0;
     bool     mIsImperial    = false;
+    bool     mIs12Hour      = false;
     uint8_t  mHrThresholds[App::Config::kHrThresholdsCount] = {};
     uint8_t  mHrThresholdCount = 0;
     uint8_t  mAccessoryState = 0;  // last SDK::Accessory::State (engaged?)

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -1,5 +1,7 @@
 #include <gui/containers/TrackFaceStatus.hpp>
 #include <images/BitmapDatabase.hpp>
+#include <texts/TextKeysAndLanguages.hpp>
+#include <touchgfx/Color.hpp>
 
 TrackFaceStatus::TrackFaceStatus()
 {
@@ -9,6 +11,19 @@ void TrackFaceStatus::initialize()
 {
     TrackFaceStatusBase::initialize();
 
+    // Draw the time left-aligned (the generated base centres it) so the AM/PM
+    // suffix can follow the digits; setTime() re-centres the whole group.
+    dayTimeValue.setTypedText(touchgfx::TypedText(T_TMP_SEMIBOLD_60_L));
+    dayTimeValue.setY(kTimeY);
+
+    // AM/PM suffix, shown only in 12-hour format.
+    mMeridiem.setColor(touchgfx::Color::getColorFromRGB(192, 192, 192));
+    mMeridiem.setLinespacing(0);
+    mMeridiem.setTypedText(touchgfx::TypedText(T_TMP_MEDIUM_18_L));
+    mMeridiem.setWildcard(mMeridiemBuffer);
+    mMeridiem.setVisible(false);
+    add(mMeridiem);
+
     // External-HR status icon above the time of day (HR-only app: no GPS icon).
     add(mSensorRow);
     mSensorRow.setPosition(0, 20, 240, 24);
@@ -16,10 +31,51 @@ void TrackFaceStatus::initialize()
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
 }
 
-void TrackFaceStatus::setTime(uint8_t h, uint8_t m)
+void TrackFaceStatus::setTime(uint8_t h, uint8_t m, bool is12Hour)
 {
-    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", h, m);
+    // Invalidate the old glyph rectangles before the text and positions move.
     dayTimeValue.invalidate();
+    mMeridiem.invalidate();
+
+    uint8_t hour = h;
+    bool    pm   = false;
+    if (is12Hour) {
+        pm   = (h >= 12);
+        hour = h % 12;
+        if (hour == 0) {
+            hour = 12;
+        }
+    }
+
+    Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", hour, m);
+    dayTimeValue.setWildcard(dayTimeValueBuffer);
+    const uint16_t timeW = dayTimeValue.getTextWidth();
+
+    uint16_t merW   = 0;
+    uint16_t groupW = timeW;
+    if (is12Hour) {
+        mMeridiemBuffer[0] = pm ? 'P' : 'A';
+        mMeridiemBuffer[1] = 'M';
+        mMeridiemBuffer[2] = 0;
+        mMeridiem.setWildcard(mMeridiemBuffer);
+        merW   = mMeridiem.getTextWidth();
+        groupW = static_cast<uint16_t>(timeW + kMeridiemGap + merW);
+    }
+
+    // Centre the digits (+ suffix) as one group on the 240px face.
+    const int16_t groupLeft = static_cast<int16_t>((getWidth() - groupW) / 2);
+
+    dayTimeValue.setPosition(groupLeft, kTimeY, static_cast<int16_t>(timeW + 4), kTimeH);
+    dayTimeValue.invalidate();
+
+    if (is12Hour) {
+        mMeridiem.setPosition(static_cast<int16_t>(groupLeft + timeW + kMeridiemGap),
+                              kMeridiemY, static_cast<int16_t>(merW + 4), kMeridiemH);
+        mMeridiem.setVisible(true);
+        mMeridiem.invalidate();
+    } else {
+        mMeridiem.setVisible(false);
+    }
 }
 
 void TrackFaceStatus::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -119,6 +119,11 @@ bool Model::isUnitsImperial() const
     return mUnitsImperial;
 }
 
+bool Model::is12HourFormat() const
+{
+    return mTimeFormat12h;
+}
+
 const uint8_t* Model::getHrThresholds() const
 {
     return mHrThresholds;
@@ -264,6 +269,7 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             auto* msg          = static_cast<CustomMessage::SettingsUpd*>(message);
             mSettings          = msg->settings;
             mUnitsImperial     = msg->unitsImperial;
+            mTimeFormat12h     = msg->timeFormat12h;
             memcpy(mHrThresholds, msg->hrThresholds, sizeof(mHrThresholds));
             mHrThresholdsCount = msg->hrThresholdsCount;
             modelListener->onSettings(mSettings);

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
@@ -15,6 +15,7 @@ void TrackPresenter::activate()
     view.setPositionId(model->menu().track.get());
 
     view.setConfig(model->isUnitsImperial(), model->getHrThresholds(), model->getHrThresholdsCount());
+    view.setTimeFormat(model->is12HourFormat());
 
     onTrackData(model->getTrackData());
 

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -67,6 +67,11 @@ void TrackView::setConfig(bool isImperial, const uint8_t* thresholds, uint8_t th
     memcpy(mHrThresholds, thresholds, mHrThresholdCount);
 }
 
+void TrackView::setTimeFormat(bool is12Hour)
+{
+    mIs12Hour = is12Hour;
+}
+
 void TrackView::setTrackData(const Track::Data& data)
 {
     trackFaceTotal.setHR(data.hr, mHrThresholds, mHrThresholdCount);
@@ -83,7 +88,7 @@ void TrackView::setTrackData(const Track::Data& data)
 
 void TrackView::setTime(uint8_t h, uint8_t m)
 {
-    trackFaceStatus.setTime(h, m);
+    trackFaceStatus.setTime(h, m, mIs12Hour);
 }
 
 void TrackView::setBatteryLevel(uint8_t level)

--- a/Examples/Apps/Workout/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Workout/Software/Libs/Header/Commands.hpp
@@ -50,12 +50,14 @@ namespace CustomMessage {
 
         // Kernel settings
         bool    unitsImperial;
+        bool    timeFormat12h;   // true = 12-hour clock, false = 24-hour
         uint8_t hrThresholds[kHrThresholdsCount];
         uint8_t hrThresholdsCount;
 
         SettingsUpd()
             : SDK::MessageBase(SETTINGS_UPDATE)
             , unitsImperial(false)
+            , timeFormat12h(false)
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
@@ -167,12 +169,13 @@ public:
     virtual ~Sender() = default;
 
     // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
+    bool settingsUpd(Settings settings, bool units, bool timeFormat12h,
                      const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
     {
         if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
             msg->settings          = settings;
             msg->unitsImperial     = units;
+            msg->timeFormat12h     = timeFormat12h;
             memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
             msg->hrThresholdsCount = thresholdCount;
             return msg.send();

--- a/Examples/Apps/Workout/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Workout/Software/Libs/Header/Service.hpp
@@ -48,6 +48,7 @@ private:
 
     Settings                  mSettings;
     bool                      mIsImperial = false;
+    bool                      mTimeFormat12h = false;
     SettingsSerializer        mSettingsSerializer;
     ActivitySummary           mSummary;
     ActivitySummarySerializer mActivitySummarySerializer;

--- a/Examples/Apps/Workout/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Workout/Software/Libs/Sources/Service.cpp
@@ -554,6 +554,7 @@ void Service::sendInitialInfoToGui()
     if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
         if (msg.send(100) && msg.ok()) {
             mIsImperial = msg->imperialUnits;
+            mTimeFormat12h = msg->timeFormat;
 
             if (msg->weightKg > 0.0f) {
                 mWeightKg = msg->weightKg;
@@ -582,7 +583,7 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, hrThresholds, CustomMessage::kHrThresholdsCount);
+    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat12h, hrThresholds, CustomMessage::kHrThresholdsCount);
     memcpy(mHrThresholds.data(), hrThresholds, sizeof(hrThresholds));
     mHrThresholdCount = CustomMessage::kHrThresholdsCount;
     mGuiSender.summary(&mSummary);


### PR DESCRIPTION
Makes the example apps follow the system 12/24-hour clock setting, which they previously ignored (time was hard-coded to 24-hour). The setting is the one added kernel-side in una-kernel PR #236 (`RequestSystemSettings::timeFormat`).

## Activity-tracking apps (Running, Cycling, Hiking, Treadmill, Workout)
The in-activity status face (`TrackFaceStatus`) now draws the time of day in the configured format. In 12-hour it shows a smaller AM/PM suffix on the digits' baseline, with the `[time + suffix]` group centred on the face, so a two-digit hour widens the group and pushes the suffix right. 24-hour is unchanged. The format flows Service → `SettingsUpd` IPC message → GUI `Model::is12HourFormat()` → `TrackPresenter`/`TrackView` → `TrackFaceStatus::setTime()`.

## Alarm app
Full 12/24-hour support for both showing and setting alarms:
- **Display** — the alarm list and ringing screen render the configured format (list uses the big-time + baseline AM/PM suffix; ringing appends the suffix inline).
- **Editing** — in 12-hour the hours wheel shows 1–12 (wrapping) and a new AM/PM step follows minutes (Hours → Minutes → AM/PM → Repeat → Effect). 24-hour keeps 0–23 and skips the AM/PM step. Alarms are still stored as a 0–23 hour, converted on load/save (`App::TimeFormat::split12`/`to24`).
- **Bug fix** — the option-wheel label buffer was 10 chars, so "Beep & Vibrate" showed as "Beep & Vi"; it now renders into a wider buffer.

## Notes
- No TouchGFX asset/text regeneration: AM/PM is drawn via wildcard buffers because every typography already carries the full ASCII glyph set. The AM/PM edit-wheel and the suffix TextAreas are hand-added (like the existing sensor-status row), so no generated files change.
- Reviewed by a subagent; the one real finding (a missing invalidate on the Alarm "New Alarm" slot) and a couple of defensive/doc nits are folded in.
- Verified in the host simulators (12h single/two-digit, 24h no-regression, vertical centring, AM/PM baseline alignment, the edit wizard, and the Alert label fix).

Pre-existing, out-of-scope: the app simulators don't link out of the box due to stale `Application.vcxproj` source manifests (`Fit/RecordingMarker.cpp`; Alarm's `Imu/ImuRunningCadence.cpp`). Not touched here — happy to fix separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 12-hour and 24-hour time displays across alarm, tracking, and workout screens.
  * 12-hour displays now show AM/PM indicators and correctly convert midnight and noon.
  * Alarm editing includes an AM/PM selection step when 12-hour mode is enabled.
  * Time format now follows the device’s configured clock preference.
* **Bug Fixes**
  * Improved longer option labels to prevent text clipping.
  * Refined time and AM/PM positioning for consistent centered layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->