### PR TITLE
refactor(apps): retire the per-app Sender with SDK helper

### DIFF
--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -64,7 +64,6 @@ public:
 private:
     ModelListener*        modelListener;
     const SDK::Kernel&    mKernel;
-    CustomMessage::Sender mSrvSender;
 
     // IGuiLifeCycleCallback
     void onStart()   override;

--- a/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Alarm/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -1,4 +1,5 @@
 #include <gui/model/Model.hpp>
+#include "SDK/Messages/MessageGuard.hpp"
 #include <gui/model/ModelListener.hpp>
 #include <gui/common/FrontendApplication.hpp>
 
@@ -12,7 +13,6 @@
 Model::Model()
     : modelListener(nullptr)
     , mKernel(SDK::KernelProviderGUI::GetInstance().getKernel())
-    , mSrvSender(mKernel)
 {
     SDK::TouchGFXCommandProcessor::GetInstance().setAppLifeCycleCallback(this);
     SDK::TouchGFXCommandProcessor::GetInstance().setCustomMessageHandler(this);
@@ -104,20 +104,20 @@ const Alarm& Model::getActiveAlarm() const
 void Model::playAlarm()
 {
     LOG_DEBUG("called\n");
-    mSrvSender.activateEffect(mActiveAlarm);
+    SDK::send_msg<CustomMessage::AlarmActivateEffect>(mKernel, mActiveAlarm);
 }
 
 void Model::stopAlarm()
 {
     LOG_DEBUG("called\n");
-    mSrvSender.stopAll();
+    SDK::send_msg<CustomMessage::AlarmStopAll>(mKernel);
     mActiveAlarm = {};
 }
 
 void Model::snoozeAlarm()
 {
     LOG_DEBUG("called\n");
-    mSrvSender.snoozeAll();
+    SDK::send_msg<CustomMessage::AlarmSnoozeAll>(mKernel);
     mActiveAlarm = {};
 }
 
@@ -145,7 +145,7 @@ void Model::saveAlarm(size_t id, Alarm alarm)
 
     if (id < mAlarmList.size()) {
         mAlarmList[id] = alarm;
-        mSrvSender.listUpd(mAlarmList);
+        SDK::send_msg<CustomMessage::AlarmList>(mKernel, mAlarmList);
         modelListener->onAlarmListUpdated(mAlarmList);
         return;
     }
@@ -156,14 +156,14 @@ void Model::saveAlarm(size_t id, Alarm alarm)
             if (mAlarmList[i] == alarm) {
                 mEditAlarmId  = i;
                 mAlarmList[i] = alarm;
-                mSrvSender.listUpd(mAlarmList);
+                SDK::send_msg<CustomMessage::AlarmList>(mKernel, mAlarmList);
                 modelListener->onAlarmListUpdated(mAlarmList);
                 return;
             }
         }
 
         mAlarmList.push_back(alarm);
-        mSrvSender.listUpd(mAlarmList);
+        SDK::send_msg<CustomMessage::AlarmList>(mKernel, mAlarmList);
     }
 }
 
@@ -173,7 +173,7 @@ void Model::deleteAlarm(size_t id)
         return;
     }
     mAlarmList.erase(mAlarmList.begin() + id);
-    mSrvSender.listUpd(mAlarmList);
+    SDK::send_msg<CustomMessage::AlarmList>(mKernel, mAlarmList);
     modelListener->onAlarmListUpdated(mAlarmList);
 }
 

--- a/Examples/Apps/Alarm/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Alarm/Software/Libs/Header/Commands.hpp
@@ -5,7 +5,6 @@
 #include "SDK/Messages/MessageBase.hpp"
 #include "SDK/Messages/MessageTypes.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
-#include "SDK/Kernel/Kernel.hpp"
 
 #include "Alarm.hpp"
 #include <vector>
@@ -50,6 +49,21 @@ namespace CustomMessage {
             , count(0)
             , timeFormat12h(false)
         {}
+
+        // Service <-> GUI
+        //
+        // timeFormat12h is only meaningful Service -> GUI; the GUI -> Service
+        // direction leaves it at the default (the Service ignores it there).
+        explicit AlarmList(const std::vector<Alarm> &list, bool timeFormat12h = false)
+            : AlarmList()
+        {
+            this->count = static_cast<uint8_t>(
+                list.size() < kMaxAlarms ? list.size() : kMaxAlarms);
+            for (uint8_t i = 0; i < this->count; ++i) {
+                this->alarms[i] = list[i];
+            }
+            this->timeFormat12h = timeFormat12h;
+        }
     };
 
     // Service --> GUI
@@ -59,6 +73,13 @@ namespace CustomMessage {
             : SDK::MessageBase(ACTIVATED_ALARM)
             , alarm{}
         {}
+
+        // Service --> GUI
+        explicit ActivatedAlarm(const Alarm &alarm)
+            : ActivatedAlarm()
+        {
+            this->alarm = alarm;
+        }
     };
 
     // GUI --> Service
