### PR TITLE
build(simulator): add -no-pie to the example apps' Linux linker options

### DIFF
--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32

--- a/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/una/Makefile
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/una/Makefile
@@ -55,7 +55,7 @@ resource_file :=
 imageconvert_executable := $(touchgfx_path)/framework/tools/imageconvert/build/linux/imageconvert.out
 fontconvert_executable := $(touchgfx_path)/framework/tools/fontconvert/build/linux/fontconvert.out
 simulator_executable := simulator.out
-linker_options += -static-libgcc -Xlinker --no-as-needed
+linker_options += -static-libgcc -Xlinker --no-as-needed -no-pie
 else
 sdl_library_path := $(touchgfx_path)/lib/sdl2/win32
 jpeg_library_path := $(touchgfx_path)/3rdparty/libjpeg/lib/win32


### PR DESCRIPTION
The prebuilt libtouchgfx.a is non-PIC, so a default-PIE toolchain (e.g. Ubuntu's gcc) cannot link it into the simulator executable: it fails with "relocation R_X86_64_32 ... can not be used when making a PIE object". The tutorial apps got -no-pie in #125; the example apps were missed, so their Linux simulator only links on toolchains that do not default to PIE. Mirror the tutorial fix for the seven apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux build compatibility for the Alarm, Cycling, HRMonitor, Hiking, Running, Treadmill, and Workout simulator applications.
  * Updated Linux linking to produce builds reliably across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->