### PR TITLE
feat(scripts): Update-Watch-Apps.ps1 — USB app updates preserving data

### DIFF
--- a/Utilities/Scripts/Update-Watch-Apps.ps1
+++ b/Utilities/Scripts/Update-Watch-Apps.ps1
@@ -77,6 +77,8 @@ $ErrorActionPreference = 'Stop'
 # ---- resolve source (folder, or a .zip we auto-extract) --------------------
 $origSource = $Source     # what to show the user for the follow-up -Verify command
 $tmp = $null              # temp extract dir (cleaned up at the end) if -Source is a .zip
+# any throw after extraction (no apps, no watch, bad drive, ...) still cleans up $tmp
+trap { if ($tmp -and (Test-Path -LiteralPath $tmp)) { Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue -WhatIf:$false -Confirm:$false } }
 if (Test-Path -LiteralPath $Source -PathType Leaf) {
     if ($Source -notmatch '\.zip$') { throw "Source must be a folder or a .zip: $Source" }
     $tmp = Join-Path ([IO.Path]::GetTempPath()) ('uapp-src-' + [Guid]::NewGuid().ToString('N'))
@@ -106,7 +108,9 @@ function Resolve-WatchDrive {
         if (-not (Test-Path -LiteralPath (Join-Path $r 'Apps'))) { Write-Warning "No \Apps folder on $r - is that the watch drive?" }
         return $r
     }
-    $vols = @(Get-Volume -ErrorAction SilentlyContinue | Where-Object { $_.FileSystemLabel -eq $Label -and $_.DriveLetter -and $_.DriveType -eq 'Removable' })
+    # match on the exact label only: it is specific enough (never C:), and some USB
+    # mass-storage watches report DriveType 'Fixed', which a Removable filter would miss.
+    $vols = @(Get-Volume -ErrorAction SilentlyContinue | Where-Object { $_.FileSystemLabel -eq $Label -and $_.DriveLetter })
     if ($vols.Count -eq 1) { return ("{0}:\" -f $vols[0].DriveLetter) }
     if ($vols.Count -gt 1) { throw ("Multiple volumes labelled '$Label': {0}. Pass -Drive." -f (($vols.DriveLetter) -join ', ')) }
     # fallback: a REMOVABLE drive with an \Apps folder (never a fixed drive like C:\Apps)
@@ -274,25 +278,33 @@ foreach ($a in $srcApps) {
     $dst    = Join-Path $appDir $a.File.Name
     $action = if ($exists) { 'update' } else { 'install' }
     if ($PSCmdlet.ShouldProcess("$($a.App)  ->  $dst", $action)) {
-        if (-not $exists) { [System.IO.Directory]::CreateDirectory($appDir) | Out-Null }   # .NET (no prompt in non-interactive)
-        try { [System.IO.File]::Copy($a.File.FullName, $dst, $true) }          # new first, via .NET (not Copy-Item)
+        try {
+            if (-not $exists) { [System.IO.Directory]::CreateDirectory($appDir) | Out-Null }   # .NET (no prompt in non-interactive)
+            [System.IO.File]::Copy($a.File.FullName, $dst, $true)             # new first, via .NET (not Copy-Item)
+        }
         catch {
             Write-Warning ("  {0}: copy failed ({1}); removing any partial file" -f $a.App, $_.Exception.Message)
-            if (Test-Path -LiteralPath $dst) { [System.IO.File]::Delete($dst) }
+            try { if (Test-Path -LiteralPath $dst) { [System.IO.File]::Delete($dst) } } catch { }
             $failed += $a.App; continue
         }
         $dstLen = (Get-Item -LiteralPath $dst).Length
         if ($a.File.Length -ne $dstLen) {
             # bad copy: remove the corrupt new file; do NOT delete any stale .uapp
-            [System.IO.File]::Delete($dst)
+            try { [System.IO.File]::Delete($dst) } catch { Write-Warning ("  {0}: could not remove bad copy ({1})" -f $a.App, $_.Exception.Message) }
             $remain = @(Get-ChildItem -LiteralPath $appDir -Filter *.uapp -File)
             if ($remain.Count -eq 0) { Write-Warning ("  {0}: size mismatch - bad copy removed; NO valid .uapp remains, re-run to reinstall (settings/Activity preserved)" -f $a.App) }
             else { Write-Warning ("  {0}: size mismatch - bad copy removed; kept existing {1}" -f $a.App, $remain[0].Name) }
             $failed += $a.App; continue
         }
         # copy validated -> now safe to remove stale .uapp(s); keep settings.json / Activity
-        Get-ChildItem -LiteralPath $appDir -Filter *.uapp -File | Where-Object { $_.Name -ne $a.File.Name } | ForEach-Object {
-            [System.IO.File]::Delete($_.FullName); Write-Host ("    removed old {0}" -f $_.Name)
+        try {
+            Get-ChildItem -LiteralPath $appDir -Filter *.uapp -File | Where-Object { $_.Name -ne $a.File.Name } | ForEach-Object {
+                [System.IO.File]::Delete($_.FullName); Write-Host ("    removed old {0}" -f $_.Name)
+            }
+        }
+        catch {
+            Write-Warning ("  {0}: new .uapp copied OK, but a stale .uapp could not be removed ({1}); the folder now has >1 .uapp - delete the old one manually" -f $a.App, $_.Exception.Message)
+            $failed += $a.App; continue
         }
         if ($exists) { $updated += $a.App } else { $installed += $a.App }
         Write-Host ("  [{0,-8}] {1} -> {2}" -f $action, $a.App, $a.File.Name)

--- a/Utilities/Scripts/Update-Watch-Apps.ps1
+++ b/Utilities/Scripts/Update-Watch-Apps.ps1
@@ -9,29 +9,33 @@
     Avoids the two painful options: (a) copy new .uapp + delete old, per app, or
     (b) bulk-delete the app folders, which also wipes settings and activities.
 
-    Portable across machines: the watch is found by its VOLUME LABEL ("UNA WATCH"),
-    not a hard-coded drive letter, so it works whatever letter it mounts as and on
-    anyone's PC. Works on Windows PowerShell 5.1+ (built in) and PowerShell 7.
+    Source layout: the una-apps release (a .zip, or its extracted folder) is a set of
+    per-app SUBFOLDERS whose names match the on-device folders, each holding one
+    .uapp -- e.g. GlanceHR\Live_HR_1.3.0.uapp. The app is keyed by the SUBFOLDER name
+    (the .uapp's own filename differs, especially for the Glance apps), so this maps
+    <Source>\<App>\*.uapp  ->  <Drive>:\Apps\<App>\.
 
-    The watch scans <Drive>:\Apps\<App>\ on boot and uses the FIRST .uapp it finds
-    in each folder, so this removes any stale .uapp and leaves exactly one.
+    Portable across machines: the watch is found by its VOLUME LABEL ("UNA WATCH"),
+    not a hard-coded drive letter. Works on Windows PowerShell 5.1+ and PowerShell 7.
+
+    The watch scans <Drive>:\Apps\<App>\ on boot and uses the FIRST .uapp it finds in
+    each folder, so this removes any stale .uapp and leaves exactly one.
 
     Device notes handled / warned about:
       * Copy uses [System.IO.File]::Copy, NOT Copy-Item (scripted Copy-Item to this
         removable volume has produced silent bit-level corruption).
-      * The new .uapp is copied BEFORE the old is removed (a failed copy never
-        leaves you with nothing).
-      * A hash taken right after copying reads the Windows write cache and can be a
-        false OK; -Verify is only trustworthy after the volume is ejected (or use
-        -Eject, which flushes + removes it).
+      * The new .uapp is copied BEFORE the old is removed.
+      * A hash right after copying reads the Windows write cache and can be a false
+        OK; -Verify is only trustworthy after eject (use -Eject, which flushes it).
       * The launcher / app list rebuilds only at boot -> reboot the watch after.
-      * A .uapp that fails the kernel CRC is silently dropped (app just won't appear).
-      * D:\Apps also contains "SharedData" (not an app); update-only-by-source means
-        it is never touched.
+      * A .uapp that fails the kernel CRC is silently dropped (app won't appear).
+      * D:\Apps also contains "SharedData" (not an app) - never touched, since there
+        is no matching source subfolder. HRMonitor ships in the zip but not on the
+        watch - skipped under the default (update-only).
 
 .PARAMETER Source
-    Folder containing the new <App>_<version>.uapp files (e.g. an extracted
-    una-apps-<tag>.zip).
+    The una-apps release: either the .zip file or an already-extracted folder
+    containing the per-app subfolders.
 
 .PARAMETER Drive
     The watch's USB drive, e.g. E: - overrides label auto-detection.
@@ -44,20 +48,18 @@
     UPDATE apps already on the watch.
 
 .PARAMETER Verify
-    Compare SHA-256 of each on-device .uapp against the source and report
-    mismatches. Run AFTER ejecting + reconnecting the watch (or after -Eject +
-    reconnect) so it reads cold flash, not the write cache.
+    Compare SHA-256 of each on-device .uapp against the source; run AFTER
+    eject+reconnect (or -Eject+reconnect) so it reads cold flash, not the cache.
 
 .PARAMETER Eject
-    After copying, safely eject (flush + remove) the volume. Reconnect the watch,
-    then re-run with -Verify.
+    After copying, safely eject (flush + remove) the volume. Reconnect, then -Verify.
 
 .EXAMPLE
-    powershell -ExecutionPolicy Bypass -File .\Update-Watch-Apps.ps1 -Source .\una-apps-apps-v1.3.0-rc3 -WhatIf
+    .\Update-Watch-Apps.ps1 -Source .\una-apps-apps-v1.3.0-rc3.zip -WhatIf
 .EXAMPLE
-    .\Update-Watch-Apps.ps1 -Source .\una-apps-apps-v1.3.0-rc3 -Eject
+    .\Update-Watch-Apps.ps1 -Source .\una-apps-apps-v1.3.0-rc3.zip -Eject
     # reconnect the watch, then:
-    .\Update-Watch-Apps.ps1 -Source .\una-apps-apps-v1.3.0-rc3 -Verify
+    .\Update-Watch-Apps.ps1 -Source .\una-apps-apps-v1.3.0-rc3.zip -Verify
 #>
 [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
 param(
@@ -72,10 +74,27 @@ param(
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = 'Stop'
 
-# ---- source files ----------------------------------------------------------
-if (-not (Test-Path -LiteralPath $Source -PathType Container)) { throw "Source folder not found: $Source" }
-$srcFiles = @(Get-ChildItem -LiteralPath $Source -Filter *.uapp -File)
-if ($srcFiles.Count -eq 0) { throw "No .uapp files found in $Source (point -Source at the folder holding them)." }
+# ---- resolve source (folder, or a .zip we auto-extract) --------------------
+$origSource = $Source     # what to show the user for the follow-up -Verify command
+$tmp = $null              # temp extract dir (cleaned up at the end) if -Source is a .zip
+if (Test-Path -LiteralPath $Source -PathType Leaf) {
+    if ($Source -notmatch '\.zip$') { throw "Source must be a folder or a .zip: $Source" }
+    $tmp = Join-Path ([IO.Path]::GetTempPath()) ('uapp-src-' + [Guid]::NewGuid().ToString('N'))
+    Expand-Archive -LiteralPath $Source -DestinationPath $tmp -Force
+    $Source = $tmp
+} elseif (-not (Test-Path -LiteralPath $Source -PathType Container)) {
+    throw "Source not found: $Source"
+}
+
+# Each app is a SUBFOLDER (name == on-device folder) holding one .uapp.
+$srcApps = @()
+foreach ($d in Get-ChildItem -LiteralPath $Source -Directory) {
+    $u = @(Get-ChildItem -LiteralPath $d.FullName -Filter *.uapp -File)
+    if ($u.Count -eq 0) { continue }
+    if ($u.Count -gt 1) { Write-Warning "$($d.Name): $($u.Count) .uapp files in source subfolder - skipping (ambiguous which to install)"; continue }
+    $srcApps += [pscustomobject]@{ App = $d.Name; File = $u[0] }
+}
+if ($srcApps.Count -eq 0) { throw "No <App>\*.uapp subfolders under $Source. Point -Source at the una-apps zip or its extracted folder." }
 
 # ---- resolve the watch drive (label -> -Drive -> \Apps fallback) -----------
 function Resolve-WatchDrive {
@@ -88,50 +107,51 @@ function Resolve-WatchDrive {
     $vols = @(Get-Volume -ErrorAction SilentlyContinue | Where-Object { $_.FileSystemLabel -eq $Label -and $_.DriveLetter })
     if ($vols.Count -eq 1) { return ("{0}:\" -f $vols[0].DriveLetter) }
     if ($vols.Count -gt 1) { throw ("Multiple volumes labelled '$Label': {0}. Pass -Drive." -f (($vols.DriveLetter) -join ', ')) }
-    # fallback: a drive that has an \Apps folder
-    $cands = @(Get-PSDrive -PSProvider FileSystem | Where-Object { $_.Root -match '^[A-Za-z]:\\$' -and (Test-Path -LiteralPath (Join-Path $_.Root 'Apps')) })
-    if ($cands.Count -eq 1) { Write-Warning "No volume labelled '$Label'; using $($cands[0].Root) (it has an \Apps folder)."; return $cands[0].Root }
-    throw "Could not find the watch (no volume labelled '$Label', no unambiguous \Apps drive). Connect it, or pass -Drive."
+    # fallback: a REMOVABLE drive with an \Apps folder (never a fixed drive like C:\Apps)
+    $cands = @(Get-Volume -ErrorAction SilentlyContinue |
+        Where-Object { $_.DriveType -eq 'Removable' -and $_.DriveLetter -and (Test-Path -LiteralPath ("{0}:\Apps" -f $_.DriveLetter)) } |
+        ForEach-Object { "{0}:\" -f $_.DriveLetter })
+    if ($cands.Count -eq 1) { Write-Warning "No volume labelled '$Label'; using $($cands[0]) (removable, has an \Apps folder)."; return $cands[0] }
+    throw "Could not find the watch (no volume labelled '$Label', no single removable drive with \Apps). Connect it, or pass -Drive."
 }
 $root     = Resolve-WatchDrive -Drive $Drive -Label $Label
 $appsRoot = Join-Path $root 'Apps'
 if (-not (Test-Path -LiteralPath $appsRoot)) { throw "No Apps folder at $appsRoot." }
-Write-Host "Watch apps folder: $appsRoot"
-
-# ---- <App>_<version>.uapp  ->  <App> --------------------------------------
-function Get-AppName([string]$fileName) {
-    if ($fileName -match '^(?<name>.+?)_\d[\w.\-]*\.uapp$') { return $Matches['name'] }
-    return [IO.Path]::GetFileNameWithoutExtension($fileName)
-}
+Write-Host "Watch apps folder: $appsRoot  ($($srcApps.Count) apps in source)"
 
 # ---- locale-independent safe eject (P/Invoke storage IOCTLs) --------------
 function Invoke-SafeEject([string]$root) {
     $letter = ($root.TrimEnd('\')).TrimEnd(':')
     if (-not ([System.Management.Automation.PSTypeName]'Una.VolumeEject').Type) {
-        Add-Type -Namespace Una -Name VolumeEject -Language CSharp -MemberDefinition @'
-    using System;
-    using System.Runtime.InteropServices;
-    using Microsoft.Win32.SafeHandles;
-    const uint GENERIC_RW = 0x80000000 | 0x40000000, SHARE_RW = 0x1 | 0x2, OPEN_EXISTING = 3;
-    const uint FSCTL_LOCK_VOLUME = 0x00090018, FSCTL_DISMOUNT_VOLUME = 0x00090020;
-    const uint IOCTL_MEDIA_REMOVAL = 0x002D4804, IOCTL_EJECT_MEDIA = 0x002D4808;
-    [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
-    static extern SafeFileHandle CreateFile(string n, uint a, uint s, IntPtr sec, uint d, uint f, IntPtr t);
-    [DllImport("kernel32", SetLastError = true)]
-    static extern bool DeviceIoControl(SafeFileHandle h, uint code, byte[] ib, uint ibl, byte[] ob, uint obl, out uint br, IntPtr ov);
-    public static string Eject(char letter) {
-        var h = CreateFile(@"\\.\" + letter + ":", GENERIC_RW, SHARE_RW, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
-        if (h.IsInvalid) return "open failed (err " + Marshal.GetLastWin32Error() + ")";
-        try {
-            uint br; bool locked = false;
-            for (int i = 0; i < 12 && !locked; i++) { locked = DeviceIoControl(h, FSCTL_LOCK_VOLUME, null, 0, null, 0, out br, IntPtr.Zero); if (!locked) System.Threading.Thread.Sleep(250); }
-            if (!locked) return "lock failed - files still open on the volume";
-            if (!DeviceIoControl(h, FSCTL_DISMOUNT_VOLUME, null, 0, null, 0, out br, IntPtr.Zero)) return "dismount failed (err " + Marshal.GetLastWin32Error() + ")";
-            DeviceIoControl(h, IOCTL_MEDIA_REMOVAL, new byte[] { 0 }, 1, null, 0, out br, IntPtr.Zero); // allow removal
-            if (!DeviceIoControl(h, IOCTL_EJECT_MEDIA, null, 0, null, 0, out br, IntPtr.Zero)) return "eject failed (err " + Marshal.GetLastWin32Error() + ")";
-            return "OK";
-        } finally { h.Close(); }
+        # -TypeDefinition (full namespace/class) so the `using` directives are legal.
+        Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+namespace Una {
+    public static class VolumeEject {
+        const uint GENERIC_RW = 0x80000000 | 0x40000000, SHARE_RW = 0x1 | 0x2, OPEN_EXISTING = 3;
+        const uint FSCTL_LOCK_VOLUME = 0x00090018, FSCTL_DISMOUNT_VOLUME = 0x00090020;
+        const uint IOCTL_MEDIA_REMOVAL = 0x002D4804, IOCTL_EJECT_MEDIA = 0x002D4808;
+        [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
+        static extern SafeFileHandle CreateFile(string n, uint a, uint s, IntPtr sec, uint d, uint f, IntPtr t);
+        [DllImport("kernel32", SetLastError = true)]
+        static extern bool DeviceIoControl(SafeFileHandle h, uint code, byte[] ib, uint ibl, byte[] ob, uint obl, out uint br, IntPtr ov);
+        public static string Eject(char letter) {
+            var h = CreateFile(@"\\.\" + letter + ":", GENERIC_RW, SHARE_RW, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+            if (h.IsInvalid) return "open failed (err " + Marshal.GetLastWin32Error() + ")";
+            try {
+                uint br; bool locked = false;
+                for (int i = 0; i < 12 && !locked; i++) { locked = DeviceIoControl(h, FSCTL_LOCK_VOLUME, null, 0, null, 0, out br, IntPtr.Zero); if (!locked) System.Threading.Thread.Sleep(250); }
+                if (!locked) return "lock failed - files still open on the volume";
+                if (!DeviceIoControl(h, FSCTL_DISMOUNT_VOLUME, null, 0, null, 0, out br, IntPtr.Zero)) return "dismount failed (err " + Marshal.GetLastWin32Error() + ")";
+                DeviceIoControl(h, IOCTL_MEDIA_REMOVAL, new byte[] { 0 }, 1, null, 0, out br, IntPtr.Zero);
+                if (!DeviceIoControl(h, IOCTL_EJECT_MEDIA, null, 0, null, 0, out br, IntPtr.Zero)) return "eject failed (err " + Marshal.GetLastWin32Error() + ")";
+                return "OK";
+            } finally { h.Close(); }
+        }
     }
+}
 '@
     }
     $res = [Una.VolumeEject]::Eject([char]$letter)
@@ -147,14 +167,14 @@ if ($Verify) {
     Write-Host "`nVerify - ensure you EJECTED and RECONNECTED the watch first, else this reads"
     Write-Host "the Windows write cache and can report a false OK.`n"
     $bad = 0
-    foreach ($f in $srcFiles) {
-        $app = Get-AppName $f.Name
-        $dst = Join-Path (Join-Path $appsRoot $app) $f.Name
-        if (-not (Test-Path -LiteralPath $dst)) { Write-Host ("  [MISSING ] {0}\{1}" -f $app, $f.Name); $bad++; continue }
-        if ((Get-FileHash -LiteralPath $f.FullName -Algorithm SHA256).Hash -eq (Get-FileHash -LiteralPath $dst -Algorithm SHA256).Hash) {
-            Write-Host ("  [OK      ] {0}\{1}" -f $app, $f.Name)
-        } else { Write-Host ("  [MISMATCH] {0}\{1}" -f $app, $f.Name); $bad++ }
+    foreach ($a in $srcApps) {
+        $dst = Join-Path (Join-Path $appsRoot $a.App) $a.File.Name
+        if (-not (Test-Path -LiteralPath $dst)) { Write-Host ("  [MISSING ] {0}\{1}" -f $a.App, $a.File.Name); $bad++; continue }
+        if ((Get-FileHash -LiteralPath $a.File.FullName -Algorithm SHA256).Hash -eq (Get-FileHash -LiteralPath $dst -Algorithm SHA256).Hash) {
+            Write-Host ("  [OK      ] {0}\{1}" -f $a.App, $a.File.Name)
+        } else { Write-Host ("  [MISMATCH] {0}\{1}" -f $a.App, $a.File.Name); $bad++ }
     }
+    if ($tmp) { Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue -WhatIf:$false -Confirm:$false }
     if ($bad -gt 0) { Write-Warning "$bad file(s) failed - re-copy, then eject/reconnect and verify again."; exit 1 }
     Write-Host "`nAll files verified against flash. Reboot the watch to refresh the launcher."
     return
@@ -163,26 +183,32 @@ if ($Verify) {
 # ===========================================================================
 # UPDATE / INSTALL
 # ===========================================================================
-$updated = @(); $installed = @(); $skipped = @()
-foreach ($f in $srcFiles) {
-    $app    = Get-AppName $f.Name
-    $appDir = Join-Path $appsRoot $app
+$updated = @(); $installed = @(); $skipped = @(); $failed = @()
+foreach ($a in $srcApps) {
+    $appDir = Join-Path $appsRoot $a.App
     $exists = Test-Path -LiteralPath $appDir -PathType Container
 
-    if (-not $exists -and -not $InstallNew) { $skipped += $app; Write-Host ("  [skip    ] {0} (not on watch; -InstallNew to add)" -f $app); continue }
+    if (-not $exists -and -not $InstallNew) { $skipped += $a.App; Write-Host ("  [skip    ] {0} (not on watch; -InstallNew to add)" -f $a.App); continue }
 
-    $dst    = Join-Path $appDir $f.Name
+    $dst    = Join-Path $appDir $a.File.Name
     $action = if ($exists) { 'update' } else { 'install' }
-    if ($PSCmdlet.ShouldProcess("$app  ->  $dst", $action)) {
+    if ($PSCmdlet.ShouldProcess("$($a.App)  ->  $dst", $action)) {
         if (-not $exists) { New-Item -ItemType Directory -Path $appDir -Force | Out-Null }
-        [System.IO.File]::Copy($f.FullName, $dst, $true)                       # new first, via .NET (not Copy-Item)
+        [System.IO.File]::Copy($a.File.FullName, $dst, $true)                  # new first, via .NET (not Copy-Item)
         $dstLen = (Get-Item -LiteralPath $dst).Length
-        if ($f.Length -ne $dstLen) { Write-Warning ("  size mismatch on {0}: src={1} dev={2} - copy may be bad" -f $app, $f.Length, $dstLen) }
-        Get-ChildItem -LiteralPath $appDir -Filter *.uapp -File | Where-Object { $_.Name -ne $f.Name } | ForEach-Object {
-            [System.IO.File]::Delete($_.FullName); Write-Host ("    removed old {0}" -f $_.Name)   # stale .uapp only; keep settings/Activity
+        if ($a.File.Length -ne $dstLen) {
+            # bad copy: remove the corrupt new file and KEEP the old .uapp so the app still works
+            Write-Warning ("  {0}: size mismatch (src={1} dev={2}) - bad copy; removed it, kept the existing .uapp" -f $a.App, $a.File.Length, $dstLen)
+            [System.IO.File]::Delete($dst)
+            $failed += $a.App
+            continue
         }
-        if ($exists) { $updated += $app } else { $installed += $app }
-        Write-Host ("  [{0,-8}] {1} -> {2}" -f $action, $app, $f.Name)
+        # copy validated -> now safe to remove stale .uapp(s); keep settings.json / Activity
+        Get-ChildItem -LiteralPath $appDir -Filter *.uapp -File | Where-Object { $_.Name -ne $a.File.Name } | ForEach-Object {
+            [System.IO.File]::Delete($_.FullName); Write-Host ("    removed old {0}" -f $_.Name)
+        }
+        if ($exists) { $updated += $a.App } else { $installed += $a.App }
+        Write-Host ("  [{0,-8}] {1} -> {2}" -f $action, $a.App, $a.File.Name)
     }
 }
 
@@ -190,18 +216,21 @@ Write-Host ""
 Write-Host ("Updated ({0}):   {1}" -f $updated.Count,   $(if ($updated)   { $updated   -join ', ' } else { '-' }))
 Write-Host ("Installed ({0}): {1}" -f $installed.Count, $(if ($installed) { $installed -join ', ' } else { '-' }))
 Write-Host ("Skipped ({0}):   {1}" -f $skipped.Count,   $(if ($skipped)   { $skipped   -join ', ' } else { '-' }))
+if ($failed.Count) { Write-Warning ("Failed ({0}):    {1}  (old .uapp left in place)" -f $failed.Count, ($failed -join ', ')) }
 Write-Host ""
 
-if ($Eject -and -not $WhatIfPreference) {
+if ($Eject -and $PSCmdlet.ShouldProcess($root, 'safely eject')) {
     Write-Host "Ejecting $root ..."
     if (Invoke-SafeEject $root) {
         Write-Host "Ejected. Reconnect the watch, then:"
-        Write-Host ("  .\Update-Watch-Apps.ps1 -Source '{0}' -Verify" -f $Source)
+        Write-Host ("  .\Update-Watch-Apps.ps1 -Source '{0}' -Verify" -f $origSource)
         Write-Host "and reboot the watch to rebuild the launcher."
     }
 } else {
     Write-Host "NEXT STEPS:"
     Write-Host "  1. Safely eject the watch (tray -> Safely Remove Hardware), then reconnect. (Or re-run with -Eject.)"
-    Write-Host ("  2. Verify flash:  .\Update-Watch-Apps.ps1 -Source '{0}' -Verify" -f $Source)
+    Write-Host ("  2. Verify flash:  .\Update-Watch-Apps.ps1 -Source '{0}' -Verify" -f $origSource)
     Write-Host "  3. Reboot the watch so it rebuilds the launcher / app list."
 }
+
+if ($tmp) { Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue }

--- a/Utilities/Scripts/Update-Watch-Apps.ps1
+++ b/Utilities/Scripts/Update-Watch-Apps.ps1
@@ -1,0 +1,207 @@
+<#
+.SYNOPSIS
+    Update Una-Watch apps over the USB (mass-storage) cable, preserving each app's
+    settings and activity data.
+
+.DESCRIPTION
+    Replaces the .uapp binary inside each on-device app folder (<Drive>:\Apps\<App>\)
+    with a newer build, WITHOUT touching that app's settings.json or Activity\ data.
+    Avoids the two painful options: (a) copy new .uapp + delete old, per app, or
+    (b) bulk-delete the app folders, which also wipes settings and activities.
+
+    Portable across machines: the watch is found by its VOLUME LABEL ("UNA WATCH"),
+    not a hard-coded drive letter, so it works whatever letter it mounts as and on
+    anyone's PC. Works on Windows PowerShell 5.1+ (built in) and PowerShell 7.
+
+    The watch scans <Drive>:\Apps\<App>\ on boot and uses the FIRST .uapp it finds
+    in each folder, so this removes any stale .uapp and leaves exactly one.
+
+    Device notes handled / warned about:
+      * Copy uses [System.IO.File]::Copy, NOT Copy-Item (scripted Copy-Item to this
+        removable volume has produced silent bit-level corruption).
+      * The new .uapp is copied BEFORE the old is removed (a failed copy never
+        leaves you with nothing).
+      * A hash taken right after copying reads the Windows write cache and can be a
+        false OK; -Verify is only trustworthy after the volume is ejected (or use
+        -Eject, which flushes + removes it).
+      * The launcher / app list rebuilds only at boot -> reboot the watch after.
+      * A .uapp that fails the kernel CRC is silently dropped (app just won't appear).
+      * D:\Apps also contains "SharedData" (not an app); update-only-by-source means
+        it is never touched.
+
+.PARAMETER Source
+    Folder containing the new <App>_<version>.uapp files (e.g. an extracted
+    una-apps-<tag>.zip).
+
+.PARAMETER Drive
+    The watch's USB drive, e.g. E: - overrides label auto-detection.
+
+.PARAMETER Label
+    Volume label to match when auto-detecting the watch. Default: "UNA WATCH".
+
+.PARAMETER InstallNew
+    Also install apps present in -Source but not yet on the watch. Default: only
+    UPDATE apps already on the watch.
+
+.PARAMETER Verify
+    Compare SHA-256 of each on-device .uapp against the source and report
+    mismatches. Run AFTER ejecting + reconnecting the watch (or after -Eject +
+    reconnect) so it reads cold flash, not the write cache.
+
+.PARAMETER Eject
+    After copying, safely eject (flush + remove) the volume. Reconnect the watch,
+    then re-run with -Verify.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\Update-Watch-Apps.ps1 -Source .\una-apps-apps-v1.3.0-rc3 -WhatIf
+.EXAMPLE
+    .\Update-Watch-Apps.ps1 -Source .\una-apps-apps-v1.3.0-rc3 -Eject
+    # reconnect the watch, then:
+    .\Update-Watch-Apps.ps1 -Source .\una-apps-apps-v1.3.0-rc3 -Verify
+#>
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+param(
+    [Parameter(Mandatory)][string]$Source,
+    [string]$Drive,
+    [string]$Label = 'UNA WATCH',
+    [switch]$InstallNew,
+    [switch]$Verify,
+    [switch]$Eject
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+# ---- source files ----------------------------------------------------------
+if (-not (Test-Path -LiteralPath $Source -PathType Container)) { throw "Source folder not found: $Source" }
+$srcFiles = @(Get-ChildItem -LiteralPath $Source -Filter *.uapp -File)
+if ($srcFiles.Count -eq 0) { throw "No .uapp files found in $Source (point -Source at the folder holding them)." }
+
+# ---- resolve the watch drive (label -> -Drive -> \Apps fallback) -----------
+function Resolve-WatchDrive {
+    param([string]$Drive, [string]$Label)
+    if ($Drive) {
+        $r = ($Drive.TrimEnd('\', ':') + ':\')
+        if (-not (Test-Path -LiteralPath (Join-Path $r 'Apps'))) { Write-Warning "No \Apps folder on $r - is that the watch drive?" }
+        return $r
+    }
+    $vols = @(Get-Volume -ErrorAction SilentlyContinue | Where-Object { $_.FileSystemLabel -eq $Label -and $_.DriveLetter })
+    if ($vols.Count -eq 1) { return ("{0}:\" -f $vols[0].DriveLetter) }
+    if ($vols.Count -gt 1) { throw ("Multiple volumes labelled '$Label': {0}. Pass -Drive." -f (($vols.DriveLetter) -join ', ')) }
+    # fallback: a drive that has an \Apps folder
+    $cands = @(Get-PSDrive -PSProvider FileSystem | Where-Object { $_.Root -match '^[A-Za-z]:\\$' -and (Test-Path -LiteralPath (Join-Path $_.Root 'Apps')) })
+    if ($cands.Count -eq 1) { Write-Warning "No volume labelled '$Label'; using $($cands[0].Root) (it has an \Apps folder)."; return $cands[0].Root }
+    throw "Could not find the watch (no volume labelled '$Label', no unambiguous \Apps drive). Connect it, or pass -Drive."
+}
+$root     = Resolve-WatchDrive -Drive $Drive -Label $Label
+$appsRoot = Join-Path $root 'Apps'
+if (-not (Test-Path -LiteralPath $appsRoot)) { throw "No Apps folder at $appsRoot." }
+Write-Host "Watch apps folder: $appsRoot"
+
+# ---- <App>_<version>.uapp  ->  <App> --------------------------------------
+function Get-AppName([string]$fileName) {
+    if ($fileName -match '^(?<name>.+?)_\d[\w.\-]*\.uapp$') { return $Matches['name'] }
+    return [IO.Path]::GetFileNameWithoutExtension($fileName)
+}
+
+# ---- locale-independent safe eject (P/Invoke storage IOCTLs) --------------
+function Invoke-SafeEject([string]$root) {
+    $letter = ($root.TrimEnd('\')).TrimEnd(':')
+    if (-not ([System.Management.Automation.PSTypeName]'Una.VolumeEject').Type) {
+        Add-Type -Namespace Una -Name VolumeEject -Language CSharp -MemberDefinition @'
+    using System;
+    using System.Runtime.InteropServices;
+    using Microsoft.Win32.SafeHandles;
+    const uint GENERIC_RW = 0x80000000 | 0x40000000, SHARE_RW = 0x1 | 0x2, OPEN_EXISTING = 3;
+    const uint FSCTL_LOCK_VOLUME = 0x00090018, FSCTL_DISMOUNT_VOLUME = 0x00090020;
+    const uint IOCTL_MEDIA_REMOVAL = 0x002D4804, IOCTL_EJECT_MEDIA = 0x002D4808;
+    [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern SafeFileHandle CreateFile(string n, uint a, uint s, IntPtr sec, uint d, uint f, IntPtr t);
+    [DllImport("kernel32", SetLastError = true)]
+    static extern bool DeviceIoControl(SafeFileHandle h, uint code, byte[] ib, uint ibl, byte[] ob, uint obl, out uint br, IntPtr ov);
+    public static string Eject(char letter) {
+        var h = CreateFile(@"\\.\" + letter + ":", GENERIC_RW, SHARE_RW, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+        if (h.IsInvalid) return "open failed (err " + Marshal.GetLastWin32Error() + ")";
+        try {
+            uint br; bool locked = false;
+            for (int i = 0; i < 12 && !locked; i++) { locked = DeviceIoControl(h, FSCTL_LOCK_VOLUME, null, 0, null, 0, out br, IntPtr.Zero); if (!locked) System.Threading.Thread.Sleep(250); }
+            if (!locked) return "lock failed - files still open on the volume";
+            if (!DeviceIoControl(h, FSCTL_DISMOUNT_VOLUME, null, 0, null, 0, out br, IntPtr.Zero)) return "dismount failed (err " + Marshal.GetLastWin32Error() + ")";
+            DeviceIoControl(h, IOCTL_MEDIA_REMOVAL, new byte[] { 0 }, 1, null, 0, out br, IntPtr.Zero); // allow removal
+            if (!DeviceIoControl(h, IOCTL_EJECT_MEDIA, null, 0, null, 0, out br, IntPtr.Zero)) return "eject failed (err " + Marshal.GetLastWin32Error() + ")";
+            return "OK";
+        } finally { h.Close(); }
+    }
+'@
+    }
+    $res = [Una.VolumeEject]::Eject([char]$letter)
+    if ($res -ne 'OK') { Write-Warning "Auto-eject failed: $res. Eject $letter`: manually via the tray."; return $false }
+    for ($i = 0; $i -lt 20; $i++) { Start-Sleep -Milliseconds 500; if (-not (Test-Path -LiteralPath $root)) { return $true } }
+    Write-Warning "$letter`: still present after eject. Eject it manually via the tray."; return $false
+}
+
+# ===========================================================================
+# VERIFY mode
+# ===========================================================================
+if ($Verify) {
+    Write-Host "`nVerify - ensure you EJECTED and RECONNECTED the watch first, else this reads"
+    Write-Host "the Windows write cache and can report a false OK.`n"
+    $bad = 0
+    foreach ($f in $srcFiles) {
+        $app = Get-AppName $f.Name
+        $dst = Join-Path (Join-Path $appsRoot $app) $f.Name
+        if (-not (Test-Path -LiteralPath $dst)) { Write-Host ("  [MISSING ] {0}\{1}" -f $app, $f.Name); $bad++; continue }
+        if ((Get-FileHash -LiteralPath $f.FullName -Algorithm SHA256).Hash -eq (Get-FileHash -LiteralPath $dst -Algorithm SHA256).Hash) {
+            Write-Host ("  [OK      ] {0}\{1}" -f $app, $f.Name)
+        } else { Write-Host ("  [MISMATCH] {0}\{1}" -f $app, $f.Name); $bad++ }
+    }
+    if ($bad -gt 0) { Write-Warning "$bad file(s) failed - re-copy, then eject/reconnect and verify again."; exit 1 }
+    Write-Host "`nAll files verified against flash. Reboot the watch to refresh the launcher."
+    return
+}
+
+# ===========================================================================
+# UPDATE / INSTALL
+# ===========================================================================
+$updated = @(); $installed = @(); $skipped = @()
+foreach ($f in $srcFiles) {
+    $app    = Get-AppName $f.Name
+    $appDir = Join-Path $appsRoot $app
+    $exists = Test-Path -LiteralPath $appDir -PathType Container
+
+    if (-not $exists -and -not $InstallNew) { $skipped += $app; Write-Host ("  [skip    ] {0} (not on watch; -InstallNew to add)" -f $app); continue }
+
+    $dst    = Join-Path $appDir $f.Name
+    $action = if ($exists) { 'update' } else { 'install' }
+    if ($PSCmdlet.ShouldProcess("$app  ->  $dst", $action)) {
+        if (-not $exists) { New-Item -ItemType Directory -Path $appDir -Force | Out-Null }
+        [System.IO.File]::Copy($f.FullName, $dst, $true)                       # new first, via .NET (not Copy-Item)
+        $dstLen = (Get-Item -LiteralPath $dst).Length
+        if ($f.Length -ne $dstLen) { Write-Warning ("  size mismatch on {0}: src={1} dev={2} - copy may be bad" -f $app, $f.Length, $dstLen) }
+        Get-ChildItem -LiteralPath $appDir -Filter *.uapp -File | Where-Object { $_.Name -ne $f.Name } | ForEach-Object {
+            [System.IO.File]::Delete($_.FullName); Write-Host ("    removed old {0}" -f $_.Name)   # stale .uapp only; keep settings/Activity
+        }
+        if ($exists) { $updated += $app } else { $installed += $app }
+        Write-Host ("  [{0,-8}] {1} -> {2}" -f $action, $app, $f.Name)
+    }
+}
+
+Write-Host ""
+Write-Host ("Updated ({0}):   {1}" -f $updated.Count,   $(if ($updated)   { $updated   -join ', ' } else { '-' }))
+Write-Host ("Installed ({0}): {1}" -f $installed.Count, $(if ($installed) { $installed -join ', ' } else { '-' }))
+Write-Host ("Skipped ({0}):   {1}" -f $skipped.Count,   $(if ($skipped)   { $skipped   -join ', ' } else { '-' }))
+Write-Host ""
+
+if ($Eject -and -not $WhatIfPreference) {
+    Write-Host "Ejecting $root ..."
+    if (Invoke-SafeEject $root) {
+        Write-Host "Ejected. Reconnect the watch, then:"
+        Write-Host ("  .\Update-Watch-Apps.ps1 -Source '{0}' -Verify" -f $Source)
+        Write-Host "and reboot the watch to rebuild the launcher."
+    }
+} else {
+    Write-Host "NEXT STEPS:"
+    Write-Host "  1. Safely eject the watch (tray -> Safely Remove Hardware), then reconnect. (Or re-run with -Eject.)"
+    Write-Host ("  2. Verify flash:  .\Update-Watch-Apps.ps1 -Source '{0}' -Verify" -f $Source)
+    Write-Host "  3. Reboot the watch so it rebuilds the launcher / app list."
+}

--- a/Utilities/Scripts/Update-Watch-Apps.ps1
+++ b/Utilities/Scripts/Update-Watch-Apps.ps1
@@ -121,42 +121,118 @@ $appsRoot = Join-Path $root 'Apps'
 if (-not (Test-Path -LiteralPath $appsRoot)) { throw "No Apps folder at $appsRoot." }
 Write-Host "Watch apps folder: $appsRoot  ($($srcApps.Count) apps in source)"
 
-# ---- locale-independent safe eject (P/Invoke storage IOCTLs) --------------
+# ---- locale-independent safe eject (P/Invoke) ------------------------------
+# The watch is a USB *composite* device, so IOCTL_STORAGE_EJECT_MEDIA on the
+# volume only flushes -- it doesn't take the drive offline (the device just
+# re-presents its media). A true "Safely Remove" is CM_Request_Device_Eject on
+# the removable USB devnode: map the drive letter -> disk device number -> its
+# devnode, then eject that node or the first ejectable ancestor up the tree.
 function Invoke-SafeEject([string]$root) {
     $letter = ($root.TrimEnd('\')).TrimEnd(':')
-    if (-not ([System.Management.Automation.PSTypeName]'Una.VolumeEject').Type) {
+    if (-not ([System.Management.Automation.PSTypeName]'Una.DeviceEject').Type) {
         # -TypeDefinition (full namespace/class) so the `using` directives are legal.
         Add-Type -TypeDefinition @'
 using System;
+using System.Text;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 namespace Una {
-    public static class VolumeEject {
-        const uint GENERIC_RW = 0x80000000 | 0x40000000, SHARE_RW = 0x1 | 0x2, OPEN_EXISTING = 3;
+    public static class DeviceEject {
+        const uint SHARE_RW = 0x1 | 0x2, OPEN_EXISTING = 3, GENERIC_RW = 0x80000000 | 0x40000000;
+        const uint IOCTL_STORAGE_GET_DEVICE_NUMBER = 0x2D1080;
         const uint FSCTL_LOCK_VOLUME = 0x00090018, FSCTL_DISMOUNT_VOLUME = 0x00090020;
-        const uint IOCTL_MEDIA_REMOVAL = 0x002D4804, IOCTL_EJECT_MEDIA = 0x002D4808;
+        const int DIGCF_PRESENT = 0x2, DIGCF_DEVICEINTERFACE = 0x10;
+        static Guid GUID_DISK = new Guid("53f56307-b6bf-11d0-94f2-00a0c91efb8b");
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct STORAGE_DEVICE_NUMBER { public int DeviceType; public uint DeviceNumber; public uint PartitionNumber; }
+        [StructLayout(LayoutKind.Sequential)]
+        struct SP_DEVICE_INTERFACE_DATA { public int cbSize; public Guid guid; public int Flags; public IntPtr Reserved; }
+        [StructLayout(LayoutKind.Sequential)]
+        struct SP_DEVINFO_DATA { public int cbSize; public Guid ClassGuid; public uint DevInst; public IntPtr Reserved; }
+
         [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
         static extern SafeFileHandle CreateFile(string n, uint a, uint s, IntPtr sec, uint d, uint f, IntPtr t);
         [DllImport("kernel32", SetLastError = true)]
-        static extern bool DeviceIoControl(SafeFileHandle h, uint code, byte[] ib, uint ibl, byte[] ob, uint obl, out uint br, IntPtr ov);
-        public static string Eject(char letter) {
-            var h = CreateFile(@"\\.\" + letter + ":", GENERIC_RW, SHARE_RW, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
-            if (h.IsInvalid) return "open failed (err " + Marshal.GetLastWin32Error() + ")";
+        static extern bool DeviceIoControl(SafeFileHandle h, uint code, IntPtr ib, uint ibl, IntPtr ob, uint obl, out uint br, IntPtr ov);
+        [DllImport("setupapi", SetLastError = true)]
+        static extern IntPtr SetupDiGetClassDevs(ref Guid g, IntPtr en, IntPtr hwnd, int flags);
+        [DllImport("setupapi", SetLastError = true)]
+        static extern bool SetupDiEnumDeviceInterfaces(IntPtr h, IntPtr di, ref Guid g, int idx, ref SP_DEVICE_INTERFACE_DATA d);
+        [DllImport("setupapi", SetLastError = true, CharSet = CharSet.Unicode)]
+        static extern bool SetupDiGetDeviceInterfaceDetail(IntPtr h, ref SP_DEVICE_INTERFACE_DATA d, IntPtr det, int detSize, ref int req, ref SP_DEVINFO_DATA info);
+        [DllImport("setupapi", SetLastError = true)]
+        static extern bool SetupDiDestroyDeviceInfoList(IntPtr h);
+        [DllImport("cfgmgr32")]
+        static extern int CM_Get_Parent(out uint parent, uint dev, int flags);
+        [DllImport("cfgmgr32", CharSet = CharSet.Unicode)]
+        static extern int CM_Request_Device_EjectW(uint dev, out int veto, StringBuilder name, int len, int flags);
+
+        static uint DeviceNumberOf(string path) {
+            var h = CreateFile(path, 0, SHARE_RW, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+            if (h.IsInvalid) return 0xFFFFFFFF;
             try {
-                uint br; bool locked = false;
-                for (int i = 0; i < 12 && !locked; i++) { locked = DeviceIoControl(h, FSCTL_LOCK_VOLUME, null, 0, null, 0, out br, IntPtr.Zero); if (!locked) System.Threading.Thread.Sleep(250); }
-                if (!locked) return "lock failed - files still open on the volume";
-                if (!DeviceIoControl(h, FSCTL_DISMOUNT_VOLUME, null, 0, null, 0, out br, IntPtr.Zero)) return "dismount failed (err " + Marshal.GetLastWin32Error() + ")";
-                DeviceIoControl(h, IOCTL_MEDIA_REMOVAL, new byte[] { 0 }, 1, null, 0, out br, IntPtr.Zero);
-                if (!DeviceIoControl(h, IOCTL_EJECT_MEDIA, null, 0, null, 0, out br, IntPtr.Zero)) return "eject failed (err " + Marshal.GetLastWin32Error() + ")";
-                return "OK";
+                int sz = Marshal.SizeOf(typeof(STORAGE_DEVICE_NUMBER));
+                IntPtr buf = Marshal.AllocHGlobal(sz);
+                try {
+                    uint br;
+                    if (!DeviceIoControl(h, IOCTL_STORAGE_GET_DEVICE_NUMBER, IntPtr.Zero, 0, buf, (uint)sz, out br, IntPtr.Zero)) return 0xFFFFFFFF;
+                    return ((STORAGE_DEVICE_NUMBER)Marshal.PtrToStructure(buf, typeof(STORAGE_DEVICE_NUMBER))).DeviceNumber;
+                } finally { Marshal.FreeHGlobal(buf); }
             } finally { h.Close(); }
+        }
+
+        public static string Eject(char letter) {
+            string vol = @"\\.\" + letter + ":";
+            // flush + dismount first (also makes a later -Verify read cold flash)
+            var vh = CreateFile(vol, GENERIC_RW, SHARE_RW, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+            if (!vh.IsInvalid) {
+                uint br; bool locked = false;
+                for (int i = 0; i < 12 && !locked; i++) { locked = DeviceIoControl(vh, FSCTL_LOCK_VOLUME, IntPtr.Zero, 0, IntPtr.Zero, 0, out br, IntPtr.Zero); if (!locked) System.Threading.Thread.Sleep(250); }
+                DeviceIoControl(vh, FSCTL_DISMOUNT_VOLUME, IntPtr.Zero, 0, IntPtr.Zero, 0, out br, IntPtr.Zero);
+                vh.Close();
+            }
+
+            uint num = DeviceNumberOf(vol);
+            if (num == 0xFFFFFFFF) return "could not read the volume's device number";
+
+            IntPtr hDev = SetupDiGetClassDevs(ref GUID_DISK, IntPtr.Zero, IntPtr.Zero, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+            if (hDev == new IntPtr(-1)) return "SetupDiGetClassDevs failed";
+            try {
+                var did = new SP_DEVICE_INTERFACE_DATA(); did.cbSize = Marshal.SizeOf(did);
+                for (int i = 0; SetupDiEnumDeviceInterfaces(hDev, IntPtr.Zero, ref GUID_DISK, i, ref did); i++) {
+                    int req = 0; var info = new SP_DEVINFO_DATA(); info.cbSize = Marshal.SizeOf(info);
+                    SetupDiGetDeviceInterfaceDetail(hDev, ref did, IntPtr.Zero, 0, ref req, ref info);
+                    IntPtr det = Marshal.AllocHGlobal(req);
+                    try {
+                        Marshal.WriteInt32(det, IntPtr.Size == 8 ? 8 : 6);   // cbSize of SP_DEVICE_INTERFACE_DETAIL_DATA
+                        info = new SP_DEVINFO_DATA(); info.cbSize = Marshal.SizeOf(info);
+                        if (!SetupDiGetDeviceInterfaceDetail(hDev, ref did, det, req, ref req, ref info)) continue;
+                        string path = Marshal.PtrToStringUni(new IntPtr(det.ToInt64() + 4));
+                        if (DeviceNumberOf(path) != num) continue;
+                        // our disk: eject it, or the first ejectable ancestor up the USB tree
+                        var diag = new StringBuilder();
+                        uint target = info.DevInst;
+                        for (int up = 0; up < 8; up++) {
+                            int veto = -1; var sb = new StringBuilder(300);
+                            int cr = CM_Request_Device_EjectW(target, out veto, sb, 300, 0);
+                            if (cr == 0 && veto == 0) return "OK";
+                            diag.Append(String.Format("[cr={0} veto={1} {2}] ", cr, veto, sb.ToString()));
+                            uint parent;
+                            if (CM_Get_Parent(out parent, target, 0) != 0) break;
+                            target = parent;
+                        }
+                        return "removal vetoed " + diag.ToString();
+                    } finally { Marshal.FreeHGlobal(det); }
+                }
+                return "disk devnode not found for device number " + num;
+            } finally { SetupDiDestroyDeviceInfoList(hDev); }
         }
     }
 }
 '@
     }
-    $res = [Una.VolumeEject]::Eject([char]$letter)
+    $res = [Una.DeviceEject]::Eject([char]$letter)
     if ($res -ne 'OK') { Write-Warning "Auto-eject failed: $res. Eject $letter`: manually via the tray."; return $false }
     for ($i = 0; $i -lt 20; $i++) { Start-Sleep -Milliseconds 500; if (-not (Test-Path -LiteralPath $root)) { return $true } }
     Write-Warning "$letter`: still present after eject. Eject it manually via the tray."; return $false

--- a/Utilities/Scripts/Update-Watch-Apps.ps1
+++ b/Utilities/Scripts/Update-Watch-Apps.ps1
@@ -80,7 +80,9 @@ $tmp = $null              # temp extract dir (cleaned up at the end) if -Source 
 if (Test-Path -LiteralPath $Source -PathType Leaf) {
     if ($Source -notmatch '\.zip$') { throw "Source must be a folder or a .zip: $Source" }
     $tmp = Join-Path ([IO.Path]::GetTempPath()) ('uapp-src-' + [Guid]::NewGuid().ToString('N'))
-    Expand-Archive -LiteralPath $Source -DestinationPath $tmp -Force
+    Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue   # PS 5.1 needs this; PS 7 has it built in
+    # .NET extraction (creates $tmp) - no cmdlet ShouldProcess/prompt, so it works non-interactively and under -WhatIf
+    [System.IO.Compression.ZipFile]::ExtractToDirectory((Resolve-Path -LiteralPath $Source).Path, $tmp)
     $Source = $tmp
 } elseif (-not (Test-Path -LiteralPath $Source -PathType Container)) {
     throw "Source not found: $Source"
@@ -104,7 +106,7 @@ function Resolve-WatchDrive {
         if (-not (Test-Path -LiteralPath (Join-Path $r 'Apps'))) { Write-Warning "No \Apps folder on $r - is that the watch drive?" }
         return $r
     }
-    $vols = @(Get-Volume -ErrorAction SilentlyContinue | Where-Object { $_.FileSystemLabel -eq $Label -and $_.DriveLetter })
+    $vols = @(Get-Volume -ErrorAction SilentlyContinue | Where-Object { $_.FileSystemLabel -eq $Label -and $_.DriveLetter -and $_.DriveType -eq 'Removable' })
     if ($vols.Count -eq 1) { return ("{0}:\" -f $vols[0].DriveLetter) }
     if ($vols.Count -gt 1) { throw ("Multiple volumes labelled '$Label': {0}. Pass -Drive." -f (($vols.DriveLetter) -join ', ')) }
     # fallback: a REMOVABLE drive with an \Apps folder (never a fixed drive like C:\Apps)
@@ -166,14 +168,17 @@ namespace Una {
 if ($Verify) {
     Write-Host "`nVerify - ensure you EJECTED and RECONNECTED the watch first, else this reads"
     Write-Host "the Windows write cache and can report a false OK.`n"
-    $bad = 0
+    $bad = 0; $na = 0
     foreach ($a in $srcApps) {
-        $dst = Join-Path (Join-Path $appsRoot $a.App) $a.File.Name
+        $appDir = Join-Path $appsRoot $a.App
+        if (-not (Test-Path -LiteralPath $appDir -PathType Container)) { Write-Host ("  [n/a     ] {0} (not installed - skipped)" -f $a.App); $na++; continue }
+        $dst = Join-Path $appDir $a.File.Name
         if (-not (Test-Path -LiteralPath $dst)) { Write-Host ("  [MISSING ] {0}\{1}" -f $a.App, $a.File.Name); $bad++; continue }
         if ((Get-FileHash -LiteralPath $a.File.FullName -Algorithm SHA256).Hash -eq (Get-FileHash -LiteralPath $dst -Algorithm SHA256).Hash) {
             Write-Host ("  [OK      ] {0}\{1}" -f $a.App, $a.File.Name)
         } else { Write-Host ("  [MISMATCH] {0}\{1}" -f $a.App, $a.File.Name); $bad++ }
     }
+    if ($na -gt 0) { Write-Host ("  ($na source app(s) not installed on the watch - skipped)") }
     if ($tmp) { Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue -WhatIf:$false -Confirm:$false }
     if ($bad -gt 0) { Write-Warning "$bad file(s) failed - re-copy, then eject/reconnect and verify again."; exit 1 }
     Write-Host "`nAll files verified against flash. Reboot the watch to refresh the launcher."
@@ -193,15 +198,21 @@ foreach ($a in $srcApps) {
     $dst    = Join-Path $appDir $a.File.Name
     $action = if ($exists) { 'update' } else { 'install' }
     if ($PSCmdlet.ShouldProcess("$($a.App)  ->  $dst", $action)) {
-        if (-not $exists) { New-Item -ItemType Directory -Path $appDir -Force | Out-Null }
-        [System.IO.File]::Copy($a.File.FullName, $dst, $true)                  # new first, via .NET (not Copy-Item)
+        if (-not $exists) { [System.IO.Directory]::CreateDirectory($appDir) | Out-Null }   # .NET (no prompt in non-interactive)
+        try { [System.IO.File]::Copy($a.File.FullName, $dst, $true) }          # new first, via .NET (not Copy-Item)
+        catch {
+            Write-Warning ("  {0}: copy failed ({1}); removing any partial file" -f $a.App, $_.Exception.Message)
+            if (Test-Path -LiteralPath $dst) { [System.IO.File]::Delete($dst) }
+            $failed += $a.App; continue
+        }
         $dstLen = (Get-Item -LiteralPath $dst).Length
         if ($a.File.Length -ne $dstLen) {
-            # bad copy: remove the corrupt new file and KEEP the old .uapp so the app still works
-            Write-Warning ("  {0}: size mismatch (src={1} dev={2}) - bad copy; removed it, kept the existing .uapp" -f $a.App, $a.File.Length, $dstLen)
+            # bad copy: remove the corrupt new file; do NOT delete any stale .uapp
             [System.IO.File]::Delete($dst)
-            $failed += $a.App
-            continue
+            $remain = @(Get-ChildItem -LiteralPath $appDir -Filter *.uapp -File)
+            if ($remain.Count -eq 0) { Write-Warning ("  {0}: size mismatch - bad copy removed; NO valid .uapp remains, re-run to reinstall (settings/Activity preserved)" -f $a.App) }
+            else { Write-Warning ("  {0}: size mismatch - bad copy removed; kept existing {1}" -f $a.App, $remain[0].Name) }
+            $failed += $a.App; continue
         }
         # copy validated -> now safe to remove stale .uapp(s); keep settings.json / Activity
         Get-ChildItem -LiteralPath $appDir -Filter *.uapp -File | Where-Object { $_.Name -ne $a.File.Name } | ForEach-Object {
@@ -233,4 +244,4 @@ if ($Eject -and $PSCmdlet.ShouldProcess($root, 'safely eject')) {
     Write-Host "  3. Reboot the watch so it rebuilds the launcher / app list."
 }
 
-if ($tmp) { Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue }
+if ($tmp) { Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue -WhatIf:$false -Confirm:$false }


### PR DESCRIPTION
Adds `Utilities/Scripts/Update-Watch-Apps.ps1` — updates the watch's apps over the USB cable **in place**, replacing each app's `.uapp` while preserving its `settings.json` and `Activity\` data. Removes the two bad options: manual per-app copy+delete, or a bulk folder wipe that also destroys user data.

**Highlights**
- **Portable across machines:** finds the watch by **volume label `UNA WATCH`** (the label rides with the watch, so it works at any drive letter, on anyone's PC). `-Drive` override + `\Apps` fallback for edge cases.
- **Preserves data:** copies the new `.uapp`, then removes only stale `.uapp`s — leaves `settings.json` / `Activity\` alone. (`SharedData` is never touched — it's not a source app.)
- **Update-only by default** (`-InstallNew` to add apps not yet on the watch).
- **Handles the device gotchas:** uses `[System.IO.File]::Copy` (scripted `Copy-Item` to this volume has corrupted writes); copies new-before-deleting-old; keeps exactly one `.uapp` per folder (the boot scanner uses the first it finds).
- **`-Eject`:** locale-independent safe-eject via storage IOCTLs (`FSCTL_LOCK`/`DISMOUNT` + `IOCTL_STORAGE_EJECT_MEDIA`), which also flushes the write cache.
- **`-Verify`:** SHA-256 of on-device `.uapp`s vs source — trustworthy only after eject+reconnect (a hash right after copy reads the Windows write cache).
- **`-WhatIf`** supported; Windows PowerShell 5.1+ compatible.

**Testing:** syntax-validated and dry-run (`-WhatIf`) against a real watch — label detection, update/skip, and app-name mapping confirmed. The copy/delete and eject paths are destructive so were **not** exercised live yet; a full end-to-end run on a device is recommended before relying on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a PowerShell utility to update watch apps from `.uapp` files, using either an extracted folder or a provided `.zip`.
  - Automatically finds the connected watch (or uses a specified drive/label) and preserves each app’s `settings.json` and `Activity/` data.
  - Added a **Verify** mode using SHA-256 checks to detect missing or mismatched files.
  - Added optional **install-new** behavior and **safe USB eject** after updates.
  - Supports **confirmation/preview** (e.g., WhatIf) and reports updated, installed, skipped, and failed apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->