### PR TITLE
ci(apps): don't let a distro security-mirror outage hang the app builds

### DIFF
--- a/.github/workflows/apps-ci.yml
+++ b/.github/workflows/apps-ci.yml
@@ -18,7 +18,9 @@ jobs:
       apps: ${{ steps.generate.outputs.apps }}
     steps:
       - name: Setup GIT
-        run: apt update && apt install -y git jq
+        # Debian base image (python:3.11-slim) — not affected by the Ubuntu security
+        # mirror; the cmake-build job repoints security.ubuntu.com for that reason.
+        run: apt-get update && apt-get install -y git jq
 
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -40,7 +42,14 @@ jobs:
         app: ${{ fromJson(needs.prepare.outputs.apps) }}
     steps:
       - name: Setup GIT
-        run: apt update && apt install -y git python3-full python3-pip python-is-python3 cmake
+        run: |
+          # security.ubuntu.com has a history of outages that hang `apt update` for the
+          # whole job (a bounded timeout doesn't reliably help — apt won't cap a blackholed
+          # multi-IP host). Repoint the security pocket at the main archive, which carries
+          # -security too and stays up, so setup never depends on that CDN.
+          find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) \
+            -exec sed -i 's#security\.ubuntu\.com/ubuntu#archive.ubuntu.com/ubuntu#g' {} +
+          apt-get update && apt-get install -y git python3-full python3-pip python-is-python3 cmake
 
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5


### PR DESCRIPTION
## Problem
The `cmake-build` matrix job runs inside the Ubuntu-based `xanderhendriks/stm32cubeide:16.0` container. Its `Setup GIT` step runs `apt update && apt install -y git python3-full python3-pip python-is-python3 cmake` (the base image ships none of these). `apt update` refreshes **every** pocket including `security.ubuntu.com`. During the 2026-07-22 `security.ubuntu.com` major outage the app-build matrix hung until the job timeout — it wedged the `apps-v1.3.0-rc4` and `apps-v1.3.0` stable runs; cancel+rerun just re-hung.

## Fix
Those packages all live in the **main archive** (`archive.ubuntu.com`), which carries the `-security` pocket too and stayed operational. So repoint the security pocket at the main archive before `apt update`, removing the dependency on that CDN:

```sh
find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) \
  -exec sed -i 's#security\.ubuntu\.com/ubuntu#archive.ubuntu.com/ubuntu#g' {} +
apt-get update && apt-get install -y git python3-full python3-pip python-is-python3 cmake
```

The `prepare` job runs on a Debian base (`python:3.11-slim`) — not affected by the Ubuntu security mirror — so it just reverts to plain `apt-get`.

> Note: an earlier revision tried a bounded `apt` timeout, but that proved insufficient in the live outage (apt won't reliably cap a blackholed multi-IP host), so this repoints instead.

CI-plumbing only — **no app-binary impact**. Companion kernel-side change: UNAWatch/una-kernel#244.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build workflow package-install steps to use `apt-get` for more consistent Ubuntu dependency installation.
  * Adjusted the CI “cmake-build” package mirror configuration to route Ubuntu security packages via the archive mirror before installing build dependencies.
  * Improved inline explanations in the workflow to clarify the Ubuntu mirror context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->