### PR TITLE
feat(alarm): AM/PM on the time picker + fix long label clipping

### DIFF
--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TimeWheel.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TimeWheel.hpp
@@ -30,21 +30,22 @@ public:
     /**
      * @brief Select 12- or 24-hour mode for the hours wheel.
      *
-     * 12-hour shows 1-12 (wrapping); 24-hour shows 0-23. Call before setTime().
-     * getTime() then returns the displayed hour (1-12 or 0-23); the caller pairs
-     * it with a separate AM/PM choice to recover the stored 0-23 hour.
+     * 12-hour shows 1-12 (wrapping) plus an in-screen AM/PM field; 24-hour shows
+     * 0-23. Call before setTime(). getTime() always returns the folded 0-23 hour.
      */
     void setFormat(bool is12Hour);
 
     /** @brief Pre-set the wheels to the given time (@p h is 0-23). */
     void setTime(uint8_t h, uint8_t m);
-    /** @brief Read the currently selected time (@p h is 1-12 in 12-hour mode). */
+    /** @brief Read the currently selected time as a 0-23 hour (AM/PM folded in). */
     void getTime(uint8_t& h, uint8_t& m);
 
-    /** @brief Show the hours wheel and hide the minutes wheel. */
+    /** @brief Make the hours field the active (editable) one. */
     void setActiveHours();
-    /** @brief Show the minutes wheel and hide the hours wheel. */
+    /** @brief Make the minutes field the active (editable) one. */
     void setActiveMinutes();
+    /** @brief Make the AM/PM field active (12-hour mode only). */
+    void setActiveAmPm();
 
     /** @brief Increment the value of the currently active wheel by one step. */
     void incValue();
@@ -53,7 +54,30 @@ public:
 
 protected:
     bool mMinutesActive{};  ///< true while the minutes wheel is active
+    bool mAmPmActive{};     ///< true while the AM/PM field is active (12-hour)
     bool mIs12Hour{};       ///< true while the hours wheel shows 1-12
+    bool mIsPm{};           ///< current AM/PM selection (12-hour)
+
+    // AM/PM suffix shown to the right of HH:MM in 12-hour mode (mirrors the
+    // watch-face display: a single small label baseline-aligned to the digits).
+    // Hand-added so no scroll-wheel/designer change is needed; it shows the
+    // selected value and turns teal while the field is active.
+    touchgfx::TextAreaWithOneWildcard mAmPm;
+    static const uint16_t AMPM_SIZE = 3;   // "AM"/"PM" + NUL
+    touchgfx::Unicode::UnicodeChar mAmPmBuffer[AMPM_SIZE];
+
+    /** @brief Position the columns for the current format (12h adds AM/PM). */
+    void applyLayout();
+    /** @brief Recolour/refresh the AM/PM label for the current state. */
+    void updateAmPm();
+    /**
+     * @brief Flip AM/PM when the hour crosses 11<->12 (12-hour mode).
+     *
+     * Matches a real clock: 11 AM -> 12 PM -> 1 PM, and 11 PM -> 12 AM. Crossing
+     * 12<->1 does not change the meridiem. @p beforeIndex / @p afterIndex are
+     * hours-wheel item indices (displayed hour = index + 1).
+     */
+    void maybeFlipMeridiem(int16_t beforeIndex, int16_t afterIndex);
 
     virtual void hoursWheelUpdateItem(TimeWheelHoursItem& item, int16_t itemIndex) override;
     virtual void hoursWheelUpdateCenterItem(TimeWheelHoursCenterItem& item, int16_t itemIndex) override;

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/edit_screen/EditView.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/edit_screen/EditView.hpp
@@ -8,11 +8,11 @@
 /**
  * @brief Screen for creating or editing an alarm.
  *
- * Steps through four sequential positions using R1 (next) / R2 (back):
- *   HOURS -> MINUTES -> REPEAT -> EFFECT
+ * Steps through the positions using R1 (next) / R2 (back):
+ *   HOURS -> MINUTES -> [AMPM] -> REPEAT -> EFFECT
  *
- * Each position shows a different wheel; only the active wheel is visible.
- * Pressing R1 on the last step (EFFECT) saves the alarm.
+ * AMPM is only visited in 12-hour mode and shares the time screen (the TimeWheel
+ * shows an AM/PM field beside HH:MM). Pressing R1 on the last step (EFFECT) saves.
  */
 class EditView : public EditViewBase
 {
@@ -38,25 +38,18 @@ protected:
     enum Position { HOURS = 0, MINUTES, AMPM, REPEAT, EFFECT };
     Position mPosition{};
 
-    /// 12-hour editing (hours wheel shows 1-12 plus a separate AM/PM step).
+    /// 12-hour editing (hours wheel shows 1-12 plus an in-screen AM/PM field).
     bool mIs12Hour = false;
-
-    /// AM/PM step wheel (hand-added; 12-hour mode only). Shares the (20,55) slot.
-    OptionWheel mAmPmMenu;
 
     touchgfx::Callback<EditView, OptionWheelItem&,       int16_t> mRepeatItemCb;
     touchgfx::Callback<EditView, OptionWheelCenterItem&, int16_t> mRepeatCenterItemCb;
     touchgfx::Callback<EditView, OptionWheelItem&,       int16_t> mEffectItemCb;
     touchgfx::Callback<EditView, OptionWheelCenterItem&, int16_t> mEffectCenterItemCb;
-    touchgfx::Callback<EditView, OptionWheelItem&,       int16_t> mAmPmItemCb;
-    touchgfx::Callback<EditView, OptionWheelCenterItem&, int16_t> mAmPmCenterItemCb;
 
     void updateRepeatItem(OptionWheelItem& item, int16_t index);
     void updateRepeatCenterItem(OptionWheelCenterItem& item, int16_t index);
     void updateEffectItem(OptionWheelItem& item, int16_t index);
     void updateEffectCenterItem(OptionWheelCenterItem& item, int16_t index);
-    void updateAmPmItem(OptionWheelItem& item, int16_t index);
-    void updateAmPmCenterItem(OptionWheelCenterItem& item, int16_t index);
 
     /** @brief Switch the visible wheel and header label to the given @p id. */
     void setPosition(Position id);

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelCenterItem.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/OptionWheelCenterItem.cpp
@@ -20,6 +20,15 @@ void OptionWheelCenterItem::apply(const OptionWheelConfig& cfg)
         } else if (cfg.msgId != TYPED_TEXT_INVALID) {
             Unicode::snprintf(mTextBuffer, kTextSize, "%s", touchgfx::TypedText(cfg.msgId).getText());
         }
