### PR TITLE
fix(simulator): clear the global logger before its kernel is destroyed

### DIFF
--- a/Libs/Header/SDK/Simulator/Kernel/Mock/Logger.hpp
+++ b/Libs/Header/SDK/Simulator/Kernel/Mock/Logger.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "SDK/Interfaces/ILogger.hpp"
+#include "SDK/UnaLogger/Logger.h"
 
 #include "SDK/Simulator/OS/OS.hpp"
 #include "touchgfx/Utils.hpp"
@@ -58,7 +59,13 @@ public:
         svlog(level, module_name, func, line, fmt, args);
     }
 
-    virtual ~Logger() = default;
+    virtual ~Logger() override
+    {
+        // If this is the currently-installed global logger, uninstall it. Otherwise a later log
+        // call -- the queue-drain LOG_WARNINGs in ~DualAppComm, which outlives the kernel that
+        // owns this logger -- would run through a freed vtable and hit a pure virtual.
+        Logger_deinit(*this);
+    }
 
 private:
     static inline OS::Mutex mMutexLog;

--- a/Libs/Header/SDK/UnaLogger/Logger.h
+++ b/Libs/Header/SDK/UnaLogger/Logger.h
@@ -169,6 +169,10 @@ void Logger_hexdump(const char *level,
 #define Logger_message(...)             do { } while(0)
 #define Logger_hexdump(...)             do { } while(0)
 
+// Nothing can be installed when logging is compiled out, so there is nothing to deregister --
+// but ~Logger() calls this unconditionally, so it still has to name something.
+#define Logger_deinit(...)              do { } while(0)
+
 #define LOG(...)                        do { } while(0)
 #define LOG_DUMP(...)                   do { } while(0)
 

--- a/Libs/Header/SDK/UnaLogger/Logger.h
+++ b/Libs/Header/SDK/UnaLogger/Logger.h
@@ -86,6 +86,21 @@
 void Logger_init(SDK::Interface::ILogger& ilogger);
 
 /**
+ * @brief   Deregister a logger previously installed via Logger_init().
+ *
+ * Clears the internal logger pointer, but only if it currently refers to
+ * @p ilogger. Call this before the ILogger instance is destroyed so that a
+ * later log call cannot dereference a dangling logger (e.g. queue-drain
+ * logging during teardown after the owning kernel has already been
+ * destroyed).
+ *
+ * @param[in]   ilogger     Reference to the ILogger interface instance
+ *
+ * @note Safe to call with a logger that was never installed (no-op).
+ */
+void Logger_deinit(SDK::Interface::ILogger& ilogger);
+
+/**
  * @brief   Output formatted log message with metadata.
  *
  * This function formats and outputs a log message with metadata including

--- a/Libs/Header/SDK/UnaLogger/Logger.h
+++ b/Libs/Header/SDK/UnaLogger/Logger.h
@@ -48,29 +48,15 @@
 #define LOG_LEVEL               4
 #endif
 
-#if (LOG_LEVEL > LOG_LEVEL_NO_LOG)
-
-// Get file name from __FILE__ without full path
-#ifndef __FILENAME__
-#if defined(_WIN32) || defined(_WIN64)
-    #define __FILENAME__ (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
-#else
-    #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-#endif
-#endif
-
-// Function name macro
-#ifndef __FUNCTION_NAME__
-#define __FUNCTION_NAME__       __func__
-#endif
-
-#ifndef LOG_MODULE_PRX
-#define LOG_MODULE_PRX          __FILENAME__
-#endif
-
-#ifndef LOG_MODULE_LEVEL
-#define LOG_MODULE_LEVEL        LOG_LEVEL_DEBUG
-#endif
+/*
+ * Logger lifecycle. Declared unconditionally, outside the LOG_LEVEL guard below: these are
+ * registration calls rather than logging output, and callers invoke them without regard to the
+ * translation unit's LOG_LEVEL. Compiling them out per-TU would give an inline caller such as
+ * SDK::Simulator::Mock::Logger::~Logger() a different body in a no-log TU than everywhere else,
+ * which is an ODR violation -- the linker would keep one arbitrary copy and could silently drop
+ * the deregistration. Both are one-shot calls, so there is no hot-path cost to always declaring
+ * them.
+ */
 
 /**
  * @brief   Initialize logger with kernel logging interface.
@@ -99,6 +85,30 @@ void Logger_init(SDK::Interface::ILogger& ilogger);
  * @note Safe to call with a logger that was never installed (no-op).
  */
 void Logger_deinit(SDK::Interface::ILogger& ilogger);
+
+#if (LOG_LEVEL > LOG_LEVEL_NO_LOG)
+
+// Get file name from __FILE__ without full path
+#ifndef __FILENAME__
+#if defined(_WIN32) || defined(_WIN64)
+    #define __FILENAME__ (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
+#else
+    #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
+#endif
+
+// Function name macro
+#ifndef __FUNCTION_NAME__
+#define __FUNCTION_NAME__       __func__
+#endif
+
+#ifndef LOG_MODULE_PRX
+#define LOG_MODULE_PRX          __FILENAME__
+#endif
+
+#ifndef LOG_MODULE_LEVEL
+#define LOG_MODULE_LEVEL        LOG_LEVEL_DEBUG
+#endif
 
 /**
  * @brief   Output formatted log message with metadata.
@@ -168,10 +178,6 @@ void Logger_hexdump(const char *level,
 #else
 #define Logger_message(...)             do { } while(0)
 #define Logger_hexdump(...)             do { } while(0)
-
-// Nothing can be installed when logging is compiled out, so there is nothing to deregister --
-// but ~Logger() calls this unconditionally, so it still has to name something.
-#define Logger_deinit(...)              do { } while(0)
 
 #define LOG(...)                        do { } while(0)
 #define LOG_DUMP(...)                   do { } while(0)

--- a/Libs/Source/UnaLogger/Logger.cpp
+++ b/Libs/Source/UnaLogger/Logger.cpp
@@ -23,6 +23,15 @@ void Logger_init(SDK::Interface::ILogger& ilogger)
     }
 }
 
+void Logger_deinit(SDK::Interface::ILogger& ilogger)
+{
+    // Only clear if this is the currently-installed logger, so a stray deinit of some other
+    // ILogger instance cannot silence logging.
+    if (sILogger == &ilogger) {
+        sILogger = nullptr;
+    }
+}
+
 void Logger_message(const char* level,
                     const char* module,
                     const char* func,


### PR DESCRIPTION
A bit of housekeeping around the Linux simulator, currently every exit looks a bit suspicious.

main() declares the MessageCore ahead of the kernels, so its DualAppComm outlives them. On shutdown ~DualAppComm drains its queues and logs every leftover message, but the service kernel that owns the installed logger is already gone by then, so the log call runs through a freed vtable and aborts right after a clean exit:

```
 ... -D- Mock.System::exit::56 : status = 0
pure virtual method called
terminate called without an active exception
```

The logger pointer was never cleared when its backing kernel died; the queue-drain logging that trips it is newer. It stayed hidden because the GCC/Linux sim only recently ran as far as shutdown, and the non-gating CI smoke check keys off the boot marker, not a clean exit.

Deregister in ~Logger via Logger_deinit so a log after teardown is a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logger shutdown handling to prevent delayed warning messages from accessing a logger after its owner is destroyed.
  * Added safe logger deinitialization that preserves the active logger when a different logger instance is released.
  * Deinitialization requests are now safely ignored when no logger is installed.
  * Improved logger lifecycle reliability across different logging configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->