### PR TITLE
fix(ci): stop release notes with backticks breaking the Slack step

### DIFF
--- a/.github/workflows/apps-ci.yml
+++ b/.github/workflows/apps-ci.yml
@@ -140,14 +140,21 @@ jobs:
 
       - id: prepare_slack_payload
         name: Prepare Slack payload
+        env:
+          BODY_RAW: ${{ steps.get_slack_params.outputs.body }}
+          SLACK_NAME: ${{ steps.get_slack_params.outputs.name }}
+          SLACK_TAG: ${{ github.ref_name }}
+          SLACK_AUTHOR: ${{ steps.get_slack_params.outputs.author }}
+          SLACK_CREATED: ${{ steps.get_slack_params.outputs.created_at }}
+          SLACK_URL: ${{ steps.get_slack_params.outputs.url }}
         run: |
-          BODY="${{ steps.get_slack_params.outputs.body }}"
+          BODY="$BODY_RAW"
           BODY=$(echo "$BODY" | sed 's/@\([a-zA-Z0-9_-]*\)/<https:\/\/github.com\/\1|@\1>/g')
           BODY=$(echo "$BODY" | sed 's/^## \([^$]*\)$/*\1*/')
           BODY=$(echo "$BODY" | sed 's/^* /- /')
           BODY=$(echo "$BODY" | sed 's/\*\*Full Changelog\*\*:/ *Full Changelog*\n/')
           if [ ${#BODY} -gt 2700 ]; then BODY="${BODY:0:2700}"$'\n''...'; fi
-          PAYLOAD=$(jq -c -n --arg name "${{ steps.get_slack_params.outputs.name }}" --arg tag "${{ github.ref_name }}" --arg body "$BODY" --arg author "${{ steps.get_slack_params.outputs.author }}" --arg created "${{ steps.get_slack_params.outputs.created_at }}" --arg url "${{ steps.get_slack_params.outputs.url }}" '{
+          PAYLOAD=$(jq -c -n --arg name "$SLACK_NAME" --arg tag "$SLACK_TAG" --arg body "$BODY" --arg author "$SLACK_AUTHOR" --arg created "$SLACK_CREATED" --arg url "$SLACK_URL" '{
             text: (":roller_coaster: *UNA Apps*: " + $name),
             blocks: [
               {

--- a/.github/workflows/apps-ci.yml
+++ b/.github/workflows/apps-ci.yml
@@ -76,6 +76,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/apps-v')
     permissions:
       contents: write
+    env:
+      TAG: ${{ github.ref_name }}
     steps:
       - name: Install dependencies
         run: |
@@ -120,17 +122,18 @@ jobs:
 
       - name: Make release immutable
         run: |
-          gh release edit ${{ github.ref_name }} --draft=false
+          gh release edit "$TAG" --draft=false
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
       - id: get_slack_params
         name: Get required parameters for slack notification
         run: |
-          RELEASE_JSON=$(gh release view ${{ github.ref_name }} --json body,author,createdAt,name,url)
-          echo "body<<EOF" >> $GITHUB_OUTPUT
+          RELEASE_JSON=$(gh release view "$TAG" --json body,author,createdAt,name,url)
+          DELIM="EOF_$(openssl rand -hex 16)"
+          echo "body<<$DELIM" >> $GITHUB_OUTPUT
           echo "$RELEASE_JSON" | jq -r '.body' >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "$DELIM" >> $GITHUB_OUTPUT
           echo "author=$(echo "$RELEASE_JSON" | jq -r '.author.login')" >> $GITHUB_OUTPUT
           echo "created_at=$(echo "$RELEASE_JSON" | jq -r '.createdAt')" >> $GITHUB_OUTPUT
           echo "name=$(echo "$RELEASE_JSON" | jq -r '.name')" >> $GITHUB_OUTPUT

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -73,15 +73,20 @@ jobs:
           SLACK_URL: ${{ steps.get_slack_params.outputs.url }}
         run: |
           BODY="$BODY_RAW"
-          # Convert markdown to Slack mrkdwn
-          BODY=$(echo "$BODY" | perl -pe 's/\[([^\]]+)\]\(([^)]+)\)/<$2|$1>/g' || { echo "Error converting links"; exit 1; })  # Links
-          BODY=$(echo "$BODY" | perl -pe 's/\*\*([^*]+)\*\*/\*$1\*/g' || { echo "Error converting bold"; exit 1; })  # Bold
-          BODY=$(echo "$BODY" | perl -pe 's/\*([^*]+)\*/_$1_/g' || { echo "Error converting italic"; exit 1; })  # Italic
-          BODY=$(echo "$BODY" | perl -pe 's/^-\s*/- /g; s/^\*\s*/- /g' || { echo "Error converting lists"; exit 1; })  # Lists
-          BODY=$(echo "$BODY" | perl -pe 's/^#\+\s*\(.*\)$/*$1*/g' || { echo "Error converting headers"; exit 1; })  # Headers
-          BODY=$(echo "$BODY" | perl -pe 's/@\([a-zA-Z0-9_-]*\)/<https:\/\/github.com\/$1|@$1>/g' || { echo "Error converting mentions"; exit 1; })  # Mentions
-          BODY=$(echo "$BODY" | perl -pe 's/\*\*Full Changelog\*\*:/ *Full Changelog*\n/' || { echo "Error adjusting changelog"; exit 1; })  # Changelog
-          BODY=$(echo "$BODY" | perl -pe 's/"/\\"/g' || { echo "Error escaping quotes"; exit 1; })  # Escape double quotes
+          # Convert markdown to Slack mrkdwn. Bold is parked in a \x01 placeholder so the
+          # italic rule cannot eat it; the changelog and header rules emit the placeholder
+          # too so their bold survives. No quote escaping here: jq --arg JSON-encodes $BODY.
+          BODY=$(echo "$BODY" | perl -pe '
+            s/^-\s+/- /;                                            # "-" lists
+            s/^\*\s+/- /;                                           # "*" lists
+            s/^#+\s*(.*)$/\x01$1\x01/;                              # Headers -> bold
+            s/\*\*Full Changelog\*\*:/ \x01Full Changelog\x01\n/;   # Changelog
+            s/\*\*([^*]+)\*\*/\x01$1\x01/g;                         # Bold -> placeholder
+            s/\*([^*]+)\*/_$1_/g;                                   # Italic
+            s/\x01([^\x01]+)\x01/*$1*/g;                            # Placeholder -> Slack bold
+            s/\[([^\]]+)\]\(([^)]+)\)/<$2|$1>/g;                    # Links
+            s/@([a-zA-Z0-9_-]+)/<https:\/\/github.com\/$1|\@$1>/g;  # Mentions
+          ') || { echo "Error converting markdown to Slack mrkdwn"; exit 1; }
           if [ ${#BODY} -gt 2700 ]; then BODY="${BODY:0:2700}"$'\n''...'; fi
           PAYLOAD=$(jq -c -n --arg name "$SLACK_NAME" --arg tag "$SLACK_TAG" --arg body "$BODY" --arg author "$SLACK_AUTHOR" --arg created "$SLACK_CREATED" --arg url "$SLACK_URL" '{
             text: (":books: *UNA SDK*: " + $name),

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -12,6 +12,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.event.release.tag_name, 'sdk-v')
+    env:
+      TAG: ${{ github.ref_name }}
     steps:
       - name: Install dependencies
         run: |
@@ -37,7 +39,7 @@ jobs:
 
       - name: Make release immutable
         run: |
-          gh release edit ${{ github.ref_name }} --draft=false
+          gh release edit "$TAG" --draft=false
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -50,10 +52,11 @@ jobs:
           RELEASE_URL: ${{ github.event.release.html_url }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          RELEASE_BODY=$(gh release view ${{ github.ref_name }} --json body --jq '.body')
-          echo "body<<EOF" >> $GITHUB_OUTPUT
+          RELEASE_BODY=$(gh release view "$TAG" --json body --jq '.body')
+          DELIM="EOF_$(openssl rand -hex 16)"
+          echo "body<<$DELIM" >> $GITHUB_OUTPUT
           echo "$RELEASE_BODY" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "$DELIM" >> $GITHUB_OUTPUT
           echo "author=$RELEASE_AUTHOR" >> $GITHUB_OUTPUT
           echo "created_at=$RELEASE_CREATED" >> $GITHUB_OUTPUT
           echo "name=$RELEASE_NAME" >> $GITHUB_OUTPUT

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -61,8 +61,15 @@ jobs:
 
       - id: prepare_slack_payload
         name: Prepare Slack payload
+        env:
+          BODY_RAW: ${{ steps.get_slack_params.outputs.body }}
+          SLACK_NAME: ${{ steps.get_slack_params.outputs.name }}
+          SLACK_TAG: ${{ github.ref_name }}
+          SLACK_AUTHOR: ${{ steps.get_slack_params.outputs.author }}
+          SLACK_CREATED: ${{ steps.get_slack_params.outputs.created_at }}
+          SLACK_URL: ${{ steps.get_slack_params.outputs.url }}
         run: |
-          BODY="${{ steps.get_slack_params.outputs.body }}"
+          BODY="$BODY_RAW"
           # Convert markdown to Slack mrkdwn
           BODY=$(echo "$BODY" | perl -pe 's/\[([^\]]+)\]\(([^)]+)\)/<$2|$1>/g' || { echo "Error converting links"; exit 1; })  # Links
           BODY=$(echo "$BODY" | perl -pe 's/\*\*([^*]+)\*\*/\*$1\*/g' || { echo "Error converting bold"; exit 1; })  # Bold
@@ -73,7 +80,7 @@ jobs:
           BODY=$(echo "$BODY" | perl -pe 's/\*\*Full Changelog\*\*:/ *Full Changelog*\n/' || { echo "Error adjusting changelog"; exit 1; })  # Changelog
           BODY=$(echo "$BODY" | perl -pe 's/"/\\"/g' || { echo "Error escaping quotes"; exit 1; })  # Escape double quotes
           if [ ${#BODY} -gt 2700 ]; then BODY="${BODY:0:2700}"$'\n''...'; fi
-          PAYLOAD=$(jq -c -n --arg name "${{ steps.get_slack_params.outputs.name }}" --arg tag "${{ github.ref_name }}" --arg body "$BODY" --arg author "${{ steps.get_slack_params.outputs.author }}" --arg created "${{ steps.get_slack_params.outputs.created_at }}" --arg url "${{ steps.get_slack_params.outputs.url }}" '{
+          PAYLOAD=$(jq -c -n --arg name "$SLACK_NAME" --arg tag "$SLACK_TAG" --arg body "$BODY" --arg author "$SLACK_AUTHOR" --arg created "$SLACK_CREATED" --arg url "$SLACK_URL" '{
             text: (":books: *UNA SDK*: " + $name),
             blocks: [
               {


### PR DESCRIPTION
`apps-v1.3.0-rc1` release CI failed at **Prepare Slack payload** (exit 127): a PR title in the auto-generated notes contained backticks (around `ELEV.`), and the step spliced the release body into the shell via `${{ steps.get_slack_params.outputs.body }}`, so the shell ran command substitution on the backticks.

The app builds, the release, and the asset upload all succeeded — only the Slack notification failed.

**Fix:** pass the release fields (body/name/tag/author/created/url) via an `env:` block and reference them as quoted shell vars (`"$BODY_RAW"`, `$SLACK_*`) instead of `${{ }}`-interpolating them into the script. Env values are literal, so backticks / `$(...)` in notes can't execute — this also closes the template-injection hole. Applied to both `apps-ci.yml` and `sdk-release.yml` (identical pattern).

---

**Also folds in two related hardening fixes** (from a follow-up review — same "a release-controlled string breaks the release job" class):

1. **Tag name no longer spliced into the shell.** `gh release edit`/`gh release view ${{ github.ref_name }}` are replaced with a job-level `env: TAG:` referenced as `"$TAG"`. Git ref names may legally contain backticks/`$`/`;`, so a hostile tag name could otherwise inject (low risk — needs push access — but cheap to close). Note kernel `ci.yml` triggers on `tags: ['*']`.
2. **Randomized `$GITHUB_OUTPUT` heredoc delimiter** for the release body (`body<<EOF` → `body<<EOF_<random>`). A release note line that is exactly `EOF` would otherwise terminate the heredoc early and fail/spoof the step. The `payload<<EOF` heredoc is left as-is (jq -c output is single-line — provably safe).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation consistency across application and SDK releases.
  * Enhanced release metadata handling for Slack notifications, including release tags, authors, timestamps, links, and descriptions.
  * Improved reliability when formatting and publishing release notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->