+        // Shrink to the largest size that fits the fixed-width item so long
+        // labels (e.g. "Beep & Vibrate") are not clipped.
+        text.setTypedText(touchgfx::TypedText(T_TMP_SEMIBOLD_30));
+        if (text.getTextWidth() > text.getWidth()) {
+            text.setTypedText(touchgfx::TypedText(T_TMP_SEMIBOLD_25));
+        }
+        if (text.getTextWidth() > text.getWidth()) {
+            text.setTypedText(touchgfx::TypedText(T_TMP_SEMIBOLD_20));
+        }
         text.setVisible(true);
         toggle.setVisible(false);
         textToggleLeft.setVisible(false);

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/TimeWheel.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/containers/TimeWheel.cpp
@@ -1,6 +1,15 @@
 #include <gui/containers/TimeWheel.hpp>
+#include <touchgfx/Color.hpp>
+#include <texts/TextKeysAndLanguages.hpp>
 
 static constexpr int kMenuAnimationSteps = 4;
+
+namespace {
+// Teal while the AM/PM field is active, light grey once settled (matches the
+// wheels' selected/idle colours).
+const touchgfx::colortype kActiveColor = touchgfx::Color::getColorFromRGB(0, 128, 128);
+const touchgfx::colortype kValueColor  = touchgfx::Color::getColorFromRGB(192, 192, 192);
+}
 
 TimeWheel::TimeWheel()
 {
@@ -9,6 +18,58 @@ TimeWheel::TimeWheel()
 void TimeWheel::initialize()
 {
     TimeWheelBase::initialize();
+
+    // AM/PM suffix (shown only in 12-hour mode; content/colour set by updateAmPm).
+    mAmPmBuffer[0] = 'A'; mAmPmBuffer[1] = 'M'; mAmPmBuffer[2] = 0;
+    mAmPm.setTypedText(touchgfx::TypedText(T_TMP_SEMIBOLD_20_L));
+    mAmPm.setWildcard(mAmPmBuffer);
+    mAmPm.setLinespacing(0);
+    mAmPm.setColor(kValueColor);
+    mAmPm.setVisible(false);
+    add(mAmPm);
+}
+
+void TimeWheel::applyLayout()
+{
+    if (mIs12Hour) {
+        // Shift HH:MM left just enough (its empty outer margins clip harmlessly)
+        // to leave room for the AM/PM suffix on the right.
+        hoursWheel.setPosition(-16, 41, 94, 143);
+        hoursInactive.setPosition(-16, 25, 94, 76);
+        semicolon.setPosition(78, 25, 12, 76);
+        minutesWheel.setPosition(90, 41, 94, 143);
+        minutesInactive.setPosition(90, 25, 94, 76);
+
+        // Single suffix, baseline-aligned to the digits (matches the display).
+        mAmPm.setPosition(168, 60, 32, 30);
+        mAmPm.setVisible(true);
+    } else {
+        // Original full-width layout from the generated base.
+        hoursWheel.setPosition(0, 41, 94, 143);
+        hoursInactive.setPosition(0, 25, 94, 76);
+        semicolon.setPosition(94, 25, 12, 76);
+        minutesWheel.setPosition(106, 41, 94, 143);
+        minutesInactive.setPosition(106, 25, 94, 76);
+
+        mAmPm.setVisible(false);
+    }
+
+    invalidate();
+}
+
+void TimeWheel::updateAmPm()
+{
+    if (!mIs12Hour) {
+        return;
+    }
+
+    // Show only the selected value; teal while the field is being edited.
+    mAmPmBuffer[0] = mIsPm ? 'P' : 'A';
+    mAmPmBuffer[1] = 'M';
+    mAmPmBuffer[2] = 0;
+    mAmPm.setWildcard(mAmPmBuffer);
+    mAmPm.setColor(mAmPmActive ? kActiveColor : kValueColor);
+    mAmPm.invalidate();
 }
 
 void TimeWheel::setFormat(bool is12Hour)
@@ -16,6 +77,9 @@ void TimeWheel::setFormat(bool is12Hour)
     mIs12Hour = is12Hour;
     hoursWheel.setNumberOfItems(is12Hour ? 12 : 24);
     hoursWheel.invalidate();
+
+    applyLayout();
+    updateAmPm();
 }
 
 void TimeWheel::setTime(uint8_t h, uint8_t m)
