### PR TITLE
refactor(clock): single-source the 12/24-hour conversion

### DIFF
--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/common/TimeFormat.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/common/TimeFormat.hpp
@@ -3,6 +3,8 @@
 
 #include <cstdint>
 
+#include "SDK/Utils/ClockTime.hpp"
+
 /**
  * @brief Helpers for converting between the stored 24-hour time and the
  *        12-hour clock shown when the system clock-format setting is 12H.
@@ -15,18 +17,15 @@ namespace App::TimeFormat {
 /** @brief Split a 0-23 hour into a 1-12 hour and an AM/PM flag. */
 inline void split12(uint8_t hour24, uint8_t& hour12, bool& pm)
 {
-    pm     = (hour24 >= 12);
-    hour12 = static_cast<uint8_t>(hour24 % 12);
-    if (hour12 == 0) {
-        hour12 = 12;
-    }
+    const SDK::Clock::Hour12 t = SDK::Clock::to12Hour(hour24);
+    hour12 = t.hour;
+    pm     = t.pm;
 }
 
 /** @brief Combine a 1-12 hour and an AM/PM flag back into a 0-23 hour. */
 inline uint8_t to24(uint8_t hour12, bool pm)
 {
-    const uint8_t base = static_cast<uint8_t>(hour12 % 12);   // 12 -> 0
-    return static_cast<uint8_t>(base + (pm ? 12 : 0));
+    return SDK::Clock::to24Hour(hour12, pm);
 }
 
 } // namespace App::TimeFormat

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -3,6 +3,8 @@
 #include <texts/TextKeysAndLanguages.hpp>
 #include <touchgfx/Color.hpp>
 
+#include "SDK/Utils/ClockTime.hpp"
+
 TrackFaceStatus::TrackFaceStatus()
 {
 }
@@ -37,15 +39,9 @@ void TrackFaceStatus::setTime(uint8_t h, uint8_t m, bool is12Hour)
     dayTimeValue.invalidate();
     mMeridiem.invalidate();
 
-    uint8_t hour = h;
-    bool    pm   = false;
-    if (is12Hour) {
-        pm   = (h >= 12);
-        hour = h % 12;
-        if (hour == 0) {
-            hour = 12;
-        }
-    }
+    const SDK::Clock::Hour12 civil = SDK::Clock::to12Hour(h);
+    const uint8_t hour = is12Hour ? civil.hour : h;
+    const bool    pm   = civil.pm;
 
     Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", hour, m);
     dayTimeValue.setWildcard(dayTimeValueBuffer);

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -3,6 +3,8 @@
 #include <texts/TextKeysAndLanguages.hpp>
 #include <touchgfx/Color.hpp>
 
+#include "SDK/Utils/ClockTime.hpp"
+
 TrackFaceStatus::TrackFaceStatus()
 {}
 
@@ -36,15 +38,9 @@ void TrackFaceStatus::setTime(uint8_t h, uint8_t m, bool is12Hour)
     dayTimeValue.invalidate();
     mMeridiem.invalidate();
 
-    uint8_t hour = h;
-    bool    pm   = false;
-    if (is12Hour) {
-        pm   = (h >= 12);
-        hour = h % 12;
-        if (hour == 0) {
-            hour = 12;
-        }
-    }
+    const SDK::Clock::Hour12 civil = SDK::Clock::to12Hour(h);
+    const uint8_t hour = is12Hour ? civil.hour : h;
+    const bool    pm   = civil.pm;
 
     Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", hour, m);
     dayTimeValue.setWildcard(dayTimeValueBuffer);

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -3,6 +3,8 @@
 #include <texts/TextKeysAndLanguages.hpp>
 #include <touchgfx/Color.hpp>
 
+#include "SDK/Utils/ClockTime.hpp"
+
 TrackFaceStatus::TrackFaceStatus()
 {
 }
@@ -37,15 +39,9 @@ void TrackFaceStatus::setTime(uint8_t h, uint8_t m, bool is12Hour)
     dayTimeValue.invalidate();
     mMeridiem.invalidate();
 