@@ -68,6 +89,13 @@ namespace CustomMessage {
             : SDK::MessageBase(ACTIVATED_EFFECT)
             , alarm{}
         {}
+
+        // GUI --> Service
+        explicit AlarmActivateEffect(const Alarm &alarm)
+            : AlarmActivateEffect()
+        {
+            this->alarm = alarm;
+        }
     };
 
     struct AlarmStop : public SDK::MessageBase {
@@ -97,113 +125,6 @@ namespace CustomMessage {
             : SDK::MessageBase(ALARM_SNOOZE_ALL)
         {}
     };
-
-
-// Helper wrapper
-class Sender {
-public:
-    Sender(const SDK::Kernel &kernel) :
-            mKernel(kernel)
-    {
-    }
-    virtual ~Sender() = default;
-
-    // Service <-> GUI
-    //
-    // timeFormat12h is only meaningful Service -> GUI; the GUI -> Service
-    // direction leaves it at the default (the Service ignores it there).
-    bool listUpd(const std::vector<Alarm> &list, bool timeFormat12h = false)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::AlarmList>();
-        if (msg) {
-            msg->count = static_cast<uint8_t>(
-                list.size() < kMaxAlarms ? list.size() : kMaxAlarms);
-            for (uint8_t i = 0; i < msg->count; ++i) {
-                msg->alarms[i] = list[i];
-            }
-            msg->timeFormat12h = timeFormat12h;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    // Service --> GUI
-    bool alarmActivated(const Alarm &alarm)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::ActivatedAlarm>();
-        if (msg) {
-            msg->alarm = alarm;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    // GUI --> Service
-    bool activateEffect(const Alarm &alarm)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::AlarmActivateEffect>();
-        if (msg) {
-            msg->alarm = alarm;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool stop(const Alarm &alarm)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::AlarmStop>();
-        if (msg) {
-            msg->alarm = alarm;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool stopAll()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::AlarmStopAll>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool snooze(const Alarm &alarm)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::AlarmSnooze>();
-        if (msg) {
-            msg->alarm = alarm;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool snoozeAll()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::AlarmSnoozeAll>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-private:
-    const SDK::Kernel &mKernel;
-};
 
 
 } // namespace CustomMessage

--- a/Examples/Apps/Alarm/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Alarm/Software/Libs/Header/Service.hpp
@@ -20,7 +20,6 @@ private:
 
     SDK::Kernel&          mKernel;
     bool                  mGuiStarted;
-    CustomMessage::Sender mGuiSender;
 
     // -- Alarm & persistence --------------------------------------------------
 

--- a/Examples/Apps/Alarm/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Alarm/Software/Libs/Sources/Service.cpp
@@ -26,7 +26,6 @@ static std::tm getLocalTime()
 Service::Service(SDK::Kernel &kernel)
         : mKernel(kernel)
         , mGuiStarted(false)
-        , mGuiSender(kernel)
         , mAlarmManager(kernel)
         , mActiveAlarm()
 {
@@ -140,12 +139,12 @@ void Service::onStartGUI()
 
     // If there is an active alarm, send it to GUI first
     if (mActiveAlarm.on) {
-        mGuiSender.alarmActivated(mActiveAlarm);
+        SDK::send_msg<CustomMessage::ActivatedAlarm>(mKernel, mActiveAlarm);
         mActiveAlarm = {}; // clear active alarm
     }
 
     // Send current alarm list to GUI
-    mGuiSender.listUpd(mAlarmManager.getAlarmList(), mTimeFormat12h);
+    SDK::send_msg<CustomMessage::AlarmList>(mKernel, mAlarmManager.getAlarmList(), mTimeFormat12h);
 }
 
 void Service::onStopGUI()
@@ -262,7 +261,7 @@ void Service::onAlarm(const Alarm& alarm)
 
         mActiveAlarm = alarm; // save active alarm
     } else {
-        mGuiSender.alarmActivated(alarm);
+        SDK::send_msg<CustomMessage::ActivatedAlarm>(mKernel, alarm);
         mActiveAlarm = {};
     }
 }
@@ -270,7 +269,7 @@ void Service::onAlarm(const Alarm& alarm)
 void Service::onListChanged(const std::vector<Alarm>& list)
 {
     if (mGuiStarted) {
-        mGuiSender.listUpd(list, mTimeFormat12h);
+        SDK::send_msg<CustomMessage::AlarmList>(mKernel, list, mTimeFormat12h);
     }
 }
 

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -113,7 +113,6 @@ public:
 private:
     ModelListener*        modelListener;
     const SDK::Kernel&    mKernel;
-    CustomMessage::Sender mSrvSender;
 
     // IGuiLifeCycleCallback
     void onStart()   override;

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -1,4 +1,5 @@
 #include <gui/model/Model.hpp>
+#include "SDK/Messages/MessageGuard.hpp"
 #include <gui/model/ModelListener.hpp>
 #include <gui/common/FrontendApplication.hpp>
 
@@ -12,7 +13,6 @@
 Model::Model()
     : modelListener(nullptr)
     , mKernel(SDK::KernelProviderGUI::GetInstance().getKernel())
-    , mSrvSender(mKernel)
 {
     SDK::TouchGFXCommandProcessor::GetInstance().setAppLifeCycleCallback(this);
     SDK::TouchGFXCommandProcessor::GetInstance().setCustomMessageHandler(this);
@@ -138,7 +138,7 @@ const Settings& Model::getSettings() const
 void Model::saveSettings(const Settings& sett)
 {
     mSettings = sett;
-    mSrvSender.settingsSave(mSettings);
+    SDK::send_msg<CustomMessage::SettingsSave>(mKernel, mSettings);
 }
 
 
@@ -159,7 +159,7 @@ uint8_t Model::getAccessoryState() const
 
 void Model::trackStart()
 {
-    mSrvSender.trackStart();
+    SDK::send_msg<CustomMessage::TrackStart>(mKernel);
 }
 
 bool Model::isTrackActive() const
@@ -169,12 +169,12 @@ bool Model::isTrackActive() const
 
 void Model::trackPause()
 {
-    mSrvSender.trackPause();
+    SDK::send_msg<CustomMessage::TrackPause>(mKernel);
 }
 
 void Model::trackResume()
 {
-    mSrvSender.trackResume();
+    SDK::send_msg<CustomMessage::TrackResume>(mKernel);
 }
 
 bool Model::isTrackPaused() const
@@ -189,7 +189,7 @@ const Track::Data& Model::getTrackData() const
 
 void Model::saveLap()
 {
-    mSrvSender.manualLap();
+    SDK::send_msg<CustomMessage::ManualLap>(mKernel);
 }
 
 void Model::setHoldConfirmMode(HoldConfirmMode mode)
@@ -204,12 +204,12 @@ Model::HoldConfirmMode Model::getHoldConfirmMode() const
 
 void Model::saveTrack()
 {
-    mSrvSender.trackStop(false);
+    SDK::send_msg<CustomMessage::TrackStop>(mKernel, false);
 }
 
 void Model::discardTrack()
 {
-    mSrvSender.trackStop(true);
+    SDK::send_msg<CustomMessage::TrackStop>(mKernel, true);
 }
 
 bool Model::isTrackSummaryAvailable() const

--- a/Examples/Apps/Cycling/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Commands.hpp
@@ -7,8 +7,6 @@
 #include "SDK/Messages/MessageBase.hpp"
 #include "SDK/Messages/MessageTypes.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
-#include "SDK/Messages/MessageGuard.hpp"
-#include "SDK/Kernel/Kernel.hpp"
 
 // Application types
 #include "Settings.hpp"
@@ -62,6 +60,17 @@ namespace CustomMessage {
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
+
+        explicit SettingsUpd(Settings settings, bool units, bool timeFormat12h,
+                         const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
+            : SettingsUpd()
+        {
+            this->settings          = settings;
+            this->unitsImperial     = units;
+            this->timeFormat12h     = timeFormat12h;
+            memcpy(this->hrThresholds, thresholds, sizeof(this->hrThresholds));
+            this->hrThresholdsCount = thresholdCount;
+        }
     };
 
     // Service --> GUI
@@ -71,6 +80,12 @@ namespace CustomMessage {
             : SDK::MessageBase(LOCAL_TIME)
             , localTime {}
         {}
+
+        explicit Time(std::tm localTime)
+            : Time()
+        {
+            this->localTime = localTime;
+        }
     };
 
     struct Battery : public SDK::MessageBase {
@@ -79,6 +94,12 @@ namespace CustomMessage {
             : SDK::MessageBase(BATTERY)
             , level(0)
         {}
+
+        explicit Battery(uint8_t level)
+            : Battery()
+        {
+            this->level = level;
+        }
     };
 
     struct GpsFix : public SDK::MessageBase {
@@ -87,6 +108,12 @@ namespace CustomMessage {
             : SDK::MessageBase(GPS_FIX)
             , state(false)
         {}
+
+        explicit GpsFix(bool state)
+            : GpsFix()
+        {
+            this->state = state;
+        }
     };
 
     struct TrackStateUpd : public SDK::MessageBase {
@@ -95,6 +122,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_STATE_UPDATE)
             , state{}
         {}
+
+        explicit TrackStateUpd(Track::State state)
+            : TrackStateUpd()
+        {
+            this->state = state;
+        }
     };
 
     struct TrackDataUpd : public SDK::MessageBase {
@@ -103,6 +136,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_DATA_UPDATE)
             , data{}
         {}
+
+        explicit TrackDataUpd(const Track::Data &data)
+            : TrackDataUpd()
+        {
+            this->data = data;
+        }
     };
 
     struct LapEnded : public SDK::MessageBase {
@@ -111,6 +150,12 @@ namespace CustomMessage {
             : SDK::MessageBase(LAP_END)
             , lapNum(0)
         {}
+
+        explicit LapEnded(uint32_t lapNum)
+            : LapEnded()
+        {
+            this->lapNum = lapNum;
+        }
     };
 
     struct Summary : public SDK::MessageBase {
@@ -119,6 +164,12 @@ namespace CustomMessage {
             : SDK::MessageBase(SUMMARY)
             , summary(nullptr)
         {}
+
+        explicit Summary(const ActivitySummary* summaryPtr)
+            : Summary()
+        {
+            this->summary = summaryPtr;
+        }
     };
 
     // External-accessory link status forwarded from the kernel's
@@ -131,6 +182,15 @@ namespace CustomMessage {
             , state(0)
             , name{}
         {}
+
+        explicit AccessoryStatusUpd(uint8_t state, const char* name)
+            : AccessoryStatusUpd()
+        {
+            this->state = state;
+            if (name) {
+                strncpy(this->name, name, sizeof(this->name) - 1);
+            }
+        }
     };
 
     // GUI --> Service
@@ -141,6 +201,12 @@ namespace CustomMessage {
         SettingsSave()
             : SDK::MessageBase(SETTINGS_SAVE)
         {}
+
+        explicit SettingsSave(Settings settings)
+            : SettingsSave()
+        {
+            this->settings = settings;
+        }
     };
 
     struct TrackStart : public SDK::MessageBase {
@@ -153,6 +219,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_STOP)
             , discard(false)
         {}
+
+        explicit TrackStop(bool discard)
+            : TrackStop()
+        {
+            this->discard = discard;
+        }
     };
 
     struct TrackPause : public SDK::MessageBase {
@@ -166,204 +238,6 @@ namespace CustomMessage {
     struct ManualLap : public SDK::MessageBase {
         ManualLap() : SDK::MessageBase(MANUAL_LAP) {}
     };
-
-
-// Helper wrapper
-class Sender {
-public:
-    Sender(const SDK::Kernel &kernel) :
-            mKernel(kernel)
-    {
-    }
-    virtual ~Sender() = default;
-
-    // Service --> GUI
-    bool settingsUpd(Settings settings, bool units, bool timeFormat12h,
-                     const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
-    {
-        if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
-            msg->settings          = settings;
-            msg->unitsImperial     = units;
-            msg->timeFormat12h     = timeFormat12h;
-            memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
-            msg->hrThresholdsCount = thresholdCount;
-            return msg.send();
-        }
-
-        return false;
-    }
-
-    bool time(std::tm localTime)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Time>();
-        if (msg) {
-            msg->localTime = localTime;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool battery(uint8_t level)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Battery>();
-        if (msg) {
-            msg->level = level;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool fix(bool state)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::GpsFix>();
-        if (msg) {
-            msg->state = state;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackState(Track::State state)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStateUpd>();
-        if (msg) {
-            msg->state = state;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackData(const Track::Data &data)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackDataUpd>();
-        if (msg) {
-            msg->data = data;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool lapEnd(uint32_t lapNum)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::LapEnded>();
-        if (msg) {
-            msg->lapNum = lapNum;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool summary(const ActivitySummary* summaryPtr)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Summary>();
-        if (msg) {
-            msg->summary = summaryPtr;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool accessoryStatus(uint8_t state, const char* name)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::AccessoryStatusUpd>();
-        if (msg) {
-            msg->state = state;
-            if (name) {
-                strncpy(msg->name, name, sizeof(msg->name) - 1);
-            }
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    // GUI --> Service
-    bool settingsSave(Settings settings)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::SettingsSave>();
-        if (msg) {
-            msg->settings = settings;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackStart()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStart>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackStop(bool discard)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStop>();
-        if (msg) {
-            msg->discard = discard;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackPause()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackPause>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackResume()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackResume>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool manualLap()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::ManualLap>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-private:
-    const SDK::Kernel &mKernel;
-};
 
 
 } // namespace CustomMessage

--- a/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
@@ -40,7 +40,6 @@ private:
 
     SDK::Kernel&          mKernel;
     bool                  mGuiStarted;
-    CustomMessage::Sender mGuiSender;
 
     // -- Settings & persistence -----------------------------------------------
 

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -51,7 +51,6 @@ static float speedFromTotals(float distanceM, float activeTimeS)
 Service::Service(SDK::Kernel &kernel)
         : mKernel(kernel)
         , mGuiStarted(false)
-        , mGuiSender(kernel)
         , mSettings{}
         , mSettingsSerializer(mKernel, "settings.json")
         , mSummary{}
@@ -184,7 +183,7 @@ void Service::run()
                 case SDK::MessageType::EVENT_ACCESSORY_STATUS: {
                     auto* evt = static_cast<SDK::Message::Accessory::EventStatus*>(msg);
                     LOG_INFO("Accessory status: state %u\n", evt->state);
-                    mGuiSender.accessoryStatus(evt->state, evt->name);
+                    SDK::send_msg<CustomMessage::AccessoryStatusUpd>(mKernel, evt->state, evt->name);
                 } break;
 
                 default:
@@ -217,9 +216,9 @@ void Service::run()
 
                 // Send to GUI real "local time" to display
                 std::tm tmNow = mTimeTracker.getLocalTime(std::time(nullptr));
-                mGuiSender.time(tmNow);
+                SDK::send_msg<CustomMessage::Time>(mKernel, tmNow);
 
-                mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
+                SDK::send_msg<CustomMessage::Battery>(mKernel, static_cast<uint8_t>(mBatterySoc.get()));
 
                 // Update GPS fix
                 if (mPreviousGpsFixState != mGps.fix) {
@@ -229,7 +228,7 @@ void Service::run()
                         notifyFirstFix();
                         firstFix = true;
                     }
-                    mGuiSender.fix(mGps.fix);
+                    SDK::send_msg<CustomMessage::GpsFix>(mKernel, mGps.fix);
                 }
 
                 if (mTrackState != Track::State::INACTIVE) {
@@ -436,7 +435,7 @@ void Service::handleEvent(const CustomMessage::TrackResume& /*event*/)
 void Service::handleEvent(const CustomMessage::ManualLap& /*event*/)
 {
     saveLap();
-    mGuiSender.lapEnd(mTrackData.lapNum);
+    SDK::send_msg<CustomMessage::LapEnded>(mKernel, mTrackData.lapNum);
     notifyLapEnd();
 }
 
@@ -640,9 +639,9 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat12h, hrThresholds, hrThresholdsCount);
-    mGuiSender.summary(&mSummary);
-    mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
+    SDK::send_msg<CustomMessage::SettingsUpd>(mKernel, mSettings, mIsImperial, mTimeFormat12h, hrThresholds, hrThresholdsCount);
+    SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
+    SDK::send_msg<CustomMessage::Battery>(mKernel, static_cast<uint8_t>(mBatterySoc.get()));
 }
 
 void Service::startTrack(std::time_t utc)
@@ -691,7 +690,7 @@ void Service::startTrack(std::time_t utc)
     mTrackState = Track::State::ACTIVE;
 
     LOG_INFO("Track started. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-    mGuiSender.trackState(mTrackState);
+    SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 }
 
 void Service::processTrack()
@@ -742,7 +741,7 @@ void Service::processTrack()
     mTrackData.elevation = mAltitudeCounter.getCurrent();
 
     // Update GUI
-    mGuiSender.trackData(mTrackData);
+    SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
 
     if (mTrackState == Track::State::ACTIVE) {
         // Save record to the FIT file
@@ -784,11 +783,11 @@ void Service::processTrack()
                 mTrackData.avgLapSpeed = speedFromTotals(autoLapDistanceM,
                                                          static_cast<float>(mTrackData.lapTime));
                 mTrackData.lapPace     = getPace(mTrackData.avgLapSpeed, mSpeedCounter.getMinValid());
-                mGuiSender.trackData(mTrackData);
+                SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
             }
 
             saveLap(autoLapDistanceM);
-            mGuiSender.lapEnd(mTrackData.lapNum);
+            SDK::send_msg<CustomMessage::LapEnded>(mKernel, mTrackData.lapNum);
             notifyLapEnd();
         }
     }
@@ -905,7 +904,7 @@ void Service::stopTrack(bool discard)
         if (!mActivitySummarySerializer.save(mSummary)) {
             LOG_ERROR("Can't save activity summary\n");
         }
-        mGuiSender.summary(&mSummary);
+        SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
 
         // Save FIT file
         ActivityWriter::TrackData fitTrack{};
@@ -945,7 +944,7 @@ void Service::stopTrack(bool discard)
     LOG_INFO("Heart rate: %.0f / %.0f bpm\n", mHrCounter.getAverage(), mHrCounter.getMaximum());
     LOG_INFO("Ascent/Descent: %.1f / %.1f m\n", mAltitudeCounter.getAscent(), mAltitudeCounter.getDescent());
 
-    mGuiSender.trackState(mTrackState);
+    SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 
     disconnect();
 }
@@ -967,10 +966,10 @@ void Service::pauseTrack(bool pause)
 
         mTrackState = Track::State::PAUSED;
         LOG_INFO("Track paused. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-        mGuiSender.trackState(mTrackState);
+        SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 
         buildPartialSummary();
-        mGuiSender.summary(&mSummary);
+        SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
     } else if (!pause && mTrackState == Track::State::PAUSED) {
         mTimeCounter.resume();
         mDistanceCounter.resume();
@@ -982,7 +981,7 @@ void Service::pauseTrack(bool pause)
 
         mTrackState = Track::State::ACTIVE;
         LOG_INFO("Track resumed. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-        mGuiSender.trackState(mTrackState);
+        SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
     }
 }
 

--- a/Examples/Apps/HRMonitor/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/HRMonitor/Software/Libs/Header/Commands.hpp
@@ -5,7 +5,6 @@
 #include "SDK/Messages/MessageBase.hpp"
 #include "SDK/Messages/MessageTypes.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
-#include "SDK/Kernel/Kernel.hpp"
 
 // Force 4-byte alignment for all message structures
 #pragma pack(push, 4)
@@ -27,35 +26,14 @@ namespace CustomMessage {
             , heartRate(0.0f)
             , trustLevel(0.0f)
         {}
-    };
 
-
-// Helper wrapper
-class Sender {
-public:
-    Sender(const SDK::Kernel &kernel) :
-            mKernel(kernel)
-    {
-    }
-    virtual ~Sender() = default;
-
-    // Service --> GUI
-    bool heartRate(float value, float trustLevel)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::HRValues>();
-        if (msg) {
-            msg->heartRate  = value;
-            msg->trustLevel = trustLevel;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
+        explicit HRValues(float heartRate, float trustLevel)
+            : HRValues()
+        {
+            this->heartRate  = heartRate;
+            this->trustLevel = trustLevel;
         }
-        return status;
-    }
-
-private:
-    const SDK::Kernel &mKernel;
-};
+    };
 
 
 } // namespace CustomMessage

--- a/Examples/Apps/HRMonitor/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/HRMonitor/Software/Libs/Header/Service.hpp
@@ -27,7 +27,6 @@ private:
 
     SDK::Kernel&          mKernel;
     bool                  mGuiStarted;
-    CustomMessage::Sender mGuiSender;
 
     // -- Sensors --------------------------------------------------------------
 

--- a/Examples/Apps/HRMonitor/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/HRMonitor/Software/Libs/Sources/Service.cpp
@@ -1,4 +1,5 @@
 #include "Service.hpp"
+#include "SDK/Messages/MessageGuard.hpp"
 
 #include <ctime>
 #include <algorithm>
@@ -16,7 +17,6 @@
 Service::Service(SDK::Kernel& kernel)
     : mKernel(kernel)
     , mGuiStarted(false)
-    , mGuiSender(mKernel)
     , mSensorHr(SDK::Sensor::Type::HEART_RATE, skSamplePeriod, skSampleLatency)
     , mHr(0.0f)
     , mHrTl(0.0f)
@@ -164,7 +164,7 @@ void Service::run()
 void Service::onStartGUI()
 {
     mGuiStarted = true;
-    mGuiSender.heartRate(0.0f, 0.0f);
+    SDK::send_msg<CustomMessage::HRValues>(mKernel, 0.0f, 0.0f);
 }
 
 void Service::onStopGUI()
@@ -181,7 +181,7 @@ void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)
                 mHr   = parser.getBpm();
                 mHrTl = parser.getTrustLevel();
 
-                mGuiSender.heartRate(mHr, mHrTl);
+                SDK::send_msg<CustomMessage::HRValues>(mKernel, mHr, mHrTl);
             }
         }
     }

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -118,7 +118,6 @@ public:
 private:
     ModelListener*        modelListener;
     const SDK::Kernel&    mKernel;
-    CustomMessage::Sender mSrvSender;
     SDK::Variant::Config  mVariant;
     char                  mVariantTitle[16] {};
 

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -1,4 +1,5 @@
 #include <gui/model/Model.hpp>
+#include "SDK/Messages/MessageGuard.hpp"
 #include <gui/model/ModelListener.hpp>
 #include <gui/common/FrontendApplication.hpp>
 
@@ -14,7 +15,6 @@
 Model::Model()
     : modelListener(nullptr)
     , mKernel(SDK::KernelProviderGUI::GetInstance().getKernel())
-    , mSrvSender(mKernel)
     , mVariant(mKernel)
 {
     SDK::TouchGFXCommandProcessor::GetInstance().setAppLifeCycleCallback(this);
@@ -160,7 +160,7 @@ const Settings& Model::getSettings() const
 void Model::saveSettings(const Settings& sett)
 {
     mSettings = sett;
-    mSrvSender.settingsSave(mSettings);
+    SDK::send_msg<CustomMessage::SettingsSave>(mKernel, mSettings);
 }
 
 
@@ -181,7 +181,7 @@ uint8_t Model::getAccessoryState() const
 
 void Model::trackStart()
 {
-    mSrvSender.trackStart();
+    SDK::send_msg<CustomMessage::TrackStart>(mKernel);
 }
 
 bool Model::isTrackActive() const
@@ -191,12 +191,12 @@ bool Model::isTrackActive() const
 
 void Model::trackPause()
 {
-    mSrvSender.trackPause();
+    SDK::send_msg<CustomMessage::TrackPause>(mKernel);
 }
 
 void Model::trackResume()
 {
-    mSrvSender.trackResume();
+    SDK::send_msg<CustomMessage::TrackResume>(mKernel);
 }
 
 bool Model::isTrackPaused() const
@@ -211,7 +211,7 @@ const Track::Data& Model::getTrackData() const
 
 void Model::saveLap()
 {
-    mSrvSender.manualLap();
+    SDK::send_msg<CustomMessage::ManualLap>(mKernel);
 }
 
 void Model::setHoldConfirmMode(HoldConfirmMode mode)
@@ -226,12 +226,12 @@ Model::HoldConfirmMode Model::getHoldConfirmMode() const
 
 void Model::saveTrack()
 {
-    mSrvSender.trackStop(false);
+    SDK::send_msg<CustomMessage::TrackStop>(mKernel, false);
 }
 
 void Model::discardTrack()
 {
-    mSrvSender.trackStop(true);
+    SDK::send_msg<CustomMessage::TrackStop>(mKernel, true);
 }
 
 bool Model::isTrackSummaryAvailable() const

--- a/Examples/Apps/Hiking/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Commands.hpp
@@ -7,8 +7,6 @@
 #include "SDK/Messages/MessageBase.hpp"
 #include "SDK/Messages/MessageTypes.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
-#include "SDK/Messages/MessageGuard.hpp"
-#include "SDK/Kernel/Kernel.hpp"
 
 // Application types
 #include "Settings.hpp"
@@ -62,6 +60,17 @@ namespace CustomMessage {
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
+
+        explicit SettingsUpd(Settings settings, bool units, bool timeFormat12h,
+                         const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
+            : SettingsUpd()
+        {
+            this->settings          = settings;
+            this->unitsImperial     = units;
+            this->timeFormat12h     = timeFormat12h;
+            memcpy(this->hrThresholds, thresholds, sizeof(this->hrThresholds));
+            this->hrThresholdsCount = thresholdCount;
+        }
     };
 
     // Service --> GUI
@@ -71,6 +80,12 @@ namespace CustomMessage {
             : SDK::MessageBase(LOCAL_TIME)
             , localTime {}
         {}
+
+        explicit Time(std::tm localTime)
+            : Time()
+        {
+            this->localTime = localTime;
+        }
     };
 
     struct Battery : public SDK::MessageBase {
@@ -79,6 +94,12 @@ namespace CustomMessage {
             : SDK::MessageBase(BATTERY)
             , level(0)
         {}
+
+        explicit Battery(uint8_t level)
+            : Battery()
+        {
+            this->level = level;
+        }
     };
 
     struct GpsFix : public SDK::MessageBase {
@@ -87,6 +108,12 @@ namespace CustomMessage {
             : SDK::MessageBase(GPS_FIX)
             , state(false)
         {}
+
+        explicit GpsFix(bool state)
+            : GpsFix()
+        {
+            this->state = state;
+        }
     };
 
     struct TrackStateUpd : public SDK::MessageBase {
@@ -95,6 +122,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_STATE_UPDATE)
             , state{}
         {}
+
+        explicit TrackStateUpd(Track::State state)
+            : TrackStateUpd()
+        {
+            this->state = state;
+        }
     };
 
     struct TrackDataUpd : public SDK::MessageBase {
@@ -103,6 +136,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_DATA_UPDATE)
             , data{}
         {}
+
+        explicit TrackDataUpd(const Track::Data &data)
+            : TrackDataUpd()
+        {
+            this->data = data;
+        }
     };
 
     struct LapEnded : public SDK::MessageBase {
@@ -111,6 +150,12 @@ namespace CustomMessage {
             : SDK::MessageBase(LAP_END)
             , lapNum(0)
         {}
+
+        explicit LapEnded(uint32_t lapNum)
+            : LapEnded()
+        {
+            this->lapNum = lapNum;
+        }
     };
 
     struct Summary : public SDK::MessageBase {
@@ -119,6 +164,12 @@ namespace CustomMessage {
             : SDK::MessageBase(SUMMARY)
             , summary(nullptr)
         {}
+
+        explicit Summary(const ActivitySummary* summaryPtr)
+            : Summary()
+        {
+            this->summary = summaryPtr;
+        }
     };
 
     // External-accessory link status forwarded from the kernel's
@@ -131,6 +182,15 @@ namespace CustomMessage {
             , state(0)
             , name{}
         {}
+
+        explicit AccessoryStatusUpd(uint8_t state, const char* name)
+            : AccessoryStatusUpd()
+        {
+            this->state = state;
+            if (name) {
+                strncpy(this->name, name, sizeof(this->name) - 1);
+            }
+        }
     };
 
     // GUI --> Service
@@ -141,6 +201,12 @@ namespace CustomMessage {
         SettingsSave()
             : SDK::MessageBase(SETTINGS_SAVE)
         {}
+
+        explicit SettingsSave(Settings settings)
+            : SettingsSave()
+        {
+            this->settings = settings;
+        }
     };
 
     struct TrackStart : public SDK::MessageBase {
@@ -153,6 +219,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_STOP)
             , discard(false)
         {}
+
+        explicit TrackStop(bool discard)
+            : TrackStop()
+        {
+            this->discard = discard;
+        }
     };
 
     struct TrackPause : public SDK::MessageBase {
@@ -166,204 +238,6 @@ namespace CustomMessage {
     struct ManualLap : public SDK::MessageBase {
         ManualLap() : SDK::MessageBase(MANUAL_LAP) {}
     };
-
-
-// Helper wrapper
-class Sender {
-public:
-    Sender(const SDK::Kernel &kernel) :
-            mKernel(kernel)
-    {
-    }
-    virtual ~Sender() = default;
-
-    // Service --> GUI
-    bool settingsUpd(Settings settings, bool units, bool timeFormat12h,
-                     const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
-    {
-        if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
-            msg->settings          = settings;
-            msg->unitsImperial     = units;
-            msg->timeFormat12h     = timeFormat12h;
-            memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
-            msg->hrThresholdsCount = thresholdCount;
-            return msg.send();
-        }
-
-        return false;
-    }
-
-    bool time(std::tm localTime)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Time>();
-        if (msg) {
-            msg->localTime = localTime;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool battery(uint8_t level)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Battery>();
-        if (msg) {
-            msg->level = level;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool fix(bool state)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::GpsFix>();
-        if (msg) {
-            msg->state = state;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackState(Track::State state)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStateUpd>();
-        if (msg) {
-            msg->state = state;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackData(const Track::Data &data)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackDataUpd>();
-        if (msg) {
-            msg->data = data;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool lapEnd(uint32_t lapNum)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::LapEnded>();
-        if (msg) {
-            msg->lapNum = lapNum;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool summary(const ActivitySummary* summaryPtr)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Summary>();
-        if (msg) {
-            msg->summary = summaryPtr;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool accessoryStatus(uint8_t state, const char* name)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::AccessoryStatusUpd>();
-        if (msg) {
-            msg->state = state;
-            if (name) {
-                strncpy(msg->name, name, sizeof(msg->name) - 1);
-            }
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    // GUI --> Service
-    bool settingsSave(Settings settings)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::SettingsSave>();
-        if (msg) {
-            msg->settings = settings;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackStart()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStart>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackStop(bool discard)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStop>();
-        if (msg) {
-            msg->discard = discard;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackPause()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackPause>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackResume()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackResume>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool manualLap()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::ManualLap>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-private:
-    const SDK::Kernel &mKernel;
-};
 
 
 } // namespace CustomMessage

--- a/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
@@ -42,7 +42,6 @@ private:
 
     SDK::Kernel&          mKernel;
     bool                  mGuiStarted;
-    CustomMessage::Sender mGuiSender;
 
     // -- Settings & persistence -----------------------------------------------
 

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -53,7 +53,6 @@ static float speedFromTotals(float distanceM, float activeTimeS)
 Service::Service(SDK::Kernel &kernel)
         : mKernel(kernel)
         , mGuiStarted(false)
-        , mGuiSender(kernel)
         , mVariant(kernel)
         , mSettings{}
         , mSettingsSerializer(mKernel, "settings.json")
@@ -195,7 +194,7 @@ void Service::run()
                 case SDK::MessageType::EVENT_ACCESSORY_STATUS: {
                     auto* evt = static_cast<SDK::Message::Accessory::EventStatus*>(msg);
                     LOG_INFO("Accessory status: state %u\n", evt->state);
-                    mGuiSender.accessoryStatus(evt->state, evt->name);
+                    SDK::send_msg<CustomMessage::AccessoryStatusUpd>(mKernel, evt->state, evt->name);
                 } break;
 
                 default:
@@ -228,9 +227,9 @@ void Service::run()
 
                 // Send to GUI real "local time" to display
                 std::tm tmNow = mTimeTracker.getLocalTime(std::time(nullptr));
-                mGuiSender.time(tmNow);
+                SDK::send_msg<CustomMessage::Time>(mKernel, tmNow);
 
-                mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
+                SDK::send_msg<CustomMessage::Battery>(mKernel, static_cast<uint8_t>(mBatterySoc.get()));
 
                 // Update GPS fix
                 if (mPreviousGpsFixState != mGps.fix) {
@@ -240,7 +239,7 @@ void Service::run()
                         notifyFirstFix();
                         firstFix = true;
                     }
-                    mGuiSender.fix(mGps.fix);
+                    SDK::send_msg<CustomMessage::GpsFix>(mKernel, mGps.fix);
                 }
 
                 if (mTrackState != Track::State::INACTIVE) {
@@ -464,7 +463,7 @@ void Service::handleEvent(const CustomMessage::TrackResume& /*event*/)
 void Service::handleEvent(const CustomMessage::ManualLap& /*event*/)
 {
     saveLap();
-    mGuiSender.lapEnd(mTrackData.lapNum);
+    SDK::send_msg<CustomMessage::LapEnded>(mKernel, mTrackData.lapNum);
     notifyLapEnd();
 }
 
@@ -668,9 +667,9 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat12h, hrThresholds, hrThresholdsCount);
-    mGuiSender.summary(&mSummary);
-    mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
+    SDK::send_msg<CustomMessage::SettingsUpd>(mKernel, mSettings, mIsImperial, mTimeFormat12h, hrThresholds, hrThresholdsCount);
+    SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
+    SDK::send_msg<CustomMessage::Battery>(mKernel, static_cast<uint8_t>(mBatterySoc.get()));
 }
 
 void Service::startTrack(std::time_t utc)
@@ -721,7 +720,7 @@ void Service::startTrack(std::time_t utc)
     mTrackState = Track::State::ACTIVE;
 
     LOG_INFO("Track started. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-    mGuiSender.trackState(mTrackState);
+    SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 }
 
 void Service::processTrack()
@@ -783,7 +782,7 @@ void Service::processTrack()
     mTrackData.lapFloors = mFloorCounter.getLapValueActive();
 
     // Update GUI
-    mGuiSender.trackData(mTrackData);
+    SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
 
     if (mTrackState == Track::State::ACTIVE) {
         // Save record to the FIT file
@@ -814,7 +813,7 @@ void Service::processTrack()
 
         if (switchLap) {
             saveLap(autoLapDistanceM);
-            mGuiSender.lapEnd(mTrackData.lapNum);
+            SDK::send_msg<CustomMessage::LapEnded>(mKernel, mTrackData.lapNum);
             notifyLapEnd();
         }
     }
@@ -942,7 +941,7 @@ void Service::stopTrack(bool discard)
         if (!mActivitySummarySerializer.save(mSummary)) {
             LOG_ERROR("Can't save activity summary\n");
         }
-        mGuiSender.summary(&mSummary);
+        SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
 
         // Save FIT file
         ActivityWriter::TrackData fitTrack{};
@@ -987,7 +986,7 @@ void Service::stopTrack(bool discard)
     LOG_INFO("Steps: %u\n", mStepCounter.getValueActive());
     LOG_INFO("Floors: %u\n", mFloorCounter.getValueActive());
 
-    mGuiSender.trackState(mTrackState);
+    SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 
     disconnect();
 }
@@ -1011,10 +1010,10 @@ void Service::pauseTrack(bool pause)
 
         mTrackState = Track::State::PAUSED;
         LOG_INFO("Track paused. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-        mGuiSender.trackState(mTrackState);
+        SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 
         buildPartialSummary();
-        mGuiSender.summary(&mSummary);
+        SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
     } else if (!pause && mTrackState == Track::State::PAUSED) {
         mTimeCounter.resume();
         mDistanceCounter.resume();
@@ -1028,7 +1027,7 @@ void Service::pauseTrack(bool pause)
 
         mTrackState = Track::State::ACTIVE;
         LOG_INFO("Track resumed. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-        mGuiSender.trackState(mTrackState);
+        SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
     }
 }
 

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -117,7 +117,6 @@ private:
     // Fields required for GUI <-> Service communication
     ModelListener*           modelListener;
     const SDK::Kernel&       mKernel;
-    CustomMessage::Sender    mSrvSender;
 
     // IGuiLifeCycleCallback
     void onStart()   override;

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -1,4 +1,5 @@
 #include <gui/model/Model.hpp>
+#include "SDK/Messages/MessageGuard.hpp"
 #include <gui/model/ModelListener.hpp>
 #include <gui/common/FrontendApplication.hpp>
 
@@ -12,7 +13,6 @@
 Model::Model()
     : modelListener(nullptr)
     , mKernel(SDK::KernelProviderGUI::GetInstance().getKernel())
-    , mSrvSender(mKernel)
 {
     SDK::TouchGFXCommandProcessor::GetInstance().setAppLifeCycleCallback(this);
     SDK::TouchGFXCommandProcessor::GetInstance().setCustomMessageHandler(this);
@@ -137,7 +137,7 @@ const Settings& Model::getSettings() const
 void Model::saveSettings(const Settings& sett)
 {
     mSettings = sett;
-    mSrvSender.settingsSave(mSettings);
+    SDK::send_msg<CustomMessage::SettingsSave>(mKernel, mSettings);
 }
 
 
@@ -236,12 +236,12 @@ void Model::trackStart(bool intervalsMode)
         }
     }
 
-    mSrvSender.trackStart(intervalsMode);
+    SDK::send_msg<CustomMessage::TrackStart>(mKernel, intervalsMode);
 }
 
 void Model::intervalsNextPhase()
 {
-    mSrvSender.intervalsNextPhase();
+    SDK::send_msg<CustomMessage::IntervalsNextPhase>(mKernel);
 }
 
 bool Model::isTrackActive() const
@@ -251,12 +251,12 @@ bool Model::isTrackActive() const
 
 void Model::trackPause()
 {
-    mSrvSender.trackPause();
+    SDK::send_msg<CustomMessage::TrackPause>(mKernel);
 }
 
 void Model::trackResume()
 {
-    mSrvSender.trackResume();
+    SDK::send_msg<CustomMessage::TrackResume>(mKernel);
 }
 
 bool Model::isTrackPaused() const
@@ -271,17 +271,17 @@ const Track::Data& Model::getTrackData() const
 
 void Model::saveLap()
 {
-    mSrvSender.manualLap();
+    SDK::send_msg<CustomMessage::ManualLap>(mKernel);
 }
 
 void Model::saveTrack()
 {
-    mSrvSender.trackStop(false);
+    SDK::send_msg<CustomMessage::TrackStop>(mKernel, false);
 }
 
 void Model::discardTrack()
 {
-    mSrvSender.trackStop(true);
+    SDK::send_msg<CustomMessage::TrackStop>(mKernel, true);
 }
 
 bool Model::isTrackSummaryAvailable() const

--- a/Examples/Apps/Running/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Commands.hpp
@@ -7,8 +7,6 @@
 #include "SDK/Messages/MessageBase.hpp"
 #include "SDK/Messages/MessageTypes.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
-#include "SDK/Messages/MessageGuard.hpp"
-#include "SDK/Kernel/Kernel.hpp"
 
 // Application types
 #include "Settings.hpp"
@@ -65,6 +63,17 @@ namespace CustomMessage {
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
+
+        explicit SettingsUpd(Settings settings, bool units, bool timeFormat12h,
+                         const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
+            : SettingsUpd()
+        {
+            this->settings          = settings;
+            this->unitsImperial     = units;
+            this->timeFormat12h     = timeFormat12h;
+            memcpy(this->hrThresholds, thresholds, sizeof(this->hrThresholds));
+            this->hrThresholdsCount = thresholdCount;
+        }
     };
 
     // Service --> GUI
@@ -74,6 +83,12 @@ namespace CustomMessage {
             : SDK::MessageBase(LOCAL_TIME)
             , localTime {}
         {}
+
+        explicit Time(std::tm localTime)
+            : Time()
+        {
+            this->localTime = localTime;
+        }
     };
 
     struct Battery : public SDK::MessageBase {
@@ -82,6 +97,12 @@ namespace CustomMessage {
             : SDK::MessageBase(BATTERY)
             , level(0)
         {}
+
+        explicit Battery(uint8_t level)
+            : Battery()
+        {
+            this->level = level;
+        }
     };
 
     struct GpsFix : public SDK::MessageBase {
@@ -90,6 +111,12 @@ namespace CustomMessage {
             : SDK::MessageBase(GPS_FIX)
             , state(false)
         {}
+
+        explicit GpsFix(bool state)
+            : GpsFix()
+        {
+            this->state = state;
+        }
     };
 
     struct TrackStateUpd : public SDK::MessageBase {
@@ -98,6 +125,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_STATE_UPDATE)
             , state{}
         {}
+
+        explicit TrackStateUpd(Track::State state)
+            : TrackStateUpd()
+        {
+            this->state = state;
+        }
     };
 
     struct TrackDataUpd : public SDK::MessageBase {
@@ -106,6 +139,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_DATA_UPDATE)
             , data{}
         {}
+
+        explicit TrackDataUpd(const Track::Data &data)
+            : TrackDataUpd()
+        {
+            this->data = data;
+        }
     };
 
     struct LapEnded : public SDK::MessageBase {
@@ -114,6 +153,12 @@ namespace CustomMessage {
             : SDK::MessageBase(LAP_END)
             , lapNum(0)
         {}
+
+        explicit LapEnded(uint32_t lapNum)
+            : LapEnded()
+        {
+            this->lapNum = lapNum;
+        }
     };
 
     struct Summary : public SDK::MessageBase {
@@ -122,11 +167,23 @@ namespace CustomMessage {
             : SDK::MessageBase(SUMMARY)
             , summary(nullptr)
         {}
+
+        explicit Summary(const ActivitySummary* summaryPtr)
+            : Summary()
+        {
+            this->summary = summaryPtr;
+        }
     };
 
     struct IntervalsPhaseAlert : public SDK::MessageBase {
         Track::IntervalsData intervals; ///< Snapshot of the NEW phase — already set before this message is sent
         IntervalsPhaseAlert() : SDK::MessageBase(INTERVALS_PHASE_ALERT) {}
+
+        explicit IntervalsPhaseAlert(const Track::IntervalsData& intervals)
+            : IntervalsPhaseAlert()
+        {
+            this->intervals = intervals;
+        }
     };
 
     struct IntervalsWorkoutCompleted : public SDK::MessageBase {
@@ -143,6 +200,15 @@ namespace CustomMessage {
             , state(0)
             , name{}
         {}
+
+        explicit AccessoryStatusUpd(uint8_t state, const char* name)
+            : AccessoryStatusUpd()
+        {
+            this->state = state;
+            if (name) {
+                strncpy(this->name, name, sizeof(this->name) - 1);
+            }
+        }
     };
 
     // GUI --> Service
@@ -153,11 +219,23 @@ namespace CustomMessage {
         SettingsSave()
             : SDK::MessageBase(SETTINGS_SAVE)
         {}
+
+        explicit SettingsSave(Settings settings)
+            : SettingsSave()
+        {
+            this->settings = settings;
+        }
     };
 
     struct TrackStart : public SDK::MessageBase {
         bool intervalsMode = false;
         TrackStart() : SDK::MessageBase(TRACK_START) {}
+
+        explicit TrackStart(bool intervalsMode)
+            : TrackStart()
+        {
+            this->intervalsMode = intervalsMode;
+        }
     };
 
     struct IntervalsNextPhase : public SDK::MessageBase {
@@ -170,6 +248,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_STOP)
             , discard(false)
         {}
+
+        explicit TrackStop(bool discard)
+            : TrackStop()
+        {
+            this->discard = discard;
+        }
     };
 
     struct TrackPause : public SDK::MessageBase {
@@ -183,238 +267,6 @@ namespace CustomMessage {
     struct ManualLap : public SDK::MessageBase {
         ManualLap() : SDK::MessageBase(MANUAL_LAP) {}
     };
-
-
-// Helper wrapper
-class Sender {
-public:
-    Sender(const SDK::Kernel &kernel) :
-            mKernel(kernel)
-    {
-    }
-    virtual ~Sender() = default;
-
-    // Service --> GUI
-    bool settingsUpd(Settings settings, bool units, bool timeFormat12h,
-                     const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
-    {
-        if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
-            msg->settings          = settings;
-            msg->unitsImperial     = units;
-            msg->timeFormat12h     = timeFormat12h;
-            memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
-            msg->hrThresholdsCount = thresholdCount;
-            return msg.send();
-        }
-
-        return false;
-    }
-
-    bool time(std::tm localTime)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Time>();
-        if (msg) {
-            msg->localTime = localTime;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool battery(uint8_t level)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Battery>();
-        if (msg) {
-            msg->level = level;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool fix(bool state)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::GpsFix>();
-        if (msg) {
-            msg->state = state;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackState(Track::State state)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStateUpd>();
-        if (msg) {
-            msg->state = state;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackData(const Track::Data &data)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackDataUpd>();
-        if (msg) {
-            msg->data = data;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool intervalsPhaseAlert(const Track::IntervalsData& intervals)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::IntervalsPhaseAlert>();
-        if (msg) {
-            msg->intervals = intervals;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool intervalsWorkoutCompleted()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::IntervalsWorkoutCompleted>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool lapEnd(uint32_t lapNum)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::LapEnded>();
-        if (msg) {
-            msg->lapNum = lapNum;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool summary(const ActivitySummary* summaryPtr)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Summary>();
-        if (msg) {
-            msg->summary = summaryPtr;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool accessoryStatus(uint8_t state, const char* name)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::AccessoryStatusUpd>();
-        if (msg) {
-            msg->state = state;
-            if (name) {
-                strncpy(msg->name, name, sizeof(msg->name) - 1);
-            }
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    // GUI --> Service
-    bool settingsSave(Settings settings)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::SettingsSave>();
-        if (msg) {
-            msg->settings = settings;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackStart(bool intervalsMode)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStart>();
-        if (msg) {
-            msg->intervalsMode = intervalsMode;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool intervalsNextPhase()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::IntervalsNextPhase>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackStop(bool discard)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStop>();
-        if (msg) {
-            msg->discard = discard;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackPause()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackPause>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackResume()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackResume>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool manualLap()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::ManualLap>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-private:
-    const SDK::Kernel &mKernel;
-};
 
 
 } // namespace CustomMessage

--- a/Examples/Apps/Running/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Service.hpp
@@ -48,7 +48,6 @@ private:
 
     SDK::Kernel&          mKernel;
     bool                  mGuiStarted;
-    CustomMessage::Sender mGuiSender;
 
     // -- Settings & persistence -----------------------------------------------
 

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -58,7 +58,6 @@ static float speedFromTotals(float distanceM, float activeTimeS)
 Service::Service(SDK::Kernel &kernel)
         : mKernel(kernel)
         , mGuiStarted(false)
-        , mGuiSender(kernel)
         , mSettings{}
         , mSettingsSerializer(mKernel, "settings.json")
         , mSummary{}
@@ -209,7 +208,7 @@ void Service::run()
                 case SDK::MessageType::EVENT_ACCESSORY_STATUS: {
                     auto* evt = static_cast<SDK::Message::Accessory::EventStatus*>(msg);
                     LOG_INFO("Accessory status: state %u\n", evt->state);
-                    mGuiSender.accessoryStatus(evt->state, evt->name);
+                    SDK::send_msg<CustomMessage::AccessoryStatusUpd>(mKernel, evt->state, evt->name);
                 } break;
 
                 default:
@@ -244,9 +243,9 @@ void Service::run()
 
                 // Send to GUI real "local time" to display
                 std::tm tmNow = mTimeTracker.getLocalTime(std::time(nullptr));
-                mGuiSender.time(tmNow);
+                SDK::send_msg<CustomMessage::Time>(mKernel, tmNow);
 
-                mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
+                SDK::send_msg<CustomMessage::Battery>(mKernel, static_cast<uint8_t>(mBatterySoc.get()));
 
                 // Update GPS fix
                 if (mPreviousGpsFixState != mGps.fix) {
@@ -256,7 +255,7 @@ void Service::run()
                         notifyFirstFix();
                         firstFix = true;
                     }
-                    mGuiSender.fix(mGps.fix);
+                    SDK::send_msg<CustomMessage::GpsFix>(mKernel, mGps.fix);
                 }
 
                 if (mTrackState != Track::State::INACTIVE) {
@@ -524,7 +523,7 @@ void Service::handleEvent(const CustomMessage::TrackResume& /*event*/)
 void Service::handleEvent(const CustomMessage::ManualLap& /*event*/)
 {
     saveLap();
-    mGuiSender.lapEnd(mTrackData.lapNum);
+    SDK::send_msg<CustomMessage::LapEnded>(mKernel, mTrackData.lapNum);
     notifyLapEnd();
 }
 
@@ -747,9 +746,9 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat12h, hrThresholds, CustomMessage::kHrThresholdsCount);
-    mGuiSender.summary(&mSummary);
-    mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
+    SDK::send_msg<CustomMessage::SettingsUpd>(mKernel, mSettings, mIsImperial, mTimeFormat12h, hrThresholds, CustomMessage::kHrThresholdsCount);
+    SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
+    SDK::send_msg<CustomMessage::Battery>(mKernel, static_cast<uint8_t>(mBatterySoc.get()));
 }
 
 void Service::startTrack(std::time_t utc)
@@ -837,7 +836,7 @@ void Service::startTrack(std::time_t utc)
 
     mTrackState = Track::State::ACTIVE;
 
-    mGuiSender.trackState(mTrackState);
+    SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 }
 
 void Service::processTrack()
@@ -899,7 +898,7 @@ void Service::processTrack()
     }
 
     // Update GUI
-    mGuiSender.trackData(mTrackData);
+    SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
 
 
     if (mTrackState == Track::State::ACTIVE) {
@@ -965,11 +964,11 @@ void Service::processTrack()
                 mTrackData.avgLapSpeed = speedFromTotals(autoLapDistanceM,
                                                          static_cast<float>(mTrackData.lapTime));
                 mTrackData.lapPace     = getPace(mTrackData.avgLapSpeed, mSpeedCounter.getMinValid());
-                mGuiSender.trackData(mTrackData);
+                SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
             }
 
             saveLap(autoLapDistanceM);
-            mGuiSender.lapEnd(mTrackData.lapNum);
+            SDK::send_msg<CustomMessage::LapEnded>(mKernel, mTrackData.lapNum);
             notifyLapEnd();
         }
 
@@ -1092,7 +1091,7 @@ void Service::stopTrack(bool discard)
         if (!mActivitySummarySerializer.save(mSummary)) {
             LOG_ERROR("Can't save activity summary\n");
         }
-        mGuiSender.summary(&mSummary);
+        SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
 
         // Save FIT file
         ActivityWriter::TrackData fitTrack{};
@@ -1132,7 +1131,7 @@ void Service::stopTrack(bool discard)
     LOG_INFO("Heart rate: %.0f / %.0f bpm\n", mHrCounter.getAverage(), mHrCounter.getMaximum());
     LOG_INFO("Ascent/Descent: %.1f / %.1f m\n", mAltitudeCounter.getAscent(), mAltitudeCounter.getDescent());
 
-    mGuiSender.trackState(mTrackState);
+    SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 
     // Persist the outdoor stride LUT synchronously before the task tears down
     // (only writes if >= 1 sample was accepted this session). finalise()
@@ -1166,10 +1165,10 @@ void Service::pauseTrack(bool pause)
 
         mTrackState = Track::State::PAUSED;
         LOG_INFO("Track paused. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-        mGuiSender.trackState(mTrackState);
+        SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 
         buildPartialSummary();
-        mGuiSender.summary(&mSummary);
+        SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
     } else if (!pause && mTrackState == Track::State::PAUSED) {
         mTimeCounter.resume();
         mDistanceCounter.resume();
@@ -1184,7 +1183,7 @@ void Service::pauseTrack(bool pause)
 
         mTrackState = Track::State::ACTIVE;
         LOG_INFO("Track resumed. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-        mGuiSender.trackState(mTrackState);
+        SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
     }
 }
 
@@ -1524,7 +1523,7 @@ void Service::advanceIntervalsPhase(bool manual)
         // alert=true: user needs notification when workout ends automatically (REST->END).
         // COOL_DOWN->END is always manual, so alert&&!manual stays false -> no vibro.
         onIntervalsPhaseChange(true, manual);
-        mGuiSender.intervalsWorkoutCompleted();
+        SDK::send_msg<CustomMessage::IntervalsWorkoutCompleted>(mKernel);
         return;
     }
 
@@ -1550,7 +1549,7 @@ void Service::advanceIntervalsPhase(bool manual)
                                     (!manual && nextPhase == Track::IntervalsPhase::COOL_DOWN);
 
     if (showAlertScreen) {
-        mGuiSender.intervalsPhaseAlert(mTrackData.intervals);
+        SDK::send_msg<CustomMessage::IntervalsPhaseAlert>(mKernel, mTrackData.intervals);
     }
 
     onIntervalsPhaseChange(showAlertScreen, manual);

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -152,7 +152,6 @@ private:
     // Fields required for GUI <-> Service communication
     ModelListener*           modelListener;
     const SDK::Kernel&       mKernel;
-    CustomMessage::Sender    mSrvSender;
 
     // IGuiLifeCycleCallback
     void onStart()   override;

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -1,4 +1,5 @@
 #include <gui/model/Model.hpp>
+#include "SDK/Messages/MessageGuard.hpp"
 #include <gui/model/ModelListener.hpp>
 #include <gui/common/FrontendApplication.hpp>
 
@@ -12,7 +13,6 @@
 Model::Model()
     : modelListener(nullptr)
     , mKernel(SDK::KernelProviderGUI::GetInstance().getKernel())
-    , mSrvSender(mKernel)
 {
     SDK::TouchGFXCommandProcessor::GetInstance().setAppLifeCycleCallback(this);
     SDK::TouchGFXCommandProcessor::GetInstance().setCustomMessageHandler(this);
@@ -142,7 +142,7 @@ const Settings& Model::getSettings() const
 void Model::saveSettings(const Settings& sett)
 {
     mSettings = sett;
-    mSrvSender.settingsSave(mSettings);
+    SDK::send_msg<CustomMessage::SettingsSave>(mKernel, mSettings);
 }
 
 
@@ -219,12 +219,12 @@ void Model::trackStart(bool intervalsMode)
         }
     }
 
-    mSrvSender.trackStart(intervalsMode);
+    SDK::send_msg<CustomMessage::TrackStart>(mKernel, intervalsMode);
 }
 
 void Model::intervalsNextPhase()
 {
-    mSrvSender.intervalsNextPhase();
+    SDK::send_msg<CustomMessage::IntervalsNextPhase>(mKernel);
 }
 
 bool Model::isTrackActive() const
@@ -234,12 +234,12 @@ bool Model::isTrackActive() const
 
 void Model::trackPause()
 {
-    mSrvSender.trackPause();
+    SDK::send_msg<CustomMessage::TrackPause>(mKernel);
 }
 
 void Model::trackResume()
 {
-    mSrvSender.trackResume();
+    SDK::send_msg<CustomMessage::TrackResume>(mKernel);
 }
 
 bool Model::isTrackPaused() const
@@ -254,17 +254,17 @@ const Track::Data& Model::getTrackData() const
 
 void Model::saveLap()
 {
-    mSrvSender.manualLap();
+    SDK::send_msg<CustomMessage::ManualLap>(mKernel);
 }
 
 void Model::saveTrack()
 {
-    mSrvSender.trackStop(false);
+    SDK::send_msg<CustomMessage::TrackStop>(mKernel, false);
 }
 
 void Model::discardTrack()
 {
-    mSrvSender.trackStop(true);
+    SDK::send_msg<CustomMessage::TrackStop>(mKernel, true);
 }
 
 void Model::setHoldConfirmMode(HoldConfirmMode mode)
@@ -279,7 +279,7 @@ Model::HoldConfirmMode Model::getHoldConfirmMode() const
 
 void Model::trackCalibrate(float distanceActualM)
 {
-    mSrvSender.trackCalibrate(distanceActualM);
+    SDK::send_msg<CustomMessage::TrackCalibrate>(mKernel, distanceActualM);
 }
 
 bool Model::isTrackSummaryAvailable() const
@@ -297,12 +297,12 @@ const ActivitySummary& Model::getTrackSummary() const
 
 void Model::requestCalibrationData()
 {
-    mSrvSender.calibDataRequest();
+    SDK::send_msg<CustomMessage::CalibDataRequest>(mKernel);
 }
 
 void Model::clearCalibrationData()
 {
-    mSrvSender.calibClear();
+    SDK::send_msg<CustomMessage::CalibClear>(mKernel);
 }
 
 

--- a/Examples/Apps/Treadmill/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Header/Commands.hpp
@@ -7,8 +7,6 @@
 #include "SDK/Messages/MessageBase.hpp"
 #include "SDK/Messages/MessageTypes.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
-#include "SDK/Messages/MessageGuard.hpp"
-#include "SDK/Kernel/Kernel.hpp"
 
 // Application types
 #include "Settings.hpp"
@@ -71,6 +69,17 @@ namespace CustomMessage {
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
+
+        explicit SettingsUpd(Settings settings, bool units, bool timeFormat12h,
+                         const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
+            : SettingsUpd()
+        {
+            this->settings          = settings;
+            this->unitsImperial     = units;
+            this->timeFormat12h     = timeFormat12h;
+            memcpy(this->hrThresholds, thresholds, sizeof(this->hrThresholds));
+            this->hrThresholdsCount = thresholdCount;
+        }
     };
 
     // Service --> GUI
@@ -80,6 +89,12 @@ namespace CustomMessage {
             : SDK::MessageBase(LOCAL_TIME)
             , localTime {}
         {}
+
+        explicit Time(std::tm localTime)
+            : Time()
+        {
+            this->localTime = localTime;
+        }
     };
 
     struct Battery : public SDK::MessageBase {
@@ -88,6 +103,12 @@ namespace CustomMessage {
             : SDK::MessageBase(BATTERY)
             , level(0)
         {}
+
+        explicit Battery(uint8_t level)
+            : Battery()
+        {
+            this->level = level;
+        }
     };
 
     struct TrackStateUpd : public SDK::MessageBase {
@@ -96,6 +117,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_STATE_UPDATE)
             , state{}
         {}
+
+        explicit TrackStateUpd(Track::State state)
+            : TrackStateUpd()
+        {
+            this->state = state;
+        }
     };
 
     struct TrackDataUpd : public SDK::MessageBase {
@@ -104,6 +131,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_DATA_UPDATE)
             , data{}
         {}
+
+        explicit TrackDataUpd(const Track::Data &data)
+            : TrackDataUpd()
+        {
+            this->data = data;
+        }
     };
 
     struct LapEnded : public SDK::MessageBase {
@@ -112,6 +145,12 @@ namespace CustomMessage {
             : SDK::MessageBase(LAP_END)
             , lapNum(0)
         {}
+
+        explicit LapEnded(uint32_t lapNum)
+            : LapEnded()
+        {
+            this->lapNum = lapNum;
+        }
     };
 
     struct Summary : public SDK::MessageBase {
@@ -120,11 +159,23 @@ namespace CustomMessage {
             : SDK::MessageBase(SUMMARY)
             , summary(nullptr)
         {}
+
+        explicit Summary(const ActivitySummary* summaryPtr)
+            : Summary()
+        {
+            this->summary = summaryPtr;
+        }
     };
 
     struct IntervalsPhaseAlert : public SDK::MessageBase {
         Track::IntervalsData intervals; ///< Snapshot of the NEW phase — already set before this message is sent
         IntervalsPhaseAlert() : SDK::MessageBase(INTERVALS_PHASE_ALERT) {}
+
+        explicit IntervalsPhaseAlert(const Track::IntervalsData& intervals)
+            : IntervalsPhaseAlert()
+        {
+            this->intervals = intervals;
+        }
     };
 
     struct IntervalsWorkoutCompleted : public SDK::MessageBase {
@@ -141,6 +192,15 @@ namespace CustomMessage {
             , state(0)
             , name{}
         {}
+
+        explicit AccessoryStatusUpd(uint8_t state, const char* name)
+            : AccessoryStatusUpd()
+        {
+            this->state = state;
+            if (name) {
+                strncpy(this->name, name, sizeof(this->name) - 1);
+            }
+        }
     };
 
     // Calibration snapshot for Settings > Calibration > View Data. The Service
@@ -155,6 +215,19 @@ namespace CustomMessage {
             : SDK::MessageBase(CALIB_DATA)
             , status(0), validBins(0), binCount(0), totalDistanceM(0.0f), pct{}
         {}
+
+        explicit CalibData(uint8_t status, uint16_t validBins, uint16_t binCount,
+                         float totalDistanceM, const uint8_t* pct, uint16_t pctCount)
+            : CalibData()
+        {
+            this->status         = status;
+            this->validBins      = validBins;
+            this->binCount       = binCount;
+            this->totalDistanceM = totalDistanceM;
+            const uint16_t n = (pctCount < SDK::Calibration::Config::kBinCount)
+                ? pctCount : SDK::Calibration::Config::kBinCount;
+            memcpy(this->pct, pct, n);
+        }
     };
 
     // GUI --> Service
@@ -165,11 +238,23 @@ namespace CustomMessage {
         SettingsSave()
             : SDK::MessageBase(SETTINGS_SAVE)
         {}
+
+        explicit SettingsSave(Settings settings)
+            : SettingsSave()
+        {
+            this->settings = settings;
+        }
     };
 
     struct TrackStart : public SDK::MessageBase {
         bool intervalsMode = false;
         TrackStart() : SDK::MessageBase(TRACK_START) {}
+
+        explicit TrackStart(bool intervalsMode)
+            : TrackStart()
+        {
+            this->intervalsMode = intervalsMode;
+        }
     };
 
     struct IntervalsNextPhase : public SDK::MessageBase {
@@ -182,6 +267,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_STOP)
             , discard(false)
         {}
+
+        explicit TrackStop(bool discard)
+            : TrackStop()
+        {
+            this->discard = discard;
+        }
     };
 
     struct TrackPause : public SDK::MessageBase {
@@ -205,6 +296,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_CALIBRATE)
             , distanceActualM(0.0f)
         {}
+
+        explicit TrackCalibrate(float distanceActualM)
+            : TrackCalibrate()
+        {
+            this->distanceActualM = distanceActualM;
+        }
     };
 
     // Ask the Service for a fresh calibration snapshot (-> CalibData).
@@ -216,280 +313,6 @@ namespace CustomMessage {
     struct CalibClear : public SDK::MessageBase {
         CalibClear() : SDK::MessageBase(CALIB_CLEAR) {}
     };
-
-
-// Helper wrapper
-class Sender {
-public:
-    Sender(const SDK::Kernel &kernel) :
-            mKernel(kernel)
-    {
-    }
-    virtual ~Sender() = default;
-
-    // Service --> GUI
-    bool settingsUpd(Settings settings, bool units, bool timeFormat12h,
-                     const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
-    {
-        if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
-            msg->settings          = settings;
-            msg->unitsImperial     = units;
-            msg->timeFormat12h     = timeFormat12h;
-            memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
-            msg->hrThresholdsCount = thresholdCount;
-            return msg.send();
-        }
-
-        return false;
-    }
-
-    bool time(std::tm localTime)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Time>();
-        if (msg) {
-            msg->localTime = localTime;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool battery(uint8_t level)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Battery>();
-        if (msg) {
-            msg->level = level;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackState(Track::State state)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStateUpd>();
-        if (msg) {
-            msg->state = state;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackData(const Track::Data &data)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackDataUpd>();
-        if (msg) {
-            msg->data = data;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool intervalsPhaseAlert(const Track::IntervalsData& intervals)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::IntervalsPhaseAlert>();
-        if (msg) {
-            msg->intervals = intervals;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool intervalsWorkoutCompleted()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::IntervalsWorkoutCompleted>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool lapEnd(uint32_t lapNum)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::LapEnded>();
-        if (msg) {
-            msg->lapNum = lapNum;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool summary(const ActivitySummary* summaryPtr)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Summary>();
-        if (msg) {
-            msg->summary = summaryPtr;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool calibData(uint8_t status, uint16_t validBins, uint16_t binCount,
-                   float totalDistanceM, const uint8_t* pct, uint16_t pctCount)
-    {
-        bool status_ = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::CalibData>();
-        if (msg) {
-            msg->status         = status;
-            msg->validBins      = validBins;
-            msg->binCount       = binCount;
-            msg->totalDistanceM = totalDistanceM;
-            const uint16_t n = (pctCount < SDK::Calibration::Config::kBinCount)
-                ? pctCount : SDK::Calibration::Config::kBinCount;
-            memcpy(msg->pct, pct, n);
-            status_ = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status_;
-    }
-
-    bool accessoryStatus(uint8_t state, const char* name)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::AccessoryStatusUpd>();
-        if (msg) {
-            msg->state = state;
-            if (name) {
-                strncpy(msg->name, name, sizeof(msg->name) - 1);
-            }
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    // GUI --> Service
-    bool settingsSave(Settings settings)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::SettingsSave>();
-        if (msg) {
-            msg->settings = settings;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackStart(bool intervalsMode)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStart>();
-        if (msg) {
-            msg->intervalsMode = intervalsMode;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool intervalsNextPhase()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::IntervalsNextPhase>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackStop(bool discard)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStop>();
-        if (msg) {
-            msg->discard = discard;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackPause()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackPause>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackResume()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackResume>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool manualLap()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::ManualLap>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackCalibrate(float distanceActualM)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackCalibrate>();
-        if (msg) {
-            msg->distanceActualM = distanceActualM;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool calibDataRequest()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::CalibDataRequest>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool calibClear()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::CalibClear>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-private:
-    const SDK::Kernel &mKernel;
-};
-
 
 } // namespace CustomMessage
 

--- a/Examples/Apps/Treadmill/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Header/Service.hpp
@@ -49,7 +49,6 @@ private:
 
     SDK::Kernel&          mKernel;
     bool                  mGuiStarted;
-    CustomMessage::Sender mGuiSender;
 
     // -- Settings & persistence -----------------------------------------------
 

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
@@ -54,7 +54,6 @@ static float speedFromTotals(float distanceM, float activeTimeS)
 Service::Service(SDK::Kernel &kernel)
         : mKernel(kernel)
         , mGuiStarted(false)
-        , mGuiSender(kernel)
         , mSettings{}
         , mSettingsSerializer(mKernel, "settings.json")
         , mSummary{}
@@ -222,7 +221,7 @@ void Service::run()
                 case SDK::MessageType::EVENT_ACCESSORY_STATUS: {
                     auto* evt = static_cast<SDK::Message::Accessory::EventStatus*>(msg);
                     LOG_INFO("Accessory status: state %u\n", evt->state);
-                    mGuiSender.accessoryStatus(evt->state, evt->name);
+                    SDK::send_msg<CustomMessage::AccessoryStatusUpd>(mKernel, evt->state, evt->name);
                 } break;
 
                 default:
@@ -243,9 +242,9 @@ void Service::run()
 
                 // Send to GUI real "local time" to display
                 std::tm tmNow = mTimeTracker.getLocalTime(std::time(nullptr));
-                mGuiSender.time(tmNow);
+                SDK::send_msg<CustomMessage::Time>(mKernel, tmNow);
 
-                mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
+                SDK::send_msg<CustomMessage::Battery>(mKernel, static_cast<uint8_t>(mBatterySoc.get()));
 
                 if (mTrackState != Track::State::INACTIVE) {
                     mTimeCounter.add(utc);
@@ -460,7 +459,7 @@ void Service::handleEvent(const CustomMessage::TrackResume& /*event*/)
 void Service::handleEvent(const CustomMessage::ManualLap& /*event*/)
 {
     saveLap();
-    mGuiSender.lapEnd(mTrackData.lapNum);
+    SDK::send_msg<CustomMessage::LapEnded>(mKernel, mTrackData.lapNum);
     notifyLapEnd();
 }
 
@@ -683,9 +682,9 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat12h, hrThresholds, CustomMessage::kHrThresholdsCount);
-    mGuiSender.summary(&mSummary);
-    mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
+    SDK::send_msg<CustomMessage::SettingsUpd>(mKernel, mSettings, mIsImperial, mTimeFormat12h, hrThresholds, CustomMessage::kHrThresholdsCount);
+    SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
+    SDK::send_msg<CustomMessage::Battery>(mKernel, static_cast<uint8_t>(mBatterySoc.get()));
 }
 
 void Service::startTrack(std::time_t utc)
@@ -769,7 +768,7 @@ void Service::startTrack(std::time_t utc)
 
     mTrackState = Track::State::ACTIVE;
 
-    mGuiSender.trackState(mTrackState);
+    SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 }
 
 void Service::processTrack()
@@ -846,7 +845,7 @@ void Service::processTrack()
     }
 
     // Update GUI
-    mGuiSender.trackData(mTrackData);
+    SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
 
 
     if (mTrackState == Track::State::ACTIVE) {
@@ -891,11 +890,11 @@ void Service::processTrack()
                 mTrackData.avgLapSpeed = speedFromTotals(autoLapDistanceM,
                                                          static_cast<float>(mTrackData.lapTime));
                 mTrackData.lapPace     = getPace(mTrackData.avgLapSpeed, mSpeedCounter.getMinValid());
-                mGuiSender.trackData(mTrackData);
+                SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
             }
 
             saveLap(autoLapDistanceM);
-            mGuiSender.lapEnd(mTrackData.lapNum);
+            SDK::send_msg<CustomMessage::LapEnded>(mKernel, mTrackData.lapNum);
             notifyLapEnd();
         }
 
@@ -1001,7 +1000,7 @@ void Service::stopTrack(bool discard)
         mActivityWriter.discard();
         mAwaitingCalibration = false;
         mTrackState = Track::State::INACTIVE;
-        mGuiSender.trackState(mTrackState);
+        SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
         disconnect();
         LOG_INFO("Track discarded.\n");
         return;
@@ -1026,7 +1025,7 @@ void Service::stopTrack(bool discard)
     if (!mActivitySummarySerializer.save(mSummary)) {
         LOG_ERROR("Can't save activity summary\n");
     }
-    mGuiSender.summary(&mSummary);
+    SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
 
     // Snapshot the FIT session message and the inputs for the §5.3 delta update.
     mPendingFitTrack = ActivityWriter::TrackData{};
@@ -1051,7 +1050,7 @@ void Service::stopTrack(bool discard)
     mCalibDEstimatedM = mDistanceCounter.getValueActive();
 
     mTrackState = Track::State::INACTIVE;
-    mGuiSender.trackState(mTrackState);
+    SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
     disconnect();
 
     LOG_INFO("Track stopped. Time %u/%u s, Dist %.1f m\n",
@@ -1106,7 +1105,7 @@ void Service::finalizeActivity(float distanceActualM)
     if (!mActivitySummarySerializer.save(mSummary)) {
         LOG_ERROR("Can't save activity summary\n");
     }
-    mGuiSender.summary(&mSummary);
+    SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
 
     if (mActivityWriter.stop(mPendingFitTrack)) {
         notifyNewActivity();
@@ -1151,8 +1150,8 @@ void Service::handleEvent(const CustomMessage::CalibDataRequest& /*event*/)
     const uint8_t status = lut.readyForPhase2()          ? 2
                          : lut.readyForOutdoorEstimate()  ? 1
                                                           : 0;
-    mGuiSender.calibData(status, static_cast<uint16_t>(lut.validBinCount()), kN,
-                         lut.totalCalibrationDistanceM(), pct, kN);
+    SDK::send_msg<CustomMessage::CalibData>(mKernel, status, static_cast<uint16_t>(lut.validBinCount()), kN,
+                                   lut.totalCalibrationDistanceM(), pct, kN);
 }
 
 void Service::handleEvent(const CustomMessage::CalibClear& /*event*/)
@@ -1198,10 +1197,10 @@ void Service::pauseTrack(bool pause)
 
         mTrackState = Track::State::PAUSED;
         LOG_INFO("Track paused. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-        mGuiSender.trackState(mTrackState);
+        SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 
         buildPartialSummary();
-        mGuiSender.summary(&mSummary);
+        SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
     } else if (!pause && mTrackState == Track::State::PAUSED) {
         mTimeCounter.resume();
         mDistanceCounter.resume();
@@ -1216,7 +1215,7 @@ void Service::pauseTrack(bool pause)
 
         mTrackState = Track::State::ACTIVE;
         LOG_INFO("Track resumed. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-        mGuiSender.trackState(mTrackState);
+        SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
     }
 }
 
@@ -1556,7 +1555,7 @@ void Service::advanceIntervalsPhase(bool manual)
         // alert=true: user needs notification when workout ends automatically (REST->END).
         // COOL_DOWN->END is always manual, so alert&&!manual stays false -> no vibro.
         onIntervalsPhaseChange(true, manual);
-        mGuiSender.intervalsWorkoutCompleted();
+        SDK::send_msg<CustomMessage::IntervalsWorkoutCompleted>(mKernel);
         return;
     }
 
@@ -1582,7 +1581,7 @@ void Service::advanceIntervalsPhase(bool manual)
                                     (!manual && nextPhase == Track::IntervalsPhase::COOL_DOWN);
 
     if (showAlertScreen) {
-        mGuiSender.intervalsPhaseAlert(mTrackData.intervals);
+        SDK::send_msg<CustomMessage::IntervalsPhaseAlert>(mKernel, mTrackData.intervals);
     }
 
     onIntervalsPhaseChange(showAlertScreen, manual);

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -111,7 +111,6 @@ private:
     // Fields required for GUI <-> Service communication
     ModelListener*           modelListener;
     const SDK::Kernel&       mKernel;
-    CustomMessage::Sender    mSrvSender;
 
     // IGuiLifeCycleCallback
     void onStart()   override;

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -1,4 +1,5 @@
 #include <gui/model/Model.hpp>
+#include "SDK/Messages/MessageGuard.hpp"
 #include <gui/model/ModelListener.hpp>
 #include <gui/common/FrontendApplication.hpp>
 
@@ -12,7 +13,6 @@
 Model::Model()
     : modelListener(nullptr)
     , mKernel(SDK::KernelProviderGUI::GetInstance().getKernel())
-    , mSrvSender(mKernel)
 {
     SDK::TouchGFXCommandProcessor::GetInstance().setAppLifeCycleCallback(this);
     SDK::TouchGFXCommandProcessor::GetInstance().setCustomMessageHandler(this);
@@ -142,7 +142,7 @@ const Settings& Model::getSettings() const
 void Model::saveSettings(const Settings& sett)
 {
     mSettings = sett;
-    mSrvSender.settingsSave(mSettings);
+    SDK::send_msg<CustomMessage::SettingsSave>(mKernel, mSettings);
 }
 
 
@@ -150,7 +150,7 @@ void Model::saveSettings(const Settings& sett)
 
 void Model::trackStart()
 {
-    mSrvSender.trackStart();
+    SDK::send_msg<CustomMessage::TrackStart>(mKernel);
 }
 
 bool Model::isTrackActive() const
@@ -160,12 +160,12 @@ bool Model::isTrackActive() const
 
 void Model::trackPause()
 {
-    mSrvSender.trackPause();
+    SDK::send_msg<CustomMessage::TrackPause>(mKernel);
 }
 
 void Model::trackResume()
 {
-    mSrvSender.trackResume();
+    SDK::send_msg<CustomMessage::TrackResume>(mKernel);
 }
 
 bool Model::isTrackPaused() const
@@ -180,7 +180,7 @@ const Track::Data& Model::getTrackData() const
 
 void Model::saveLap()
 {
-    mSrvSender.manualLap();
+    SDK::send_msg<CustomMessage::ManualLap>(mKernel);
 }
 
 void Model::setHoldConfirmMode(HoldConfirmMode mode)
@@ -195,12 +195,12 @@ Model::HoldConfirmMode Model::getHoldConfirmMode() const
 
 void Model::saveTrack()
 {
-    mSrvSender.trackStop(false);
+    SDK::send_msg<CustomMessage::TrackStop>(mKernel, false);
 }
 
 void Model::discardTrack()
 {
-    mSrvSender.trackStop(true);
+    SDK::send_msg<CustomMessage::TrackStop>(mKernel, true);
 }
 
 bool Model::isTrackSummaryAvailable() const

--- a/Examples/Apps/Workout/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Workout/Software/Libs/Header/Commands.hpp
@@ -7,8 +7,6 @@
 #include "SDK/Messages/MessageBase.hpp"
 #include "SDK/Messages/MessageTypes.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
-#include "SDK/Messages/MessageGuard.hpp"
-#include "SDK/Kernel/Kernel.hpp"
 
 // Application types
 #include "Settings.hpp"
@@ -61,6 +59,17 @@ namespace CustomMessage {
             , hrThresholds {}
             , hrThresholdsCount(0)
         {}
+
+        explicit SettingsUpd(Settings settings, bool units, bool timeFormat12h,
+                         const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
+            : SettingsUpd()
+        {
+            this->settings          = settings;
+            this->unitsImperial     = units;
+            this->timeFormat12h     = timeFormat12h;
+            memcpy(this->hrThresholds, thresholds, sizeof(this->hrThresholds));
+            this->hrThresholdsCount = thresholdCount;
+        }
     };
 
     // Service --> GUI
@@ -70,6 +79,12 @@ namespace CustomMessage {
             : SDK::MessageBase(LOCAL_TIME)
             , localTime {}
         {}
+
+        explicit Time(std::tm localTime)
+            : Time()
+        {
+            this->localTime = localTime;
+        }
     };
 
     struct Battery : public SDK::MessageBase {
@@ -78,6 +93,12 @@ namespace CustomMessage {
             : SDK::MessageBase(BATTERY)
             , level(0)
         {}
+
+        explicit Battery(uint8_t level)
+            : Battery()
+        {
+            this->level = level;
+        }
     };
 
     struct TrackStateUpd : public SDK::MessageBase {
@@ -86,6 +107,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_STATE_UPDATE)
             , state{}
         {}
+
+        explicit TrackStateUpd(Track::State state)
+            : TrackStateUpd()
+        {
+            this->state = state;
+        }
     };
 
     struct TrackDataUpd : public SDK::MessageBase {
@@ -94,6 +121,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_DATA_UPDATE)
             , data{}
         {}
+
+        explicit TrackDataUpd(const Track::Data &data)
+            : TrackDataUpd()
+        {
+            this->data = data;
+        }
     };
 
     struct LapEnded : public SDK::MessageBase {
@@ -102,6 +135,12 @@ namespace CustomMessage {
             : SDK::MessageBase(LAP_END)
             , lapNum(0)
         {}
+
+        explicit LapEnded(uint32_t lapNum)
+            : LapEnded()
+        {
+            this->lapNum = lapNum;
+        }
     };
 
     struct Summary : public SDK::MessageBase {
@@ -110,6 +149,12 @@ namespace CustomMessage {
             : SDK::MessageBase(SUMMARY)
             , summary(nullptr)
         {}
+
+        explicit Summary(const ActivitySummary* summaryPtr)
+            : Summary()
+        {
+            this->summary = summaryPtr;
+        }
     };
 
     // External-accessory link status forwarded from the kernel's
@@ -122,6 +167,15 @@ namespace CustomMessage {
             , state(0)
             , name{}
         {}
+
+        explicit AccessoryStatusUpd(uint8_t state, const char* name)
+            : AccessoryStatusUpd()
+        {
+            this->state = state;
+            if (name) {
+                strncpy(this->name, name, sizeof(this->name) - 1);
+            }
+        }
     };
 
     // GUI --> Service
@@ -132,6 +186,12 @@ namespace CustomMessage {
         SettingsSave()
             : SDK::MessageBase(SETTINGS_SAVE)
         {}
+
+        explicit SettingsSave(Settings settings)
+            : SettingsSave()
+        {
+            this->settings = settings;
+        }
     };
 
     struct TrackStart : public SDK::MessageBase {
@@ -144,6 +204,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TRACK_STOP)
             , discard(false)
         {}
+
+        explicit TrackStop(bool discard)
+            : TrackStop()
+        {
+            this->discard = discard;
+        }
     };
 
     struct TrackPause : public SDK::MessageBase {
@@ -157,191 +223,6 @@ namespace CustomMessage {
     struct ManualLap : public SDK::MessageBase {
         ManualLap() : SDK::MessageBase(MANUAL_LAP) {}
     };
-
-
-// Helper wrapper
-class Sender {
-public:
-    Sender(const SDK::Kernel &kernel) :
-            mKernel(kernel)
-    {
-    }
-    virtual ~Sender() = default;
-
-    // Service --> GUI
-    bool settingsUpd(Settings settings, bool units, bool timeFormat12h,
-                     const uint8_t (&thresholds)[kHrThresholdsCount], uint8_t thresholdCount)
-    {
-        if (auto msg = SDK::make_msg<CustomMessage::SettingsUpd>(mKernel)) {
-            msg->settings          = settings;
-            msg->unitsImperial     = units;
-            msg->timeFormat12h     = timeFormat12h;
-            memcpy(msg->hrThresholds, thresholds, sizeof(msg->hrThresholds));
-            msg->hrThresholdsCount = thresholdCount;
-            return msg.send();
-        }
-
-        return false;
-    }
-
-    bool time(std::tm localTime)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Time>();
-        if (msg) {
-            msg->localTime = localTime;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool battery(uint8_t level)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Battery>();
-        if (msg) {
-            msg->level = level;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackState(Track::State state)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStateUpd>();
-        if (msg) {
-            msg->state = state;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackData(const Track::Data &data)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackDataUpd>();
-        if (msg) {
-            msg->data = data;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool lapEnd(uint32_t lapNum)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::LapEnded>();
-        if (msg) {
-            msg->lapNum = lapNum;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool summary(const ActivitySummary* summaryPtr)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::Summary>();
-        if (msg) {
-            msg->summary = summaryPtr;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool accessoryStatus(uint8_t state, const char* name)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::AccessoryStatusUpd>();
-        if (msg) {
-            msg->state = state;
-            if (name) {
-                strncpy(msg->name, name, sizeof(msg->name) - 1);
-            }
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    // GUI --> Service
-    bool settingsSave(Settings settings)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::SettingsSave>();
-        if (msg) {
-            msg->settings = settings;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackStart()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStart>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackStop(bool discard)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackStop>();
-        if (msg) {
-            msg->discard = discard;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackPause()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackPause>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool trackResume()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::TrackResume>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool manualLap()
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<CustomMessage::ManualLap>();
-        if (msg) {
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-private:
-    const SDK::Kernel &mKernel;
-};
 
 
 } // namespace CustomMessage

--- a/Examples/Apps/Workout/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Workout/Software/Libs/Header/Service.hpp
@@ -42,7 +42,6 @@ private:
 
     SDK::Kernel&          mKernel;
     bool                  mGuiStarted;
-    CustomMessage::Sender mGuiSender;
 
     // -- Settings & persistence -----------------------------------------------
 

--- a/Examples/Apps/Workout/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Workout/Software/Libs/Sources/Service.cpp
@@ -35,7 +35,6 @@ constexpr std::time_t kOneSecond = 1;
 Service::Service(SDK::Kernel &kernel)
         : mKernel(kernel)
         , mGuiStarted(false)
-        , mGuiSender(kernel)
         , mSettings{}
         , mSettingsSerializer(mKernel, "settings.json")
         , mSummary{}
@@ -173,7 +172,7 @@ void Service::run()
                 case SDK::MessageType::EVENT_ACCESSORY_STATUS: {
                     auto* evt = static_cast<SDK::Message::Accessory::EventStatus*>(msg);
                     LOG_INFO("Accessory status: state %u\n", evt->state);
-                    mGuiSender.accessoryStatus(evt->state, evt->name);
+                    SDK::send_msg<CustomMessage::AccessoryStatusUpd>(mKernel, evt->state, evt->name);
                 } break;
 
                 default:
@@ -194,9 +193,9 @@ void Service::run()
 
                 // Send to GUI real "local time" to display
                 std::tm tmNow = mTimeTracker.getLocalTime(std::time(nullptr));
-                mGuiSender.time(tmNow);
+                SDK::send_msg<CustomMessage::Time>(mKernel, tmNow);
 
-                mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
+                SDK::send_msg<CustomMessage::Battery>(mKernel, static_cast<uint8_t>(mBatterySoc.get()));
 
                 if (mTrackState != Track::State::INACTIVE) {
                     mTimeCounter.add(utc);
@@ -384,7 +383,7 @@ void Service::handleEvent(const CustomMessage::TrackResume& /*event*/)
 void Service::handleEvent(const CustomMessage::ManualLap& /*event*/)
 {
     saveLap();
-    mGuiSender.lapEnd(mTrackData.lapNum);
+    SDK::send_msg<CustomMessage::LapEnded>(mKernel, mTrackData.lapNum);
     notifyLapEnd();
 }
 
@@ -583,11 +582,11 @@ void Service::sendInitialInfoToGui()
         }
     }
 
-    mGuiSender.settingsUpd(mSettings, mIsImperial, mTimeFormat12h, hrThresholds, CustomMessage::kHrThresholdsCount);
+    SDK::send_msg<CustomMessage::SettingsUpd>(mKernel, mSettings, mIsImperial, mTimeFormat12h, hrThresholds, CustomMessage::kHrThresholdsCount);
     memcpy(mHrThresholds.data(), hrThresholds, sizeof(hrThresholds));
     mHrThresholdCount = CustomMessage::kHrThresholdsCount;
-    mGuiSender.summary(&mSummary);
-    mGuiSender.battery(static_cast<uint8_t>(mBatterySoc.get()));
+    SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
+    SDK::send_msg<CustomMessage::Battery>(mKernel, static_cast<uint8_t>(mBatterySoc.get()));
 }
 
 void Service::startTrack(std::time_t utc)
@@ -630,7 +629,7 @@ void Service::startTrack(std::time_t utc)
 
     mTrackState = Track::State::ACTIVE;
 
-    mGuiSender.trackState(mTrackState);
+    SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 }
 
 void Service::processTrack()
@@ -657,7 +656,7 @@ void Service::processTrack()
     updateHrDerivedMetrics();
 
     // Update GUI
-    mGuiSender.trackData(mTrackData);
+    SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
 
 
     if (mTrackState == Track::State::ACTIVE) {
@@ -682,7 +681,7 @@ void Service::processTrack()
 
         if (switchLap) {
             saveLap();
-            mGuiSender.lapEnd(mTrackData.lapNum);
+            SDK::send_msg<CustomMessage::LapEnded>(mKernel, mTrackData.lapNum);
             notifyLapEnd();
         }
 
@@ -806,7 +805,7 @@ void Service::stopTrack(bool discard)
         if (!mActivitySummarySerializer.save(mSummary)) {
             LOG_ERROR("Can't save activity summary\n");
         }
-        mGuiSender.summary(&mSummary);
+        SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
 
         // Save FIT file
         ActivityWriter::TrackData fitTrack{};
@@ -838,7 +837,7 @@ void Service::stopTrack(bool discard)
     LOG_INFO("Heart rate: %.0f / %.0f bpm\n", mHrCounter.getAverage(), mHrCounter.getMaximum());
     LOG_INFO("Calories: %.1f kcal\n", mTrackData.totalCalories);
 
-    mGuiSender.trackState(mTrackState);
+    SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 
     disconnect();
 }
@@ -860,10 +859,10 @@ void Service::pauseTrack(bool pause)
 
         mTrackState = Track::State::PAUSED;
         LOG_INFO("Track paused. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-        mGuiSender.trackState(mTrackState);
+        SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
 
         buildPartialSummary();
-        mGuiSender.summary(&mSummary);
+        SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
     } else if (!pause && mTrackState == Track::State::PAUSED) {
         mTimeCounter.resume();
         mDistanceCounter.resume();
@@ -875,7 +874,7 @@ void Service::pauseTrack(bool pause)
 
         mTrackState = Track::State::ACTIVE;
         LOG_INFO("Track resumed. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-        mGuiSender.trackState(mTrackState);
+        SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
     }
 }
 

--- a/Libs/Header/SDK/Interfaces/IAppComm.hpp
+++ b/Libs/Header/SDK/Interfaces/IAppComm.hpp
@@ -111,16 +111,18 @@ public:
      * @retval nullptr if allocation failed
      *
      * @note Template wrapper for type-safe allocation
-     * @note Calls placement new on allocated memory
+     * @note Calls placement new on allocated memory, forwarding any ctor args
      * @note Pool determined automatically by address during deallocation
      * @note Example: auto* msg = comm->allocateMessage<GpsRequestMsg>();
+     * @note Example: auto* msg = comm->allocateMessage<BatteryMsg>(level);
      */
-    template<typename T>
-    T* allocateMessage() {
+    template<typename T, typename... Args>
+    T* allocateMessage(Args&&... args) {
         void* ptr = allocateMessage(sizeof(T));
         if (ptr) {
-            // Placement new to construct typed object
-            return new (ptr) T();
+            // Placement new to construct typed object (forwarding ctor args).
+            // static_cast<Args&&> is std::forward without pulling in <utility>.
+            return new (ptr) T(static_cast<Args&&>(args)...);
         }
         return nullptr;
     }

--- a/Libs/Header/SDK/Messages/MessageGuard.hpp
+++ b/Libs/Header/SDK/Messages/MessageGuard.hpp
@@ -69,10 +69,11 @@ private:
     T*                 mPtr;
 };
 
-template<typename T>
-MessageGuard<T> make_msg(const SDK::Kernel& kernel)
+template<typename T, typename... Args>
+MessageGuard<T> make_msg(const SDK::Kernel& kernel, Args&&... args)
 {
-    T* raw = kernel.comm.template allocateMessage<T>();
+    // static_cast<Args&&> is std::forward without pulling in <utility>.
+    T* raw = kernel.comm.template allocateMessage<T>(static_cast<Args&&>(args)...);
     return MessageGuard<T>(kernel, raw);
 }
 
@@ -82,6 +83,19 @@ inline SDK::MessageGuard<MessageID> make_msg(const SDK::Kernel&     kernel,
     auto* raw = kernel.comm.template allocateMessage<MessageID>(); // 0 args
     raw->setType(type);
     return SDK::MessageGuard<MessageID>(kernel, raw);
+}
+
+// One-shot: allocate a T (forwarding any ctor args), send it, and release it on return -- the whole
+// send path for a fire-and-forget message in one call, so the message type stays pure data and never
+// needs to know about the kernel.
+template<typename T, typename... Args>
+bool send_msg(const SDK::Kernel& kernel, Args&&... args)
+{
+    auto guard = make_msg<T>(kernel, static_cast<Args&&>(args)...);
+    if (!guard) {
+        return false;
+    }
+    return guard.send();
 }
 
 } // namespace SDK


### PR DESCRIPTION
This is an exercise in bloat reduction, trying to make it so any new example has less to copy/paste.


Every app hand-rolled a `CustomMessage::Sender` whose methods were all the same allocate/set/send/release sequence. These were all copies of what it appears `make_msg` was introduced to accomplish.

`allocateMessage` and `make_msg` now forward constructor arguments, and a new `send_msg<T>(kernel, ...)` does the allocate/send/release in one call. Messages are plain structs again: each gets a constructor that fills its own fields (the memcpy/strncpy/clamp cases carried over unchanged) and no longer holds a kernel reference. Call sites become
`SDK::send_msg<CustomMessage::TrackStateUpd>(kernel, state)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and consistency of GUI↔service messaging across Alarm, Cycling, HR Monitor, Hiking, Running, Treadmill, and Workout apps.
  * Alarm playback/control, snoozing, and alarm list updates now propagate more consistently, including active-alarm startup behavior.
  * Track/lap lifecycle events, summaries, sensor/telemetry updates, calibration status, and interval-training notifications are forwarded more reliably.
  * Startup/resume GUI state (initial settings/summaries and live telemetry like time/battery/GPS) stays correctly synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->