@@ -24,6 +88,7 @@ void TimeWheel::setTime(uint8_t h, uint8_t m)
         // In 12-hour mode item index 0..11 maps to displayed hour 1..12.
         int16_t hourIndex = h;
         if (mIs12Hour) {
+            mIsPm = (h >= 12);
             uint8_t h12 = h % 12;
             if (h12 == 0) {
                 h12 = 12;
@@ -36,19 +101,27 @@ void TimeWheel::setTime(uint8_t h, uint8_t m)
 
         minutesWheel.animateToItem(m, 0);
         setMinutes(m);
+
+        updateAmPm();
     }
 }
 
 void TimeWheel::getTime(uint8_t& h, uint8_t& m)
 {
     const int16_t hourIndex = hoursWheel.getSelectedItem();
-    h = static_cast<uint8_t>(mIs12Hour ? hourIndex + 1 : hourIndex);
+    if (mIs12Hour) {
+        const uint8_t base = static_cast<uint8_t>((hourIndex + 1) % 12);   // 12 -> 0
+        h = static_cast<uint8_t>(base + (mIsPm ? 12 : 0));
+    } else {
+        h = static_cast<uint8_t>(hourIndex);
+    }
     m = minutesWheel.getSelectedItem();
 }
 
 void TimeWheel::setActiveHours()
 {
     mMinutesActive = false;
+    mAmPmActive = false;
 
     minutesWheel.setVisible(false);
     minutesWheel.invalidate();
@@ -59,11 +132,14 @@ void TimeWheel::setActiveHours()
     hoursWheel.invalidate();
     hoursInactive.setVisible(false);
     hoursInactive.invalidate();
+
+    updateAmPm();
 }
 
 void TimeWheel::setActiveMinutes()
 {
     mMinutesActive = true;
+    mAmPmActive = false;
 
     minutesWheel.setVisible(true);
     minutesWheel.invalidate();
@@ -74,10 +150,37 @@ void TimeWheel::setActiveMinutes()
     hoursWheel.invalidate();
     hoursInactive.setVisible(true);
     hoursInactive.invalidate();
+
+    updateAmPm();
+}
+
+void TimeWheel::setActiveAmPm()
+{
+    mMinutesActive = false;
+    mAmPmActive = true;
+
+    // Neither number is being edited: show both as settled (static) values.
+    hoursWheel.setVisible(false);
+    hoursWheel.invalidate();
+    hoursInactive.setVisible(true);
+    hoursInactive.invalidate();
+
+    minutesWheel.setVisible(false);
+    minutesWheel.invalidate();
+    minutesInactive.setVisible(true);
+    minutesInactive.invalidate();
+
+    updateAmPm();
 }
 
 void TimeWheel::incValue()
 {
+    if (mAmPmActive) {
+        mIsPm = !mIsPm;
+        updateAmPm();
+        return;
+    }
+
     if (mMinutesActive) {
         if (minutesWheel.getNumberOfItems() <= 1) {
             return;
@@ -90,14 +193,22 @@ void TimeWheel::incValue()
         if (hoursWheel.getNumberOfItems() <= 1) {
             return;
         }
-        int16_t p = hoursWheel.getSelectedItem() + 1;
-        hoursWheel.animateToItem(p, kMenuAnimationSteps);
-        setHours(hoursWheel.getSelectedItem());
+        const int16_t before = hoursWheel.getSelectedItem();
+        hoursWheel.animateToItem(before + 1, kMenuAnimationSteps);
+        const int16_t after = hoursWheel.getSelectedItem();
+        setHours(after);
+        maybeFlipMeridiem(before, after);
     }
 }
 
 void TimeWheel::decValue()
 {
+    if (mAmPmActive) {
+        mIsPm = !mIsPm;
+        updateAmPm();
+        return;
+    }
+
     if (mMinutesActive) {
         if (minutesWheel.getNumberOfItems() <= 1) {
             return;
@@ -110,9 +221,26 @@ void TimeWheel::decValue()
         if (hoursWheel.getNumberOfItems() <= 1) {
             return;
         }
-        int16_t p = hoursWheel.getSelectedItem() - 1;
-        hoursWheel.animateToItem(p, kMenuAnimationSteps);
-        setHours(hoursWheel.getSelectedItem());
+        const int16_t before = hoursWheel.getSelectedItem();
+        hoursWheel.animateToItem(before - 1, kMenuAnimationSteps);
+        const int16_t after = hoursWheel.getSelectedItem();
+        setHours(after);
+        maybeFlipMeridiem(before, after);
+    }
+}
+
+void TimeWheel::maybeFlipMeridiem(int16_t beforeIndex, int16_t afterIndex)
+{
+    if (!mIs12Hour) {
+        return;
+    }
+
+    // Displayed hour = index + 1; flip only across the 11<->12 boundary.
+    const int before = beforeIndex + 1;
+    const int after  = afterIndex + 1;
+    if ((before == 11 && after == 12) || (before == 12 && after == 11)) {
+        mIsPm = !mIsPm;
+        updateAmPm();
     }
 }
 

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/edit_screen/EditView.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/edit_screen/EditView.cpp
@@ -1,20 +1,15 @@
 #include <gui/edit_screen/EditView.hpp>
 #include <gui/common/AlarmLabels.hpp>
-#include <gui/common/TimeFormat.hpp>
 
-// AM/PM labels drawn in the AM/PM wheel and step name (literals avoid adding
-// new TypedTexts; the OptionWheel/messageText fonts already carry the letters).
-static const touchgfx::Unicode::UnicodeChar kAmText[]   = {'A', 'M', 0};
-static const touchgfx::Unicode::UnicodeChar kPmText[]   = {'P', 'M', 0};
+// Step-name label for the AM/PM step (literal avoids adding a new TypedText;
+// the messageText font already carries the letters).
 static const touchgfx::Unicode::UnicodeChar kAmPmName[] = {'A', 'M', '/', 'P', 'M', 0};
 
 EditView::EditView() :
     mRepeatItemCb(this,       &EditView::updateRepeatItem),
     mRepeatCenterItemCb(this, &EditView::updateRepeatCenterItem),
     mEffectItemCb(this,       &EditView::updateEffectItem),
-    mEffectCenterItemCb(this, &EditView::updateEffectCenterItem),
-    mAmPmItemCb(this,         &EditView::updateAmPmItem),
-    mAmPmCenterItemCb(this,   &EditView::updateAmPmCenterItem)
+    mEffectCenterItemCb(this, &EditView::updateEffectCenterItem)
 {
 }
 
@@ -38,16 +33,6 @@ void EditView::setupScreen()
     effectMenu.setUpdateCenterItemCallback(mEffectCenterItemCb);
     effectMenu.setNumberOfItems(Alarm::EFFECT_COUNT);
     effectMenu.invalidate();
-
-    // AM/PM wheel: hand-added so it shares the (20,55) slot with the other
-    // wheels without a designer change. Only used in 12-hour mode.
-    mAmPmMenu.initialize();
-    mAmPmMenu.setXY(20, 55);
-    mAmPmMenu.setUpdateItemCallback(mAmPmItemCb);
-    mAmPmMenu.setUpdateCenterItemCallback(mAmPmCenterItemCb);
-    mAmPmMenu.setNumberOfItems(2);   // 0 = AM, 1 = PM
-    mAmPmMenu.setVisible(false);
-    add(mAmPmMenu);
 }
 
 void EditView::tearDownScreen()
@@ -57,15 +42,10 @@ void EditView::tearDownScreen()
 
 void EditView::set(uint8_t h, uint8_t m, Alarm::Repeat repeat, Alarm::Effect effect)
 {
+    // The TimeWheel owns the AM/PM field in 12-hour mode, so it splits/folds the
+    // 0-23 hour itself.
     timeMenu.setFormat(mIs12Hour);
     timeMenu.setTime(h, m);
-
-    if (mIs12Hour) {
-        uint8_t h12;
-        bool    pm;
-        App::TimeFormat::split12(h, h12, pm);
-        mAmPmMenu.selectItem(pm ? 1 : 0);
-    }
 
     repeatMenu.selectItem(static_cast<int16_t>(repeat));
     effectMenu.selectItem(static_cast<int16_t>(effect));
@@ -99,20 +79,6 @@ void EditView::updateEffectCenterItem(OptionWheelCenterItem& item, int16_t index
     item.apply(cfg);
 }
 
-void EditView::updateAmPmItem(OptionWheelItem& item, int16_t index)
-{
-    OptionWheelConfig cfg;
-    cfg.rawText = (index == 1) ? kPmText : kAmText;
-    item.apply(cfg);
-}
-
-void EditView::updateAmPmCenterItem(OptionWheelCenterItem& item, int16_t index)
-{
-    OptionWheelConfig cfg;
-    cfg.rawText = (index == 1) ? kPmText : kAmText;
-    item.apply(cfg);
-}
-
 void EditView::setPosition(Position id)
 {
     switch (id) {
@@ -123,7 +89,6 @@ void EditView::setPosition(Position id)
         timeMenu.setActiveHours();
         repeatMenu.setVisible(false);
         effectMenu.setVisible(false);
-        mAmPmMenu.setVisible(false);
         tick.setVisible(false);
         break;
     case Position::MINUTES:
@@ -133,7 +98,6 @@ void EditView::setPosition(Position id)
         timeMenu.setActiveMinutes();
         repeatMenu.setVisible(false);
         effectMenu.setVisible(false);
-        mAmPmMenu.setVisible(false);
         tick.setVisible(false);
         tick.invalidate();
         break;
@@ -141,10 +105,10 @@ void EditView::setPosition(Position id)
         title.set(T_TEXT_ALARM_UC);
         Unicode::snprintf(messageTextBuffer, MESSAGETEXT_SIZE, "%s", kAmPmName);
         messageText.invalidate();
-        timeMenu.setVisible(false);
+        timeMenu.setVisible(true);
+        timeMenu.setActiveAmPm();
         repeatMenu.setVisible(false);
         effectMenu.setVisible(false);
-        mAmPmMenu.setVisible(true);
         tick.setVisible(false);
         tick.invalidate();
         break;
@@ -154,7 +118,6 @@ void EditView::setPosition(Position id)
         timeMenu.setVisible(false);
         repeatMenu.setVisible(true);
         effectMenu.setVisible(false);
-        mAmPmMenu.setVisible(false);
         tick.setVisible(false);
         tick.invalidate();
         break;
@@ -163,7 +126,6 @@ void EditView::setPosition(Position id)
         setActiveName(T_TEXT_ALERT);
         timeMenu.setVisible(false);
         repeatMenu.setVisible(false);
-        mAmPmMenu.setVisible(false);
         effectMenu.setVisible(true);
         tick.setVisible(true);
         tick.invalidate();
@@ -176,7 +138,6 @@ void EditView::setPosition(Position id)
     timeMenu.invalidate();
     repeatMenu.invalidate();
     effectMenu.invalidate();
-    mAmPmMenu.invalidate();
     tick.invalidate();
 }
 
@@ -189,10 +150,9 @@ void EditView::setActiveName(TypedTextId msgId)
 void EditView::handleKeyEvent(uint8_t key)
 {
     if (key == SDK::GUI::Button::L1) {
-        if (mPosition == Position::HOURS || mPosition == Position::MINUTES) {
+        if (mPosition == Position::HOURS || mPosition == Position::MINUTES
+                || mPosition == Position::AMPM) {
             timeMenu.decValue();
-        } else if (mPosition == Position::AMPM) {
-            mAmPmMenu.selectPrev();
         } else if (mPosition == Position::REPEAT) {
             repeatMenu.selectPrev();
         } else if (mPosition == Position::EFFECT) {
@@ -201,10 +161,9 @@ void EditView::handleKeyEvent(uint8_t key)
     }
 
     if (key == SDK::GUI::Button::L2) {
-        if (mPosition == Position::HOURS || mPosition == Position::MINUTES) {
+        if (mPosition == Position::HOURS || mPosition == Position::MINUTES
+                || mPosition == Position::AMPM) {
             timeMenu.incValue();
-        } else if (mPosition == Position::AMPM) {
-            mAmPmMenu.selectNext();
         } else if (mPosition == Position::REPEAT) {
             repeatMenu.selectNext();
         } else if (mPosition == Position::EFFECT) {
@@ -216,11 +175,7 @@ void EditView::handleKeyEvent(uint8_t key)
         if (mPosition == Position::EFFECT) {
             uint8_t h = 0;
             uint8_t m = 0;
-            timeMenu.getTime(h, m);
-            if (mIs12Hour) {
-                // getTime() gave a 1-12 hour; fold in the AM/PM choice.
-                h = App::TimeFormat::to24(h, mAmPmMenu.getSelectedItem() == 1);
-            }
+            timeMenu.getTime(h, m);   // 0-23, AM/PM already folded in
             presenter->save(h, m,
                 static_cast<Alarm::Repeat>(repeatMenu.getSelectedItem()),
                 static_cast<Alarm::Effect>(effectMenu.getSelectedItem()));


### PR DESCRIPTION
Two related Alarm-app changes (separate commits).

## 1. fix: shrink over-long option-wheel labels
The selected option-wheel item drew at a fixed 30px in a 200px box, so "Beep & Vibrate" (226px) was clipped ~13px each side. The selected label now shrinks to the largest size that fits (30 → 25 → 20); shorter labels are unchanged. Follow-up to the buffer-truncation fix in #206.

## 2. feat: AM/PM on the time-picker screen
The 12-hour alarm editor used to pick AM/PM on its own wizard step (a separate wheel). AM/PM is now a field on the time screen beside HH:MM:

- HH:MM shifts left to leave room for a single AM/PM suffix on the right, styled like the watch-face display (SemiBold-20, baseline-aligned).
- Stepping **Hours → Minutes → AM/PM** highlights each field in teal as it becomes active; only the selected AM/PM value is shown.
- Scrolling the hour across **11↔12** flips AM/PM (like a real clock: 11 AM → 12 PM → 1 PM; 12 AM ← 11 PM); 12↔1 doesn't change it.
- `TimeWheel` now owns the AM/PM value (`setTime` splits the 0–23 hour, `getTime` folds it back), so `EditView` dropped its separate `OptionWheel` and the 12↔24 conversion.
- **24-hour mode is unchanged** — original full-width layout, no AM/PM column, step skipped.

Done in hand-written code (no TouchGFX designer/regen). Reviewed by a subagent (no correctness issues).

## Verification
Built and driven in the Alarm host simulator (12h and 24h):
- Hours/Minutes/AM/PM each highlight correctly; single suffix, no clipping or minutes overlap.
- Round-trip: set 8 + PM → stored 20:00 → displays "8:00 PM".
- 11↔12 flip confirmed both directions; 12↔1 leaves AM/PM unchanged.
- 24h: full-width layout, AM/PM step skipped, "Beep & Vibrate" shows in full.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AM/PM editing directly within the time wheel for 12-hour mode.
  * Time values now correctly convert to 24-hour format when saved.
  * Updated editing flow to include AM/PM between minutes and repeat settings.
* **Bug Fixes**
  * AM/PM now changes correctly when moving across the 11–12 hour boundary.
  * Improved display sizing for longer wheel labels to prevent text clipping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->