-    uint8_t hour = h;
-    bool    pm   = false;
-    if (is12Hour) {
-        pm   = (h >= 12);
-        hour = h % 12;
-        if (hour == 0) {
-            hour = 12;
-        }
-    }
+    const SDK::Clock::Hour12 civil = SDK::Clock::to12Hour(h);
+    const uint8_t hour = is12Hour ? civil.hour : h;
+    const bool    pm   = civil.pm;
 
     Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", hour, m);
     dayTimeValue.setWildcard(dayTimeValueBuffer);

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -3,6 +3,8 @@
 #include <texts/TextKeysAndLanguages.hpp>
 #include <touchgfx/Color.hpp>
 
+#include "SDK/Utils/ClockTime.hpp"
+
 TrackFaceStatus::TrackFaceStatus()
 {
 }
@@ -37,15 +39,9 @@ void TrackFaceStatus::setTime(uint8_t h, uint8_t m, bool is12Hour)
     dayTimeValue.invalidate();
     mMeridiem.invalidate();
 
-    uint8_t hour = h;
-    bool    pm   = false;
-    if (is12Hour) {
-        pm   = (h >= 12);
-        hour = h % 12;
-        if (hour == 0) {
-            hour = 12;
-        }
-    }
+    const SDK::Clock::Hour12 civil = SDK::Clock::to12Hour(h);
+    const uint8_t hour = is12Hour ? civil.hour : h;
+    const bool    pm   = civil.pm;
 
     Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", hour, m);
     dayTimeValue.setWildcard(dayTimeValueBuffer);

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/TrackFaceStatus.cpp
@@ -3,6 +3,8 @@
 #include <texts/TextKeysAndLanguages.hpp>
 #include <touchgfx/Color.hpp>
 
+#include "SDK/Utils/ClockTime.hpp"
+
 TrackFaceStatus::TrackFaceStatus()
 {
 }
@@ -37,15 +39,9 @@ void TrackFaceStatus::setTime(uint8_t h, uint8_t m, bool is12Hour)
     dayTimeValue.invalidate();
     mMeridiem.invalidate();
 
-    uint8_t hour = h;
-    bool    pm   = false;
-    if (is12Hour) {
-        pm   = (h >= 12);
-        hour = h % 12;
-        if (hour == 0) {
-            hour = 12;
-        }
-    }
+    const SDK::Clock::Hour12 civil = SDK::Clock::to12Hour(h);
+    const uint8_t hour = is12Hour ? civil.hour : h;
+    const bool    pm   = civil.pm;
 
     Unicode::snprintf(dayTimeValueBuffer, DAYTIMEVALUE_SIZE, "%u:%02u", hour, m);
     dayTimeValue.setWildcard(dayTimeValueBuffer);

--- a/Libs/Header/SDK/Utils/ClockTime.hpp
+++ b/Libs/Header/SDK/Utils/ClockTime.hpp
@@ -1,0 +1,51 @@
+/**
+ ******************************************************************************
+ * @file    ClockTime.hpp
+ * @brief   Shared 12/24-hour time-of-day conversion.
+ *
+ * Semantics only: the SDK carries the 12/24 choice; how a face displays it
+ * (padding, separator, AM/PM glyphs, layout) is a per-face design choice.
+ ******************************************************************************
+ */
+#ifndef SDK_UTILS_CLOCKTIME_HPP
+#define SDK_UTILS_CLOCKTIME_HPP
+
+#include <cstdint>
+
+namespace SDK::Clock
+{
+
+/// A 24-hour reading expressed on a 12-hour clock.
+struct Hour12
+{
+    std::uint8_t hour;  ///< 1..12
+    bool         pm;    ///< false = AM, true = PM
+};
+
+/**
+ * @brief Convert a 0-23 hour to a 12-hour clock reading.
+ *
+ * Precondition: @p hour24 is in [0, 23]. Boundary mapping:
+ *   0 -> 12 AM,  1..11 -> 1..11 AM,  12 -> 12 PM,  13..23 -> 1..11 PM.
+ */
+constexpr Hour12 to12Hour(std::uint8_t hour24) noexcept
+{
+    const bool         pm  = hour24 >= 12u;
+    const std::uint8_t rem = static_cast<std::uint8_t>(hour24 % 12u);
+    return Hour12{ rem == 0u ? static_cast<std::uint8_t>(12) : rem, pm };
+}
+
+/**
+ * @brief Inverse of to12Hour(): a 12-hour reading + AM/PM back to a 0-23 hour.
+ *
+ * Precondition: @p hour12 is in [1, 12]. (12, AM) -> 0, (12, PM) -> 12.
+ */
+constexpr std::uint8_t to24Hour(std::uint8_t hour12, bool pm) noexcept
+{
+    const std::uint8_t base = static_cast<std::uint8_t>(hour12 % 12u);  // 12 -> 0
+    return static_cast<std::uint8_t>(base + (pm ? 12u : 0u));
+}
+
+} // namespace SDK::Clock
+
+#endif // SDK_UTILS_CLOCKTIME_HPP

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(una-sdk-host-tests
     simulator/FileSystemMock_test.cpp
     sensorlayer/GyroscopeParser_test.cpp
     metrics/MonotonicCounter_test.cpp
+    utils/ClockTime_test.cpp
     support/KernelTestDoubles_test.cpp
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/SettingsSerializer.cpp"
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp"

--- a/Tests/Host/utils/ClockTime_test.cpp
+++ b/Tests/Host/utils/ClockTime_test.cpp
@@ -1,0 +1,55 @@
+/**
+ ******************************************************************************
+ * @file    ClockTime_test.cpp
+ * @brief   Tests for the SDK::Clock time-of-day helpers.
+ ******************************************************************************
+ */
+
+#include "SDK/Utils/ClockTime.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+using SDK::Clock::to12Hour;
+using SDK::Clock::to24Hour;
+
+TEST(ClockTime, To12HourBoundaries)
+{
+    EXPECT_EQ(to12Hour(0).hour, 12u);   EXPECT_FALSE(to12Hour(0).pm);   // midnight -> 12 AM
+    EXPECT_EQ(to12Hour(1).hour, 1u);    EXPECT_FALSE(to12Hour(1).pm);
+    EXPECT_EQ(to12Hour(11).hour, 11u);  EXPECT_FALSE(to12Hour(11).pm);
+    EXPECT_EQ(to12Hour(12).hour, 12u);  EXPECT_TRUE(to12Hour(12).pm);   // noon -> 12 PM
+    EXPECT_EQ(to12Hour(13).hour, 1u);   EXPECT_TRUE(to12Hour(13).pm);
+    EXPECT_EQ(to12Hour(23).hour, 11u);  EXPECT_TRUE(to12Hour(23).pm);
+}
+
+TEST(ClockTime, To24HourInverts)
+{
+    EXPECT_EQ(to24Hour(12, false), 0u);   // 12 AM -> 00
+    EXPECT_EQ(to24Hour(12, true), 12u);   // 12 PM -> 12
+    EXPECT_EQ(to24Hour(1, false), 1u);
+    EXPECT_EQ(to24Hour(11, true), 23u);
+}
+
+TEST(ClockTime, RoundTripEveryHour)
+{
+    for (int h = 0; h < 24; ++h) {
+        const auto t = to12Hour(static_cast<std::uint8_t>(h));
+        EXPECT_GE(t.hour, 1u);
+        EXPECT_LE(t.hour, 12u);
+        EXPECT_EQ(to24Hour(t.hour, t.pm), static_cast<std::uint8_t>(h))
+            << "round-trip failed at hour " << h;
+    }
+}
+
+// Usable in constant expressions.
+TEST(ClockTime, ConstexprEvaluable)
+{
+    static_assert(to12Hour(0).hour == 12 && !to12Hour(0).pm, "midnight");
+    static_assert(to12Hour(12).hour == 12 && to12Hour(12).pm, "noon");
+    static_assert(to12Hour(13).hour == 1 && to12Hour(13).pm, "1 PM");
+    static_assert(to24Hour(12, false) == 0, "12 AM -> 0");
+    static_assert(to24Hour(12, true) == 12, "12 PM -> 12");
+    SUCCEED();
+}


### PR DESCRIPTION
Move a little bit of the nuanced code into a shared utility. >=, mod, etc. are exactly the easy things to make silly mistakes when implementing multiple times.

This doesn't necessarily simplify much, subjectively I think it makes it slightly harder to make mistakes. No ego attached to this if it doesn't feel like a good direction though.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 12-hour/24-hour time conversion and AM/PM rendering consistency across alarm, cycling, hiking, running, treadmill, and workout displays.
  * Fixed boundary handling for midnight, noon, and adjacent hours to ensure accurate, stable time presentation.

* **New Features**
  * Added shared SDK clock conversion helpers to standardize 12-hour ↔ 24-hour conversions.

* **Tests**
  * Added host-side unit tests covering boundary cases, inversion accuracy, full round-trip correctness, and compile-time verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->