### PR TITLE
feat(sensor): add experimental RR_INTERVAL beat-to-beat pathway

### DIFF
--- a/Docs/ExternalSensors.md
+++ b/Docs/ExternalSensors.md
@@ -75,3 +75,115 @@ against this SDK keeps working as the frame grows. Use this to label records or
 log separate FIT series (e.g. `hr_source`, internal-PPG, and external-strap HR)
 — do not gate HR display on it. Apps that only need BPM should stay on
 `HEART_RATE` and ignore `HEART_RATE_EX` entirely.
+
+## Beat-to-beat R-R intervals (`RR_INTERVAL`, experimental)
+
+> **Experimental — there is no firmware producer yet.** `0x44` is the SDK-side
+> half of the contract, landed so HRV / DFA-alpha1 work can be built against a
+> fixed shape. Do not ship against it until a producer exists.
+
+`HEART_RATE` and `HEART_RATE_EX` both carry a *rate*. HRV metrics (RMSSD, SDNN,
+DFA-alpha1, threshold detection) need the individual beat-to-beat intervals
+instead, which a strap reports in the same `0x2A37` notification as the BPM.
+`RR_INTERVAL` is the opt-in sensor type that carries them, parsed with
+`SDK::SensorDataParser::RrInterval`:
+
+- `getRrMs()` — the interval in milliseconds;
+- `getBpm()` — the implied instantaneous rate, a convenience, **not** a smoothed
+  HR;
+- `getSource()` → `Source::{UNKNOWN, OPTICAL, EXTERNAL, ECG}` — the shared
+  values are `static_assert`ed against `HeartRateEx::Source`;
+- `hasDiscontinuity()` / `isArtifactSuspect()` / `isSkinContactLost()` — quality
+  and continuity signals;
+- `checkContinuity(prevTimestampUs)` → `Continuity::{UNUSABLE, CONTIGUOUS, GAP,
+  REORDERED}` — whether this interval continues from the previous one. A lost or
+  reordered frame is otherwise undetectable.
+
+**This page owns the producer half; `SensorDataParserRrInterval.hpp` owns the
+consumer half.** Read both before writing either. The rules most easily assumed
+wrongly: one interval per frame rather than one per callback; mixed field types
+rather than the all-float `HEART_RATE_EX` layout; a frame timestamp that is a beat
+instant rather than an arrival; event-based delivery; and which frame counts as
+"previous" when checking continuity — the consumer's obligation, and not
+simply the frame you saw last.
+
+### Notes for whoever writes the producer
+
+The R-R array is the **last** field of the `0x2A37` notification and its offset is
+variable, so a decoder has to walk the flags byte rather than assume a layout:
+
+| Flags bit | Effect on the layout |
+|---|---|
+| 0 | HR value is `uint8` (0) or `uint16` (1) |
+| 1 | sensor contact detected — the source for `NO_SKIN_CONTACT` |
+| 2 | sensor contact supported; when 0, bit 1 carries no information |
+| 3 | a 2-byte *energy expended* field is present, **before** the R-R array |
+| 4 | the R-R array is present |
+
+The R-R values themselves are `uint16` in units of 1/1024 s, oldest first, filling
+the remainder of the notification.
+
+Bit 3 is the trap. The kernel decoder reads only the 16-bit-value,
+contact-detected and contact-supported bits (Ross Ryles, PR #220), so a producer
+extended from it will have every R-R offset wrong on any strap that reports energy
+expended — and the misread values still look like plausible intervals, so nothing
+downstream will flag it.
+
+`NO_SKIN_CONTACT` collapses bits 1 and 2 into one flag, which fails in the safe
+direction: 0 means "do not discard", which is also what "contact detection
+unsupported" and "flags not populated" mean. If a producer needs to distinguish
+them, a new flag bit can be added at any time without breaking anything already
+built — undefined bits are ignored by the accessors.
+
+Leave `DETECTOR_STAMPED` clear: decoding `0x2A37` means seeing a notification
+arrive, not a beat, so the claim that flag makes does not apply to you. No budget
+turns on it today — there is one continuity budget, because nothing in this SDK can
+size a tighter one — but it is the record of how the stamp was obtained, a consumer
+may key its own budget on it, and it is the one bit that could later make a consumer
+stricter rather than more forgiving. Clearing it is always safe.
+
+### What a producer owes
+
+None of this is enforced by the SDK.
+
+- **Register `getFieldsNumber()` as the delivery stride**, not the parse minimum.
+  The stride is fixed per driver and a consumer's field count derives from it, so a
+  narrower registration makes the later fields permanently undeliverable.
+- **Write every field you registered, on every frame.** Nothing guarantees a frame
+  is cleared between pushes, so an unwritten field may still hold the previous
+  one's value. Set `DISCONTINUITY` after a reconnect and never rewrite `FLAGS`, and
+  the bit stays set for the session — which reads downstream as a stream that is
+  never contiguous, and makes an HRV consumer discard every window.
+- **A producer that knows it has a gap says so with `DISCONTINUITY`.**
+- **Emit a frame only when you have an interval.** There are no status-only frames:
+  `isDataValid()` rejects a zero interval and every accessor that reads the frame
+  then reads it as absent, so its flags would not arrive anyway.
+- **Report float milliseconds** whatever the native unit. A strap's 1/1024 s ticks
+  convert losslessly: one tick is 125/128 ms, exact in binary floating point, and
+  `n * 125` stays under float32's 2^24 exact-integer limit for every count a 16-bit
+  wire field can hold.
+- **Register event-based delivery** (`Driver::Mode::EVENT_BASED` on the simulator's
+  driver; on-device, the kernel's equivalent). Nothing guarantees a periodic path
+  preserves every frame, and a decimated beat stream loses beats rather than
+  coarsening.
+- **Register a minimum delivery period no longer than the shortest interval you
+  will emit**, and do so even where you also register the mode above. A
+  rate-adapting path is free to thin frames arriving closer together than the period
+  it was given; thinning a beat stream is losing beats, and nothing guarantees a
+  given platform's event path bypasses rate adaptation.
+- **Stamp the beat instant the interval ends on, in the microsecond domain.** An
+  interval is fractional in milliseconds, so whole-millisecond stamping throws that
+  fraction away for nothing. Put whole milliseconds in `mTimeStamp` and the
+  sub-millisecond remainder in `mTimeStampUs`.
+
+If your detector reports beat instants, stamp those and set `DETECTOR_STAMPED`. If
+you see only arrival, reconstruct them — for the `k` intervals of a notification
+arriving at `T`, in wire order, `t[i] = T - SUM(rr[j] for j > i)` — and leave the
+bit clear. That subtraction is a recipe for a producer with nothing better, not the
+definition of the field. Where it underflows, because a notification arrives less
+than `SUM(rr)` after boot, emit only the intervals whose instant is representable
+and set `DISCONTINUITY` on the first emitted. Do not invent a stamp for the rest,
+and never stamp zero, which is not an instant.
+
+Strap battery level is out of scope: it lives on a separate standard service
+(`0x180F`), so it is neither the same packet nor HRV-relevant.

--- a/Docs/SensorsLayer.md
+++ b/Docs/SensorsLayer.md
@@ -23,6 +23,8 @@ All available sensor types are defined in [`SDK::Sensor::Type`](../Libs/Header/S
 | Cardio | HEART_BEAT | 0x40 | Beat peak event | No | - |
 | Cardio | HEART_RATE | 0x41 | Current heart rate (bpm) | Yes | BPM (float), TRUST_LEVEL (float) - 2 |
 | Cardio | HEART_RATE_METRICS | 0x42 | Aggregated metrics (AHR, RHR) | Yes | AHR (float bpm), RHR (float bpm) - 2 |
+| Cardio | HEART_RATE_EX | 0x43 | Opt-in multi-source HR (arbitrated + source + raw) | Yes | BPM, TRUST, SOURCE, OPTICAL_BPM, OPTICAL_TRUST, EXTERNAL_BPM, EXTERNAL_TRUST (all float) - 7 |
+| Cardio | RR_INTERVAL | 0x44 | Beat-to-beat R-R interval (experimental) | Yes | RR_MS (float ms), SOURCE (u32 enum), FLAGS (u32 bits) - 3 |
 | Pedometer | STEP_DETECTOR | 0x50 | Step event | Yes | STEP_DETECTED (u32=1) - 1 |
 | Pedometer | STEP_COUNTER | 0x51 | Step count since reboot | Yes | STEP_COUNT (u32) - 1 |
 | Pedometer | FLOOR_COUNTER | 0x60 | Floor counter | Yes | FLOORS_UP (i32), FLOORS_DOWN (i32) - 2 |
@@ -155,6 +157,51 @@ As above, `float bpm = p.getBpm(); float trust = p.getTrustLevel();`
 |-------|------|------|------|
 | 0 | AHR | float | bpm |
 | 1 | RHR | float | bpm |
+
+### HEART_RATE_EX (0x43)
+
+**Parser**: `SDK::SensorDataParser::HeartRateEx`
+
+**Fields**:
+| Index | Name | Type | Unit |
+|-------|------|------|------|
+| 0 | BPM | float | bpm (arbitrated; same value as `HEART_RATE`) |
+| 1 | TRUST_LEVEL | float | - |
+| 2 | SOURCE | float | `Source`: 0 unknown, 1 optical, 2 external strap |
+| 3 | OPTICAL_BPM | float | bpm (raw PPG; 0 when absent/stale/off-wrist) |
+| 4 | OPTICAL_TRUST | float | - |
+| 5 | EXTERNAL_BPM | float | bpm (raw strap; 0 when absent/stale) |
+| 6 | EXTERNAL_TRUST | float | - |
+
+Opt-in. Carries the same arbitrated reading as `HEART_RATE` plus which source it
+came from and the raw per-source values, so an app can label records or log
+separate FIT series. Apps that only need BPM should stay on `HEART_RATE`. See
+[External Sensors](ExternalSensors.md) for the source semantics.
+
+### RR_INTERVAL (0x44)
+
+**Parser**: `SDK::SensorDataParser::RrInterval`
+
+**Fields**:
+| Index | Name | Type | Unit |
+|-------|------|------|------|
+| 0 | RR_MS | float | ms |
+| 1 | SOURCE | u32 | `Source`: 0 unknown, 1 optical, 2 external strap, 3 ECG |
+| 2 | FLAGS | u32 | bit0 discontinuity, bit1 artifact-suspect, bit2 no-skin-contact, bit3 detector-stamped |
+
+Experimental and opt-in. Unlike the other cardio types it carries the individual
+beat-to-beat intervals rather than a rate, which is what HRV metrics (RMSSD, SDNN,
+DFA-alpha1) are computed from. Three things make it unlike the frames above: one
+interval per frame, so iterate `DataBatch::size()`; mixed field types, so read `[0]`
+through `.f` and `[1]`/`[2]` through `.u`; and the frame timestamp is the beat
+instant the interval ends on, so continuity is checked with
+`RrInterval::checkContinuity()` rather than by comparing timestamps by hand.
+
+The consumer contract — the timestamp and continuity rules — is in
+`SensorDataParserRrInterval.hpp`. What a producer owes, and the `0x2A37` field layout
+it has to decode, are in [External Sensors](ExternalSensors.md). There is no
+firmware producer yet, so do not ship
+against `0x44` until there is one.
 
 ### STEP_DETECTOR (0x50)
 

--- a/Libs/Header/SDK/SensorLayer/DataParsers/SensorDataParserRrInterval.hpp
+++ b/Libs/Header/SDK/SensorLayer/DataParsers/SensorDataParserRrInterval.hpp
@@ -1,0 +1,541 @@
+/**
+ ******************************************************************************
+ * @file    SensorDataParserRrInterval.hpp
+ * @brief   SensorData parser for the RR_INTERVAL (beat-to-beat) sensor.
+ ******************************************************************************
+ *
+ * EXPERIMENTAL. There is no firmware producer yet, and 0x44 is not stable until
+ * one has been written against this header.
+ *
+ * One beat-to-beat R-R interval per frame — the gap between consecutive
+ * heartbeats, which is what RMSSD, SDNN and DFA alpha1 are computed from. Opt-in:
+ * offering it must not change what a HEART_RATE consumer already sees.
+ *
+ * FIELD LAYOUT. Positional, each field a fixed type in the Data union — unlike
+ * HEART_RATE_EX this frame is not all-float, so a producer writes through the
+ * matching writer (.f / .u) or a consumer reads garbage.
+ *
+ *   [0] rr_ms   float, REQUIRED — the interval in milliseconds
+ *   [1] source  u32   — Source
+ *   [2] flags   u32   — Flag bits
+ *   [3] RESERVED for a graded per-beat confidence. Nothing else may take it.
+ *
+ * Data carries no in-band length field, so a frame cannot hold a variable-length
+ * burst: the several intervals of one 0x2A37 notification arrive as consecutive
+ * one-interval frames, and a consumer iterates DataBatch::size() rather than
+ * assuming one frame per callback.
+ *
+ * WHAT A PRODUCER OWES is in Docs/ExternalSensors.md, beside the 0x2A37 decode a
+ * producer has to perform anyway. Why the budget below is the size it is, and
+ * which values are still open, are in the pull request that introduced this file.
+ *
+ * TIMESTAMP. The frame stamp is the beat instant the interval ends on. That is
+ * the invariant, not how a producer reaches it: a detector reporting beat instants
+ * stamps them and sets DETECTOR_STAMPED, one seeing only arrival reconstructs them
+ * and leaves the bit clear. Unlike a field this cannot be tightened later, because
+ * a consumer relying on true beat instants breaks the moment a producer stops
+ * supplying them.
+ *
+ * The stamp is TWO FIELDS AND THE SECOND IS A REMAINDER. getTimestampUs() forms
+ * ms * 1000 + us, a duration only while us stays under 1000, so whole milliseconds
+ * go in mTimeStamp and sub-millisecond microseconds in mTimeStampUs, as
+ * SensorDataSample::setTimestampUs writes them. Used as a full counter the field
+ * doubles the apparent interval. checkContinuity() answers UNUSABLE for a frame it
+ * can see breaking this, which is a backstop and not a guarantee: it cannot inspect
+ * prevUs, a full counter landing under 1000 by chance still gets a verdict, and a
+ * frame declaring DISCONTINUITY is answered before the check is reached.
+ *
+ * CONTINUITY. rr_ms is authoritative for the interval VALUE, the timestamp for
+ * CONTINUITY, so a disagreement between t[n] - t[n-1] and rr[n] is a lost or
+ * reordered frame and nothing else detects one — there is no sequence number.
+ * checkContinuity() IS that check. Do not compare the stamps for equality; the
+ * budget is what the verdict rests on.
+ *
+ * DISCONTINUITY outranks the stamps and is answered before them. Zero is "no
+ * stamp" at either end.
+ *
+ * The budget is a WINDOW, not a bound. A slow connection interval, a link-layer
+ * retransmission or a drain stall each produce an honest comparison reading GAP,
+ * and nothing here rules them out: read an isolated GAP as one gap that cannot be
+ * accounted for, not as a corrupt stream. A consumer holding a real figure passes
+ * it to the two-argument overload. Erring loose is deliberate — the expensive
+ * error is the false positive, which discards the windows the strap was connected
+ * for.
+ *
+ * Two accepted residuals. A lost beat goes undetected once
+ * the whole missing interval fits inside the budget, which is a rate above
+ * kGuaranteedDetectableBpm; and Data's millisecond field is uint32, so the single
+ * pair straddling its wrap reads REORDERED.
+ *
+ * CONSUMER OBLIGATION. The stamp you pass is the previous frame whose
+ * isDataValid() HELD — whatever verdict that frame got — and zero until you have
+ * seen one. Nothing checks it, and both ways of getting it wrong are silent.
+ * Advance across an invalid frame and you carry its zero forward, so the next
+ * pair reads UNUSABLE where a beat's interval in fact went unreported, which is
+ * a GAP and a window to discard. Advance only on CONTIGUOUS
+ * and nothing re-establishes the stream after a reordering.
+ *
+ ******************************************************************************
+ */
+#ifndef SDK_SENSORLAYER_DATAPARSERS_SENSOR_DATA_PARSER_RR_INTERVAL_HPP
+#define SDK_SENSORLAYER_DATAPARSERS_SENSOR_DATA_PARSER_RR_INTERVAL_HPP
+
+#include "SDK/SensorLayer/DataParsers/SensorDataParserHeartRateEx.hpp"
+#include "SDK/SensorLayer/SensorDataView.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <type_traits>
+
+namespace SDK
+{
+    namespace SensorDataParser
+    {
+        /**
+         * @brief Helper class for parsing one RR_INTERVAL frame from a DataView.
+         */
+        class RrInterval
+        {
+        public:
+            /**
+             * @brief Field indices. Only RR_MS is required for a frame to parse;
+             *        a producer still registers COUNT as its delivery stride.
+             * @note  The indices are frozen: arbitrary when picked, fixed now.
+             */
+            enum Field : uint8_t {
+                RR_MS  = 0, ///< R-R interval, milliseconds, float (required)
+                SOURCE = 1, ///< producer of this interval, u32 (0 = not reported)
+                FLAGS  = 2, ///< quality / continuity bits, u32 (0 = not reported)
+                COUNT  = 3  ///< Field count (3)
+            };
+
+            /**
+             * @brief Which producer emitted the interval.
+             * @note  Mirrors HeartRateEx::Source, extended with ECG. The shared
+             *        values are locked by static_assert below to HeartRateEx and
+             *        through it to the kernel HR arbiter enum, which defines them.
+             * @note  ECG is convention: the arbiter has no value for it, so no
+             *        static_assert holds it. Settle it before anything ships.
+             */
+            enum class Source : uint8_t {
+                UNKNOWN  = 0, ///< none / unknown
+                OPTICAL  = 1, ///< wrist optical (PPG)
+                EXTERNAL = 2, ///< external BLE strap
+                /// Electrocardiogram. Settled by the kernel HR arbiter assigning a
+                /// value; if it assigns 3 to something else, every frame already
+                /// written is mislabelled.
+                ECG      = 3,
+            };
+
+            static_assert(static_cast<uint8_t>(Source::UNKNOWN) ==
+                          static_cast<uint8_t>(HeartRateEx::Source::UNKNOWN),
+                          "RR_INTERVAL Source::UNKNOWN must match HEART_RATE_EX");
+            static_assert(static_cast<uint8_t>(Source::OPTICAL) ==
+                          static_cast<uint8_t>(HeartRateEx::Source::OPTICAL),
+                          "RR_INTERVAL Source::OPTICAL must match HEART_RATE_EX");
+            static_assert(static_cast<uint8_t>(Source::EXTERNAL) ==
+                          static_cast<uint8_t>(HeartRateEx::Source::EXTERNAL),
+                          "RR_INTERVAL Source::EXTERNAL must match HEART_RATE_EX");
+
+            /**
+             * @brief Continuity / quality flag bits (FLAGS field).
+             * @note  Frozen, including DETECTOR_STAMPED's polarity: clearing a bit
+             *        must be the claim-nothing state, since that is what a producer
+             *        populating nothing leaves behind.
+             */
+            enum Flag : uint32_t {
+                DISCONTINUITY    = 1u << 0, ///< not contiguous with the previous interval (gap / reconnect / first)
+                ARTIFACT_SUSPECT = 1u << 1, ///< producer flags this interval as likely artefactual
+                NO_SKIN_CONTACT  = 1u << 2, ///< strap reports loss of skin contact (0x2A37 contact bit)
+                DETECTOR_STAMPED = 1u << 3, ///< timestamp is a detector-observed beat instant, not reconstructed from arrival
+            };
+
+            /**
+             * @brief Result of checkContinuity().
+             * @note  Frozen values; a consumer may log or persist them.
+             * @note  Four outcomes rather than a bool because they want different
+             *        responses: a GAP invalidates the window it falls in, a
+             *        REORDERED says the stream cannot be accumulated in arrival
+             *        order at all, and UNUSABLE says nothing was measured and no
+             *        window need be discarded.
+             */
+            enum class Continuity : uint8_t {
+                UNUSABLE   = 0, ///< nothing can be said: malformed frame, missing stamp, or a value outside the comparable range
+                CONTIGUOUS = 1, ///< the observed gap agrees with rr_ms inside the budget
+                GAP        = 2, ///< the gap exceeds rr_ms by more than the budget, or the producer declared DISCONTINUITY
+                REORDERED  = 3, ///< the gap falls short by more than the budget
+            };
+
+            /**
+             * @name Continuity budget terms
+             * @brief The budget's inputs. Published so tests can pin them, NOT so a
+             *        consumer can apply one by hand: the check is checkContinuity().
+             * @{
+             */
+
+            /// Two quanta of getTimestampUs()'s 1 us resolution, two because a
+            /// difference of two stamps carries the error of both. Never binds.
+            static constexpr float kTimestampQuantisationMs = 0.002f;
+
+            /// The fastest rate this contract UNDERTAKES to detect a lost beat at —
+            /// not the fastest rate at which it happens to, which is higher and moves
+            /// with kLostBeatMarginFraction, so do not build on it. Bounds detection,
+            /// not validity: a faster stream parses normally. 200 is 220-minus-age at
+            /// age 20.
+            static constexpr float kGuaranteedDetectableBpm = 200.0f;
+
+            /// The shortest whole interval a lost beat can add at that rate. The
+            /// budget must stay strictly under it or loss is undetectable.
+            static constexpr float kShortestLostBeatMs = 60000.0f / kGuaranteedDetectableBpm;
+
+            /// Keeps the budget clear of the ceiling, so a beat that ran slightly
+            /// fast is not absorbed. No measurement behind the magnitude: it would
+            /// take beat-to-beat variation measured at kGuaranteedDetectableBpm, and
+            /// it pulls both ways — a larger margin narrows the budget and buys false
+            /// positives, while raising the rate above which a lost beat is silent.
+            static constexpr float kLostBeatMarginFraction = 0.10f;
+
+            /// The budget every frame gets, whatever it claims about its stamping.
+            /// A window, not a bound: see continuityToleranceMs() for how a consumer
+            /// that can do better supplies its own.
+            static constexpr float kDefaultContinuityToleranceMs =
+                    kShortestLostBeatMs - (kShortestLostBeatMs * kLostBeatMarginFraction);
+
+            /// Upper bound on an interval, and on a caller-supplied budget, that
+            /// checkContinuity() will compare at all: the span of Data's uint32
+            /// millisecond timestamp field. Chosen from what the timestamps can mean,
+            /// which keeps it well clear of where the float-to-int64 conversion below
+            /// would become undefined.
+            static constexpr float kMaxComparableRrMs = 4294967296.0f; // 2^32 ms
+
+            /// The largest value the accessor's arithmetic can produce from Data's
+            /// two uint32 fields, which is what keeps the signed conversion below in
+            /// range. Deliberately looser than any conforming stamp: tightening it
+            /// would only reject a prevUs no conforming producer can emit.
+            static constexpr uint64_t kMaxTimestampUs =
+                    (0xFFFFFFFFull * 1000ull) + 0xFFFFFFFFull;
+
+            // The budget has to sit between floor and ceiling or it separates
+            // nothing: at or above the ceiling a lost beat is undetectable, at or
+            // below the floor it could not absorb the stamps themselves.
+            static_assert(kDefaultContinuityToleranceMs < kShortestLostBeatMs,
+                          "a budget at or above the shortest lost beat cannot detect loss");
+            static_assert(kDefaultContinuityToleranceMs > kTimestampQuantisationMs,
+                          "a budget below the timestamp quantum could not absorb the stamps themselves");
+            /** @} */
+
+            /**
+             * @brief Construct a new RrInterval parser over one frame.
+             * @param data Sensor data view holding at least the RR_MS float.
+             */
+            RrInterval(const SDK::Sensor::DataView data) : mData(data) {}
+
+            /**
+             * @brief Whether the frame carries a usable R-R interval.
+             * @note  Shape AND value: a NaN / infinite / zero / negative interval
+             *        is not a slow heartbeat but a malformed frame, and would put
+             *        NaN into every downstream HRV accumulator. Every accessor
+             *        that reads the frame gates on this, timestamps included, so
+             *        such a frame reads as absent — metadata describes an interval,
+             *        and a confident Source beside a NaN would invite a consumer to
+             *        act on it.
+             *        Lenient on the upper field bound, so a producer may append.
+             */
+            bool isDataValid() const
+            {
+                return (mData.getFieldCount() >= 1) &&
+                       std::isfinite(mData.f[Field::RR_MS]) &&
+                       (mData.f[Field::RR_MS] > 0.0f);
+            }
+
+            /**
+             * @brief The R-R interval in milliseconds (0 if invalid).
+             */
+            float getRrMs() const
+            {
+                return isDataValid() ? mData.f[Field::RR_MS] : 0.0f;
+            }
+
+            /**
+             * @brief Implied instantaneous heart rate (bpm) for convenience.
+             * @note  Single-beat rate, NOT a smoothed HR and not a "max HR". 0 if
+             *        the interval is invalid.
+             * @note  No physiological range check: an implausible but finite
+             *        interval (5 ms, or 40 s) passes through, because artefact
+             *        policy is the consumer's — see ARTIFACT_SUSPECT. Only
+             *        representability is guarded, a tiny enough interval making
+             *        60000/rr overflow to infinity, which is not a reading; that
+             *        reads 0 while getRrMs() still returns the raw interval.
+             */
+            float getBpm() const
+            {
+                const float rr = getRrMs();
+                if (rr <= 0.0f) {
+                    return 0.0f;
+                }
+                const float bpm = 60000.0f / rr;
+                return std::isfinite(bpm) ? bpm : 0.0f;
+            }
+
+            /**
+             * @brief Producer of this interval, or UNKNOWN if not supplied (or if
+             *        the frame is malformed — see isDataValid()).
+             */
+            Source getSource() const
+            {
+                if (!isDataValid() || (mData.getFieldCount() <= Field::SOURCE)) {
+                    return Source::UNKNOWN;
+                }
+                // The union's integer member: no narrowing, so any value a producer
+                // can write is representable and unknown values fall to UNKNOWN.
+                switch (mData.u[Field::SOURCE]) {
+                    case static_cast<uint32_t>(Source::OPTICAL):  return Source::OPTICAL;
+                    case static_cast<uint32_t>(Source::EXTERNAL): return Source::EXTERNAL;
+                    case static_cast<uint32_t>(Source::ECG):      return Source::ECG;
+                    default:                                      return Source::UNKNOWN;
+                }
+            }
+
+            /**
+             * @brief True if this interval is NOT contiguous with the previous one
+             *        (gap, reconnect, or first interval). Absent flags read as
+             *        contiguous.
+             */
+            bool hasDiscontinuity() const
+            {
+                return (flags() & Flag::DISCONTINUITY) != 0u;
+            }
+
+            /**
+             * @brief True if the producer marks this interval as artefact-suspect.
+             */
+            bool isArtifactSuspect() const
+            {
+                return (flags() & Flag::ARTIFACT_SUSPECT) != 0u;
+            }
+
+            /**
+             * @brief True if the strap reports loss of skin contact for this
+             *        reading. False when contact is good or unreported.
+             */
+            bool isSkinContactLost() const
+            {
+                return (flags() & Flag::NO_SKIN_CONTACT) != 0u;
+            }
+
+            /**
+             * @brief True if the producer asserts this frame's timestamp is a
+             *        detector-observed beat instant rather than one reconstructed
+             *        from a notification arrival.
+             * @note  Informational today — the budget is the same either way — so
+             *        setting it cannot provoke a false gap. Report it truthfully
+             *        regardless: it is the only record of how the stamp was obtained,
+             *        and a consumer may key its own budget on it via the two-argument
+             *        checkContinuity().
+             */
+            bool isDetectorStamped() const
+            {
+                return (flags() & Flag::DETECTOR_STAMPED) != 0u;
+            }
+
+            /**
+             * @brief The continuity budget this frame calls for, in milliseconds.
+             * @note  Exposed so a consumer overriding it can see what it overrides,
+             *        and so the choice is inspectable in a log. Not a threshold to
+             *        apply by hand — checkContinuity() is.
+             * @note  Frame-dependent by signature, not by behaviour: every frame
+             *        currently gets kDefaultContinuityToleranceMs.
+             */
+            float continuityToleranceMs() const
+            {
+                return kDefaultContinuityToleranceMs;
+            }
+
+            /**
+             * @brief Whether this interval continues from the beat that ended the
+             *        previous one, using the budget this frame calls for.
+             * @param prevUs getTimestampUs() of the previous frame whose
+             *               isDataValid() held — see CONSUMER OBLIGATION.
+             * @note  See CONTINUITY at the top of this file. A frame declaring
+             *        DISCONTINUITY reads
+             *        GAP whatever the stamps say — including with no previous stamp
+             *        to compare against, since the declaration is producer knowledge
+             *        that does not rest on them. So the first frame of a stream
+             *        reads GAP if it declares one and UNUSABLE if it does not, and
+             *        both are right: there is no window to discard either way.
+             *        hasDiscontinuity() still distinguishes a declared gap from a
+             *        detected one.
+             */
+            Continuity checkContinuity(uint64_t prevUs) const
+            {
+                return checkContinuity(prevUs, continuityToleranceMs());
+            }
+
+            /**
+             * @name A narrower stamp is refused rather than widened
+             * @brief getTimestamp() and getTimestampUs() sit next to each other,
+             *        differ by a factor of 1000, and both reach uint64_t without a
+             *        diagnostic — so passing the millisecond one returns a
+             *        confident GAP on a contiguous pair, in the single operation
+             *        this contract exists to stop consumers writing themselves. A
+             *        millisecond stamp is indistinguishable at runtime from a
+             *        microsecond stamp of a session 1000x younger.
+             *
+             *        Deleted on WIDTH rather than on uint32_t: a stamp is always
+             *        uint64_t here, and matching that one type would leave
+             *        checkContinuity(0ull) ambiguous wherever uint64_t is not
+             *        unsigned long long. The predicate is a whitelist — an unsigned
+             *        integral at least as wide as uint64_t — because a blacklist
+             *        admits the next category by omission. No type predicate reaches
+             *        the unit mistake itself: checkContinuity(5000ull) still reads a
+             *        confident GAP. Cost: the stamp needs an unsigned 64-bit spelling,
+             *        so the zero a consumer starts from is checkContinuity(0ull), and
+             *        a µs count from <chrono> needs one cast.
+             * @{
+             */
+            template <typename T, typename = typename std::enable_if<
+                                          !(std::is_integral<T>::value &&
+                                            !std::is_signed<T>::value &&
+                                            (sizeof(T) >= sizeof(uint64_t)))>::type>
+            Continuity checkContinuity(T prevNotMicroseconds) const = delete;
+
+            template <typename T, typename = typename std::enable_if<
+                                          !(std::is_integral<T>::value &&
+                                            !std::is_signed<T>::value &&
+                                            (sizeof(T) >= sizeof(uint64_t)))>::type>
+            Continuity checkContinuity(T prevNotMicroseconds, float toleranceMs) const = delete;
+
+            /**
+             * @brief The transposition, refused from the budget's side.
+             * @note  A budget is float milliseconds. checkContinuity(budgetMs, prevUs)
+             *        otherwise puts the stamp in the budget and the budget in the
+             *        stamp.
+             *
+             *        PARTIAL, and the limit bounds what any overload set can do here:
+             *        the two predicates are duals, so a type refused as a STAMP is
+             *        accepted as a BUDGET and the transposition survives there — an
+             *        int64_t or <chrono> stamp, a double, a conversion operator, an
+             *        enum. A budget in the wrong UNIT is unreachable by any signature.
+             *        Closing the class wants a tagged budget type, which changes every
+             *        call site.
+             *
+             *        Cost: a budget spelled as an unsigned 64-bit type no longer
+             *        compiles. (x, 270), (x, 270.0f), (x, 270u) and (x, someSignedLong)
+             *        are unaffected.
+             */
+            template <typename B, typename = typename std::enable_if<
+                                          std::is_integral<B>::value &&
+                                          !std::is_signed<B>::value &&
+                                          (sizeof(B) >= sizeof(uint64_t))>::type>
+            Continuity checkContinuity(uint64_t prevUs, B budgetNotAStamp) const = delete;
+            /** @} */
+
+            /**
+             * @brief As above, against a caller-supplied budget.
+             * @param prevUs      getTimestampUs() of the previous frame whose
+             *                    isDataValid() held — see CONSUMER OBLIGATION.
+             * @param toleranceMs the budget to allow, in milliseconds.
+             * @note  For a consumer that knows the link parameters or has measured
+             *        the jitter it sees. A negative, NaN or unrepresentable budget
+             *        reads UNUSABLE rather than silently becoming zero — unless the
+             *        frame declares DISCONTINUITY, which is answered before the budget
+             *        is read, so a bad budget goes unreported on those frames. The
+             *        comparison is SIGNED and in microseconds, because subtracting two
+             *        unsigned stamps directly makes a reordered pair wrap to an
+             *        enormous forward gap.
+             */
+            Continuity checkContinuity(uint64_t prevUs, float toleranceMs) const
+            {
+                if (!isDataValid()) {
+                    return Continuity::UNUSABLE;
+                }
+
+                // A declared gap outranks anything the stamps can show.
+                if (hasDiscontinuity()) {
+                    return Continuity::GAP;
+                }
+
+                const uint64_t thisUs = getTimestampUs();
+                // The microsecond field is a remainder, not a counter (see
+                // TIMESTAMP); as a counter, no comparison it enters means anything.
+                if ((thisUs - (static_cast<uint64_t>(getTimestamp()) * 1000ull)) >= 1000ull) {
+                    return Continuity::UNUSABLE;
+                }
+                // Zero is "no stamp" throughout this class. Values above
+                // kMaxTimestampUs did not come from getTimestampUs(), and admitting
+                // them would put the signed conversion below out of range.
+                if ((thisUs == 0ull) || (prevUs == 0ull) || (prevUs > kMaxTimestampUs)) {
+                    return Continuity::UNUSABLE;
+                }
+
+                // Rejects NaN and negatives through the negated comparison, and
+                // infinities through the upper bound.
+                if (!(toleranceMs >= 0.0f) || (toleranceMs >= kMaxComparableRrMs)) {
+                    return Continuity::UNUSABLE;
+                }
+
+                // isDataValid() established finite and positive; this is the
+                // representability guard for the conversion, as in getBpm().
+                const float rrMs = getRrMs();
+                if (rrMs >= kMaxComparableRrMs) {
+                    return Continuity::UNUSABLE;
+                }
+
+                const int64_t deltaUs = (thisUs >= prevUs)
+                        ? static_cast<int64_t>(thisUs - prevUs)
+                        : -static_cast<int64_t>(prevUs - thisUs);
+                const int64_t rrUs  = static_cast<int64_t>(rrMs * 1000.0f);
+                const int64_t tolUs = static_cast<int64_t>(toleranceMs * 1000.0f);
+                const int64_t errUs = deltaUs - rrUs;
+
+                if (errUs > tolUs) {
+                    return Continuity::GAP;
+                }
+                if (errUs < -tolUs) {
+                    return Continuity::REORDERED;
+                }
+                return Continuity::CONTIGUOUS;
+            }
+
+            uint32_t getTimestamp() const
+            {
+                return isDataValid() ? mData.getTimestamp() : 0;
+            }
+
+            uint64_t getTimestampUs() const
+            {
+                return isDataValid() ? mData.getTimestampUs() : 0;
+            }
+
+            /**
+             * @brief Number of expected fields (3).
+             * @note  The DELIVERY STRIDE a producer registers, not the parse
+             *        minimum (see isDataValid()). Unpopulated metadata fields are
+             *        zero, which reads as "not reported".
+             */
+            static constexpr uint8_t getFieldsNumber()
+            {
+                return Field::COUNT;
+            }
+
+        private:
+            /**
+             * @brief Raw FLAGS word, or 0 when absent or the frame is malformed.
+             * @note  Every flag predicate reads through this, so a malformed frame
+             *        reports no flags rather than the last producer's bits.
+             */
+            uint32_t flags() const
+            {
+                if (!isDataValid() || (mData.getFieldCount() <= Field::FLAGS)) {
+                    return 0u;
+                }
+                return mData.u[Field::FLAGS];
+            }
+
+            const SDK::Sensor::DataView mData;
+        }; /* class RrInterval */
+    }; /* namespace SensorDataParser */
+
+} /* namespace SDK */
+
+#endif /* SDK_SENSORLAYER_DATAPARSERS_SENSOR_DATA_PARSER_RR_INTERVAL_HPP */

--- a/Libs/Header/SDK/SensorLayer/SensorTypes.hpp
+++ b/Libs/Header/SDK/SensorLayer/SensorTypes.hpp
@@ -40,6 +40,7 @@ namespace SDK::Sensor
         HEART_RATE_METRICS_DAILY = 0x00000042, ///< Aggregated metrics for the current day (e.g., AHR, RHR).
         HEART_RATE_METRICS   = HEART_RATE_METRICS_DAILY, /// Legacy alias of HEART_RATE_METRICS_DAILY.
         HEART_RATE_EX        = 0x00000043, ///< Opt-in multi-source HR: arbitrated + source + raw optical + raw external. 7 fields.
+        RR_INTERVAL          = 0x00000044, ///< EXPERIMENTAL (no firmware producer yet; shape may change). Opt-in beat-to-beat R-R interval (ms), one interval per frame. HRV/DFA source.
         /** @} */
 
         /** @name Pedometer

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(una-sdk-host-tests
     apps/Running/ActivityWriter_test.cpp
     sensorlayer/HeartRateParser_test.cpp
     sensorlayer/HeartRateExParser_test.cpp
+    sensorlayer/RrIntervalParser_test.cpp
     simulator/FileSystemMock_test.cpp
     sensorlayer/GyroscopeParser_test.cpp
     sensorlayer/SensorConnection_test.cpp

--- a/Tests/Host/sensorlayer/RrIntervalParser_test.cpp
+++ b/Tests/Host/sensorlayer/RrIntervalParser_test.cpp
@@ -1,0 +1,1360 @@
+/**
+ * Host unit tests for SensorDataParser::RrInterval — the opt-in beat-to-beat
+ * R-R interval frame (one interval per frame; optional appended source + flags
+ * fields, lenient field-count validation like HeartRateEx).
+ */
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "SDK/SensorLayer/SensorData.hpp"
+#include "SDK/SensorLayer/SensorTypes.hpp"
+#include "SDK/SensorLayer/SensorDataView.hpp"
+#include "SDK/SensorLayer/DataParsers/SensorDataParserRrInterval.hpp"
+
+using RrInterval = SDK::SensorDataParser::RrInterval;
+
+namespace {
+
+// A SDK::Sensor::Data with room for rr_ms + source + flags, and one spare for
+// the "extra trailing field" forward-compat case.
+struct RrData {
+    alignas(SDK::Sensor::Data) uint8_t buf[sizeof(SDK::Sensor::Data) +
+            3 * sizeof(SDK::Sensor::Data::Field)] {};
+    SDK::Sensor::Data* operator->() { return data(); }
+    SDK::Sensor::Data* data() { return reinterpret_cast<SDK::Sensor::Data*>(buf); }
+};
+
+int src(RrInterval::Source s) { return static_cast<int>(s); }
+
+int cont(RrInterval::Continuity c) { return static_cast<int>(c); }
+
+// One RR frame stamped at a given microsecond instant, so the continuity tests
+// go through real frames and the real accessors rather than through arithmetic
+// on literals.
+struct Beat {
+    RrData   d;
+    uint16_t fields;
+
+    Beat(float rrMs, uint64_t tsUs, uint32_t flags,
+         uint16_t nFields = RrInterval::COUNT)
+        : fields(nFields)
+    {
+        d->mTimeStamp                    = static_cast<uint32_t>(tsUs / 1000ull);
+        d->mTimeStampUs                  = static_cast<uint32_t>(tsUs % 1000ull);
+        d->mValue[RrInterval::RR_MS].f   = rrMs;
+        d->mValue[RrInterval::FLAGS].u32 = flags;
+    }
+
+    RrInterval parser() { return RrInterval(SDK::Sensor::DataView(*d.data(), fields)); }
+};
+
+uint64_t msToUs(float ms) { return static_cast<uint64_t>(ms * 1000.f); }
+
+// Whether checkContinuity() can be called with a stamp of type T at all. A
+// deleted overload is chosen by overload resolution and then makes the call
+// ill-formed, which in this immediate context is a substitution failure rather
+// than a hard error — so this detects the deletion instead of failing to compile.
+template <typename T, typename = void>
+struct AcceptsStamp : std::false_type {};
+
+template <typename T>
+struct AcceptsStamp<T, std::void_t<decltype(std::declval<const RrInterval&>()
+                                                    .checkContinuity(std::declval<T>()))>>
+    : std::true_type {};
+
+// Whether a BUDGET of type B is accepted alongside a valid stamp.
+template <typename B, typename = void>
+struct AcceptsBudget : std::false_type {};
+
+template <typename B>
+struct AcceptsBudget<B, std::void_t<decltype(std::declval<const RrInterval&>()
+                                                     .checkContinuity(uint64_t(1),
+                                                                      std::declval<B>()))>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct AcceptsStampAndBudget : std::false_type {};
+
+template <typename T>
+struct AcceptsStampAndBudget<T, std::void_t<decltype(std::declval<const RrInterval&>()
+                                                             .checkContinuity(std::declval<T>(),
+                                                                              1.f))>>
+    : std::true_type {};
+
+enum UnscopedStamp : unsigned { kSessionStartMs = 5000 };
+
+struct ConvertsToStamp { operator uint64_t() const { return 5000ull; } };
+
+} // namespace
+
+TEST(RrIntervalParser, WireNumbersAreFrozen)
+{
+    // The frozen numbers. They ARE the contract -- a producer and a consumer
+    // compiled from different revisions have only these and the field types to
+    // agree on -- and the rest of the suite writes each fixture through the same
+    // symbols it reads back, so renumbering Field, Source or Flag would be
+    // invisible to it.
+    //
+    // Source::ECG is convention rather than settled, the arbiter having no value
+    // for it. Pinned here anyway: until it does, this file is the only thing that
+    // says what 3 means.
+    EXPECT_EQ(static_cast<uint32_t>(SDK::Sensor::Type::RR_INTERVAL), 0x44u);
+
+    EXPECT_EQ(RrInterval::RR_MS,  0);
+    EXPECT_EQ(RrInterval::SOURCE, 1);
+    EXPECT_EQ(RrInterval::FLAGS,  2);
+    EXPECT_EQ(RrInterval::COUNT,  3);
+
+    EXPECT_EQ(static_cast<uint32_t>(RrInterval::Source::UNKNOWN),  0u);
+    EXPECT_EQ(static_cast<uint32_t>(RrInterval::Source::OPTICAL),  1u);
+    EXPECT_EQ(static_cast<uint32_t>(RrInterval::Source::EXTERNAL), 2u);
+    EXPECT_EQ(static_cast<uint32_t>(RrInterval::Source::ECG),      3u);
+
+    EXPECT_EQ(RrInterval::Flag::DISCONTINUITY,    1u << 0);
+    EXPECT_EQ(RrInterval::Flag::ARTIFACT_SUSPECT, 1u << 1);
+    EXPECT_EQ(RrInterval::Flag::NO_SKIN_CONTACT,  1u << 2);
+    EXPECT_EQ(RrInterval::Flag::DETECTOR_STAMPED, 1u << 3);
+
+    // Polarity is part of the wire contract, not an implementation detail: the
+    // bit has to mean "detector-stamped", so that clearing it — which is what a
+    // producer that populates nothing does — is the claim-nothing state. No
+    // budget currently turns on it, but the moment one does, a bit meaning
+    // "arrival-reconstructed" would hand the tightest budget to the least
+    // informative producer, and by then the numbering is frozen.
+    EXPECT_EQ(cont(RrInterval::Continuity::UNUSABLE),   0);
+    EXPECT_EQ(cont(RrInterval::Continuity::CONTIGUOUS), 1);
+    EXPECT_EQ(cont(RrInterval::Continuity::GAP),        2);
+    EXPECT_EQ(cont(RrInterval::Continuity::REORDERED),  3);
+}
+
+TEST(RrIntervalParser, ParsesAFrameWrittenWithRawWireIndices)
+{
+    // Written the way a producer built from the documentation writes it: literal
+    // offsets, literal values, no symbol shared with the reader, so a
+    // reader/writer disagreement about the layout has somewhere to surface.
+    RrData m;
+    m->mValue[0].f   = 855.f;
+    m->mValue[1].u32 = 2u; // EXTERNAL
+    m->mValue[2].u32 = 5u; // DISCONTINUITY | NO_SKIN_CONTACT
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 3));
+
+    EXPECT_FLOAT_EQ(p.getRrMs(), 855.f);
+    EXPECT_EQ(src(p.getSource()), src(RrInterval::Source::EXTERNAL));
+    EXPECT_TRUE(p.hasDiscontinuity());
+    EXPECT_FALSE(p.isArtifactSuspect());
+    EXPECT_TRUE(p.isSkinContactLost());
+}
+
+TEST(RrIntervalParser, FieldsNumberIsTheFullStride)
+{
+    // Not the parse minimum: a producer registers this as its Driver stride, and
+    // registering fewer fields would make SOURCE/FLAGS permanently undeliverable.
+    EXPECT_EQ(RrInterval::getFieldsNumber(), 3);
+    EXPECT_EQ(RrInterval::getFieldsNumber(), RrInterval::COUNT);
+}
+
+TEST(RrIntervalParser, OneFieldMinimalFrame)
+{
+    RrData m;
+    m->mTimeStamp = 1000;
+    m->mValue[RrInterval::RR_MS].f = 855.f;
+    // Non-zero, and past the delivered end: a Driver republishes one DataSample, so
+    // the word beyond the stride is the PREVIOUS beat's source, not a fresh zero.
+    // Without this the frame's undelivered SOURCE reads zero either way and the
+    // field-count guard in getSource() is pinned by nothing.
+    m->mValue[RrInterval::SOURCE].u32 = static_cast<uint32_t>(RrInterval::Source::EXTERNAL);
+
+    // A short frame still parses — the upper field bound is lenient.
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 1));
+
+    EXPECT_TRUE(p.isDataValid());
+    EXPECT_FLOAT_EQ(p.getRrMs(), 855.f);
+    EXPECT_FLOAT_EQ(p.getBpm(), 60000.f / 855.f);
+    EXPECT_EQ(p.getTimestamp(), 1000u);
+    // Metadata absent -> safe defaults, never a false gap.
+    EXPECT_EQ(src(p.getSource()), src(RrInterval::Source::UNKNOWN));
+    EXPECT_FALSE(p.hasDiscontinuity());
+    EXPECT_FALSE(p.isArtifactSuspect());
+}
+
+TEST(RrIntervalParser, MicrosecondTailSurvivesOnAValidFrame)
+{
+    // The contract tells a producer to stamp in the microsecond domain, so the
+    // sub-millisecond tail has to reach a consumer intact — an interval is
+    // fractional in milliseconds and the whole point of the mandate is that the
+    // fraction is not thrown away.
+    RrData m;
+    m->mTimeStamp                  = 1000;
+    m->mTimeStampUs                = 469; // 1000.469 ms
+    m->mValue[RrInterval::RR_MS].f = 855.f;
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 1));
+
+    EXPECT_EQ(p.getTimestamp(), 1000u);
+    EXPECT_EQ(p.getTimestampUs(), 1000469ull);
+}
+
+TEST(RrIntervalParser, ZeroMetadataReadsAsNotReported)
+{
+    // The invariant that makes the producer obligation survivable: a full-stride
+    // frame whose metadata words are zero degrades to "no information" rather
+    // than to a confident wrong answer. Zero is the value a producer that
+    // registers the stride and populates nothing leaves behind, whoever wrote it.
+    RrData m;
+    m->mValue[RrInterval::RR_MS].f = 855.f;
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), RrInterval::COUNT));
+
+    EXPECT_TRUE(p.isDataValid());
+    EXPECT_EQ(src(p.getSource()), src(RrInterval::Source::UNKNOWN));
+    EXPECT_FALSE(p.hasDiscontinuity());
+    EXPECT_FALSE(p.isArtifactSuspect());
+    EXPECT_FALSE(p.isSkinContactLost());
+    // Including the continuity claim: unclaimed, so the loose budget.
+    EXPECT_FALSE(p.isDetectorStamped());
+    EXPECT_FLOAT_EQ(p.continuityToleranceMs(),
+                    RrInterval::kDefaultContinuityToleranceMs);
+}
+
+TEST(RrIntervalParser, ThreeFieldExternalWithGap)
+{
+    RrData m;
+    m->mValue[RrInterval::RR_MS].f    = 412.f;
+    m->mValue[RrInterval::SOURCE].u32 = static_cast<uint32_t>(RrInterval::Source::EXTERNAL);
+    m->mValue[RrInterval::FLAGS].u32  = RrInterval::Flag::DISCONTINUITY;
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 3));
+
+    EXPECT_FLOAT_EQ(p.getRrMs(), 412.f);
+    EXPECT_EQ(src(p.getSource()), src(RrInterval::Source::EXTERNAL));
+    EXPECT_TRUE(p.hasDiscontinuity());
+    EXPECT_FALSE(p.isArtifactSuspect());
+}
+
+TEST(RrIntervalParser, ArtifactFlagIndependentOfGap)
+{
+    RrData m;
+    m->mValue[RrInterval::RR_MS].f    = 800.f;
+    m->mValue[RrInterval::SOURCE].u32 = static_cast<uint32_t>(RrInterval::Source::ECG);
+    m->mValue[RrInterval::FLAGS].u32  = RrInterval::Flag::ARTIFACT_SUSPECT;
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 3));
+
+    EXPECT_EQ(src(p.getSource()), src(RrInterval::Source::ECG));
+    EXPECT_TRUE(p.isArtifactSuspect());
+    EXPECT_FALSE(p.hasDiscontinuity());
+}
+
+TEST(RrIntervalParser, SkinContactLostFlag)
+{
+    RrData m;
+    m->mValue[RrInterval::RR_MS].f    = 900.f;
+    m->mValue[RrInterval::SOURCE].u32 = static_cast<uint32_t>(RrInterval::Source::EXTERNAL);
+    m->mValue[RrInterval::FLAGS].u32  = RrInterval::Flag::NO_SKIN_CONTACT;
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 3));
+
+    EXPECT_TRUE(p.isSkinContactLost());
+    EXPECT_FALSE(p.hasDiscontinuity());
+    EXPECT_FALSE(p.isArtifactSuspect());
+}
+
+TEST(RrIntervalParser, UnknownSourceForOutOfRangeValue)
+{
+    RrData m;
+    m->mValue[RrInterval::RR_MS].f    = 700.f;
+    m->mValue[RrInterval::SOURCE].u32 = 9u; // not a known Source
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 2));
+
+    EXPECT_EQ(src(p.getSource()), src(RrInterval::Source::UNKNOWN));
+}
+
+TEST(RrIntervalParser, KnownFlagsCombine)
+{
+    // The realistic case for a strap reconnect: the first beat after the gap is
+    // both discontinuous and worth distrusting. Each predicate must read its own
+    // bit, not the mask being non-zero.
+    RrData m;
+    m->mValue[RrInterval::RR_MS].f    = 850.f;
+    m->mValue[RrInterval::SOURCE].u32 = static_cast<uint32_t>(RrInterval::Source::EXTERNAL);
+    m->mValue[RrInterval::FLAGS].u32  = RrInterval::Flag::DISCONTINUITY |
+                                        RrInterval::Flag::ARTIFACT_SUSPECT;
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 3));
+
+    EXPECT_TRUE(p.hasDiscontinuity());
+    EXPECT_TRUE(p.isArtifactSuspect());
+    EXPECT_FALSE(p.isSkinContactLost());
+}
+
+TEST(RrIntervalParser, AllFlagsSetAtOnce)
+{
+    RrData m;
+    m->mValue[RrInterval::RR_MS].f   = 850.f;
+    m->mValue[RrInterval::FLAGS].u32 = RrInterval::Flag::DISCONTINUITY |
+                                       RrInterval::Flag::ARTIFACT_SUSPECT |
+                                       RrInterval::Flag::NO_SKIN_CONTACT |
+                                       RrInterval::Flag::DETECTOR_STAMPED;
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 3));
+
+    EXPECT_TRUE(p.hasDiscontinuity());
+    EXPECT_TRUE(p.isArtifactSuspect());
+    EXPECT_TRUE(p.isSkinContactLost());
+    EXPECT_TRUE(p.isDetectorStamped());
+}
+
+TEST(RrIntervalParser, UndefinedFlagBitsDoNotDisturbKnownOnes)
+{
+    RrData m;
+    m->mValue[RrInterval::RR_MS].f   = 800.f;
+    // A sparse high bit alongside bit0 — the case a float-carried mask rounds
+    // away, and the reason FLAGS is u32.
+    m->mValue[RrInterval::FLAGS].u32 = RrInterval::Flag::DISCONTINUITY | (1u << 24);
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 3));
+
+    EXPECT_TRUE(p.hasDiscontinuity());
+    EXPECT_FALSE(p.isArtifactSuspect());
+    EXPECT_FALSE(p.isSkinContactLost());
+}
+
+TEST(RrIntervalParser, UnusableRrValuesMakeTheFrameInvalid)
+{
+    // Not slow heartbeats — malformed frames. Letting these through would put
+    // NaN/inf into every downstream HRV accumulator.
+    const float bad[] = {
+        std::numeric_limits<float>::quiet_NaN(),
+        std::numeric_limits<float>::infinity(),
+        -std::numeric_limits<float>::infinity(),
+        0.f,
+        -800.f,
+    };
+
+    for (float v : bad) {
+        RrData m;
+        m->mTimeStamp                     = 1000;
+        m->mValue[RrInterval::RR_MS].f    = v;
+        m->mValue[RrInterval::SOURCE].u32 = static_cast<uint32_t>(RrInterval::Source::EXTERNAL);
+        m->mValue[RrInterval::FLAGS].u32  = RrInterval::Flag::DISCONTINUITY |
+                                            RrInterval::Flag::NO_SKIN_CONTACT;
+
+        RrInterval p(SDK::Sensor::DataView(*m.data(), 3));
+
+        EXPECT_FALSE(p.isDataValid());
+        EXPECT_FLOAT_EQ(p.getRrMs(), 0.f);
+        EXPECT_FLOAT_EQ(p.getBpm(), 0.f);
+        // The whole frame reads as absent — timestamps and metadata included.
+        // Populated metadata beside a malformed interval describes nothing, and
+        // handing back a confident EXTERNAL would invite a consumer to trust the
+        // rest of the frame.
+        EXPECT_EQ(p.getTimestamp(), 0u);
+        EXPECT_EQ(p.getTimestampUs(), 0u);
+        EXPECT_EQ(src(p.getSource()), src(RrInterval::Source::UNKNOWN));
+        EXPECT_FALSE(p.hasDiscontinuity());
+        EXPECT_FALSE(p.isArtifactSuspect());
+        EXPECT_FALSE(p.isSkinContactLost());
+        EXPECT_FALSE(p.isDetectorStamped());
+    }
+}
+
+TEST(RrIntervalParser, ATwoFieldFrameHasNoFlagsWordToRead)
+{
+    // The other side of the lenient field bound, and the only stride between the
+    // one-field minimum and the full three that any accessor has to reason about.
+    // FLAGS is past the end here, so every flag predicate must read as absent
+    // rather than reaching for a word the producer did not deliver — which, since
+    // a Driver republishes one DataSample, is the PREVIOUS beat's flags. A stale
+    // DISCONTINUITY read out of bounds is exactly what the per-frame write rule
+    // exists to prevent, so the bound has to be pinned at the stride that tests it.
+    RrData m;
+    m->mValue[RrInterval::RR_MS].f    = 800.f;
+    m->mValue[RrInterval::SOURCE].u32 = static_cast<uint32_t>(RrInterval::Source::EXTERNAL);
+    m->mValue[RrInterval::FLAGS].u32  = RrInterval::Flag::DISCONTINUITY |
+                                        RrInterval::Flag::DETECTOR_STAMPED;
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 2));
+
+    EXPECT_TRUE(p.isDataValid());
+    EXPECT_EQ(src(p.getSource()), src(RrInterval::Source::EXTERNAL)); // delivered
+    EXPECT_FALSE(p.hasDiscontinuity());                              // not delivered
+    EXPECT_FALSE(p.isArtifactSuspect());
+    EXPECT_FALSE(p.isSkinContactLost());
+    EXPECT_FALSE(p.isDetectorStamped());
+    // And the budget follows the absent claim, not the undelivered word.
+    EXPECT_FLOAT_EQ(p.continuityToleranceMs(),
+                    RrInterval::kDefaultContinuityToleranceMs);
+}
+
+TEST(RrIntervalParser, AppendedFieldLeavesTheKnownOnesAlone)
+{
+    // The forward-compatibility claim the contract rests on: a later producer may
+    // append a field (a graded confidence, say) and register a wider stride, and
+    // an app built against today's layout must be unaffected. This is what makes
+    // deferring such a field safe rather than a decision that has to be made now.
+    RrData m;
+    m->mValue[RrInterval::RR_MS].f    = 855.f;
+    m->mValue[RrInterval::SOURCE].u32 = static_cast<uint32_t>(RrInterval::Source::OPTICAL);
+    m->mValue[RrInterval::FLAGS].u32  = RrInterval::Flag::ARTIFACT_SUSPECT;
+    m->mValue[RrInterval::COUNT].u32  = 0xDEADBEEFu; // a field this build knows nothing about
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), RrInterval::COUNT + 1));
+
+    EXPECT_TRUE(p.isDataValid());
+    EXPECT_FLOAT_EQ(p.getRrMs(), 855.f);
+    EXPECT_EQ(src(p.getSource()), src(RrInterval::Source::OPTICAL));
+    EXPECT_TRUE(p.isArtifactSuspect());
+    EXPECT_FALSE(p.hasDiscontinuity());
+    EXPECT_FALSE(p.isSkinContactLost());
+}
+
+// ---------------------------------------------------------------------------
+// Continuity. These pin the relationships between the budget's named terms, not
+// the numbers they produce: every budget below is recomputed from its terms, so
+// changing a term either moves both sides together or breaks a test.
+// ---------------------------------------------------------------------------
+
+TEST(RrIntervalContinuity, TheBudgetsFallOutOfTheNamedTerms)
+{
+    // The ceiling. A lost beat adds one whole interval, so a budget detects loss
+    // only while it stays under the shortest interval that could go missing —
+    // recomputed from the policy rate here rather than restated, so moving
+    // kGuaranteedDetectableBpm moves the ceiling with it.
+    EXPECT_FLOAT_EQ(RrInterval::kShortestLostBeatMs,
+                    60000.f / RrInterval::kGuaranteedDetectableBpm);
+
+    // The floor. getTimestampUs() resolves to 1 us and a difference of two
+    // stamps carries at most two quanta.
+    EXPECT_FLOAT_EQ(RrInterval::kTimestampQuantisationMs, 2.f * 0.001f);
+
+    // The budget sits strictly between floor and ceiling. Without that the check
+    // cannot separate a jittered pair from a lost beat at all, and this is the
+    // whole claim the derivation makes.
+    EXPECT_GT(RrInterval::kDefaultContinuityToleranceMs,
+              RrInterval::kTimestampQuantisationMs);
+    EXPECT_LT(RrInterval::kDefaultContinuityToleranceMs,
+              RrInterval::kShortestLostBeatMs);
+
+    // The budget is NOT a sum of terms, and that is the finding rather than an
+    // omission. Neither stamping class brackets: for an arrival-reconstructed
+    // frame the dominant term is the transport jitter between two arrivals, which
+    // nothing in this repository exposes, configures or bounds; for a
+    // detector-stamped frame it is the detector-to-stamp jitter, which nothing
+    // bounds either, because there is no detector. So the budget is the ceiling
+    // less its margin — the whole of the window available — rather than a figure
+    // claimed to cover anything.
+    EXPECT_FLOAT_EQ(RrInterval::kDefaultContinuityToleranceMs,
+                    RrInterval::kShortestLostBeatMs *
+                            (1.f - RrInterval::kLostBeatMarginFraction));
+}
+
+TEST(RrIntervalContinuity, ThereIsExactlyOneBudgetAndNoFrameChangesIt)
+{
+    // NOTHING in a frame moves the budget. That is what makes a producer
+    // populating nothing safe, and a reintroduced per-stamping-class budget would
+    // have to break this deliberately rather than by accident.
+    const float    rr     = 800.f;
+    const uint64_t prevUs = 5000000ull;
+    // An offset a tight per-class budget would have separated on, and this one
+    // absorbs.
+    const uint64_t offUs  = msToUs(50.f);
+    ASSERT_LT(offUs, msToUs(RrInterval::kDefaultContinuityToleranceMs));
+    const uint64_t thisUs = prevUs + 800000ull + offUs;
+
+    const uint32_t flagSets[] = {
+        0u,
+        RrInterval::Flag::DETECTOR_STAMPED,
+        RrInterval::Flag::ARTIFACT_SUSPECT | RrInterval::Flag::NO_SKIN_CONTACT,
+        RrInterval::Flag::DETECTOR_STAMPED | RrInterval::Flag::ARTIFACT_SUSPECT |
+                RrInterval::Flag::NO_SKIN_CONTACT,
+    };
+
+    for (uint32_t flags : flagSets) {
+        for (uint16_t stride : { uint16_t(1), uint16_t(2),
+                                 uint16_t(RrInterval::COUNT) }) {
+            Beat b(rr, thisUs, flags, stride);
+            EXPECT_FLOAT_EQ(b.parser().continuityToleranceMs(),
+                            RrInterval::kDefaultContinuityToleranceMs)
+                    << "flags=" << flags << " stride=" << stride;
+            EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+                      cont(RrInterval::Continuity::CONTIGUOUS))
+                    << "flags=" << flags << " stride=" << stride;
+        }
+    }
+
+    // The flag is still readable — it is the only record of how the stamp was
+    // obtained, and a consumer may key its OWN budget on it through the
+    // two-argument overload even though this class does not.
+    Beat stamped(rr, thisUs, RrInterval::Flag::DETECTOR_STAMPED);
+    EXPECT_TRUE(stamped.parser().isDetectorStamped());
+    EXPECT_EQ(cont(stamped.parser().checkContinuity(prevUs, 20.f)),
+              cont(RrInterval::Continuity::GAP));
+}
+
+TEST(RrIntervalContinuity, TheStampBoundIsLooseAndTheMicrosecondFieldIsARemainder)
+{
+    // kMaxTimestampUs is the gate on prevUs, and it is the ceiling of the accessor's
+    // ARITHMETIC over Data's two uint32 fields -- what keeps the signed conversion in
+    // range -- not the reachable maximum, which is lower because the microsecond
+    // field is a remainder. Holding the loose value refuses no prevUs a
+    // conforming producer can send; the remainder is what the verdicts rest on.
+    RrData m;
+    m->mTimeStamp                  = 0xFFFFFFFFu;
+    m->mTimeStampUs                = 0xFFFFFFFFu;
+    m->mValue[RrInterval::RR_MS].f = 800.f;
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 1));
+
+    EXPECT_EQ(p.getTimestampUs(), RrInterval::kMaxTimestampUs);
+    // And such a stamp is accepted as a previous instant rather than rejected as
+    // impossible: a bound narrower than the accessor's range would read this as
+    // "not from this API".
+    EXPECT_LE(p.getTimestampUs(), RrInterval::kMaxTimestampUs);
+
+    Beat b(800.f, 5000000ull, 0u);
+    EXPECT_EQ(cont(b.parser().checkContinuity(RrInterval::kMaxTimestampUs)),
+              cont(RrInterval::Continuity::REORDERED));
+    EXPECT_EQ(cont(b.parser().checkContinuity(RrInterval::kMaxTimestampUs + 1ull)),
+              cont(RrInterval::Continuity::UNUSABLE));
+
+    // The remainder is a PRECONDITION of the comparison, not a convention a writer
+    // happens to follow: a full microsecond count doubles the apparent interval and
+    // can order two frames backwards, so such a frame gets no verdict rather than a
+    // confident wrong one. Without the guard the pair below reads GAP, silently. It
+    // is a backstop only -- it cannot inspect prevUs, and a full counter that lands
+    // under 1000 by chance still gets a verdict.
+    {
+        RrData full;
+        full->mTimeStamp                  = 5800u;
+        full->mTimeStampUs                = 5800000u; // a full counter, not a tail
+        full->mValue[RrInterval::RR_MS].f = 800.f;
+        RrInterval full_p(SDK::Sensor::DataView(*full.data(), 1));
+
+        RrData prev;
+        prev->mTimeStamp                  = 5000u;
+        prev->mTimeStampUs                = 5000000u;
+        prev->mValue[RrInterval::RR_MS].f = 800.f;
+        RrInterval q(SDK::Sensor::DataView(*prev.data(), 1));
+
+        EXPECT_EQ(cont(full_p.checkContinuity(q.getTimestampUs())),
+                  cont(RrInterval::Continuity::UNUSABLE));
+        // Both sides of the threshold, since every other case here sits orders of
+        // magnitude clear of it.
+        RrData edge;
+        edge->mTimeStamp                  = 5800u;
+        edge->mTimeStampUs                = 999u;
+        edge->mValue[RrInterval::RR_MS].f = 800.f;
+        RrInterval e(SDK::Sensor::DataView(*edge.data(), 1));
+        EXPECT_NE(cont(e.checkContinuity(5000999ull)),
+                  cont(RrInterval::Continuity::UNUSABLE)) << "999 us is a remainder";
+
+        // And past where a 32-bit ms * 1000 product would wrap: the guard's
+        // subtraction has to be done in 64 bits or a CONFORMING frame at a high
+        // uptime reads UNUSABLE. 4294968 ms * 1000 overflows uint32.
+        RrData high;
+        high->mTimeStamp                  = 4294968u;
+        high->mTimeStampUs                = 500u;
+        high->mValue[RrInterval::RR_MS].f = 800.f;
+        RrInterval h(SDK::Sensor::DataView(*high.data(), 1));
+        EXPECT_NE(cont(h.checkContinuity(4294967700ull)),
+                  cont(RrInterval::Continuity::UNUSABLE))
+                << "a conforming frame past the 32-bit product's wrap";
+
+        RrData over;
+        over->mTimeStamp                  = 5800u;
+        over->mTimeStampUs                = 1000u; // one microsecond past a remainder
+        over->mValue[RrInterval::RR_MS].f = 800.f;
+        RrInterval o(SDK::Sensor::DataView(*over.data(), 1));
+        EXPECT_EQ(cont(o.checkContinuity(5001000ull)),
+                  cont(RrInterval::Continuity::UNUSABLE)) << "1000 us is not";
+    }
+}
+
+TEST(RrIntervalContinuity, TheComparableBoundIsTheSpanOfTheMillisecondField)
+{
+    // The other field-width bound, held for the same reason and by the same route:
+    // kMaxComparableRrMs is the span of Data's uint32 millisecond field, and an
+    // rr_ms at or above it did not come from a stream this API can measure.
+    //
+    // It needs its own line because nothing else reaches it. Every case that
+    // exercises the bound — an interval too large to compare, a budget too large
+    // to compare — spells it symbolically or picks a value orders of magnitude
+    // clear of it, so halving the constant leaves all of them green while
+    // silently refusing intervals and budgets a producer is free to send.
+    EXPECT_FLOAT_EQ(RrInterval::kMaxComparableRrMs,
+                    static_cast<float>(
+                            static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1ull));
+}
+
+TEST(RrIntervalContinuity, ThePolicyTermsAreHeldToTheirStatedJustification)
+{
+    // The CHOSEN terms. The test above pins only the derivation's internal
+    // consistency, and scaling a picked term scales both sides of it without
+    // complaint — so each is held here to the reason given for it, and moving one
+    // means editing that reason in the same change. The terms that follow from the
+    // others are recomputed above; the two held to Data's field widths get a test
+    // each.
+
+    // kGuaranteedDetectableBpm is justified as covering a threshold protocol run to
+    // exhaustion — the 220-minus-age maximum at age 20. That is an exact figure,
+    // so it is pinned exactly rather than bracketed: a range would let the term
+    // drift anywhere inside it, and every budget below is scaled from this one,
+    // so 200 -> 240 would silently cut the published loose budget from 270 ms to
+    // 225 ms with nothing to complain. Moving it means editing the reason in the
+    // header and this line together.
+    EXPECT_FLOAT_EQ(RrInterval::kGuaranteedDetectableBpm, 220.f - 20.f);
+    // Lowering it is the tempting move, because it widens every budget and makes
+    // false gaps go away; what it buys is giving up detection at rates people
+    // reach. Raising it is the opposite trade, and the window closes entirely not
+    // far above: a lost beat at 240 bpm is only 250 ms.
+    EXPECT_LE(RrInterval::kGuaranteedDetectableBpm, 240.f);
+
+    // kLostBeatMarginFraction is bounded rather than pinned, and the difference is
+    // the point: the rate's rationale names a figure to pin it to, this one's
+    // names only a reason the term must exist. So the bound is the honest test —
+    // big enough to mean something, small enough to stay a margin rather than
+    // become the budget. Inside that bracket this is the only assertion that holds
+    // the term: the continuity cases are written in quantities derived from the
+    // budget, so they move with it instead of complaining.
+    EXPECT_GE(RrInterval::kLostBeatMarginFraction, 0.05f);
+    EXPECT_LE(RrInterval::kLostBeatMarginFraction, 0.25f);
+}
+
+TEST(RrIntervalContinuity, EqualityIsUnusableWhichIsWhyThereIsABudgetAtAll)
+{
+    // An R-R value is a whole number of 1/1024 s ticks, so it is fractional in
+    // milliseconds, and for this tick count not a whole number of microseconds
+    // either. Equality is not something to rely on either way: a count divisible
+    // by 16 does land on a whole microsecond, and a producer that floors its
+    // arithmetic lands on the same truncation checkContinuity applies. The budget
+    // is what the verdict rests on.
+    const float    rr   = 876.f * 125.f / 128.f; // 876 ticks == 855.46875 ms
+    const uint64_t rrUs = static_cast<uint64_t>(rr * 1000.f + 0.5f);
+
+    EXPECT_NE(static_cast<float>(rrUs) / 1000.f, rr);
+
+    // ...and the check reads it as contiguous regardless.
+    const uint64_t prevUs = 10000000ull;
+    Beat b(rr, prevUs + rrUs, 0u);
+    EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+              cont(RrInterval::Continuity::CONTIGUOUS));
+}
+
+TEST(RrIntervalContinuity, JitterReadsContiguousAndALostBeatReadsAsAGap)
+{
+    // Through real frames and the exported operation — the three cases the
+    // budget has to sort out, in the order they matter.
+    const float    rr     = 876.f * 125.f / 128.f;
+    const uint64_t prevUs = 10000000ull;
+    const uint64_t rrUs   = static_cast<uint64_t>(rr * 1000.f + 0.5f);
+
+    // Jitter just inside the budget, in both directions. A healthy stream must
+    // never read as a lost frame: that false positive is the expensive error,
+    // because it discards the HRV windows the strap was connected for.
+    const uint64_t jitterUs = msToUs(RrInterval::kDefaultContinuityToleranceMs - 1.f);
+    {
+        Beat late(rr, prevUs + rrUs + jitterUs, 0u);
+        EXPECT_EQ(cont(late.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::CONTIGUOUS));
+        Beat early(rr, prevUs + rrUs - jitterUs, 0u);
+        EXPECT_EQ(cont(early.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::CONTIGUOUS));
+    }
+
+    // A hole the size of the shortest interval the contract undertakes to detect
+    // the loss of -- not a beat of the stream above, which is slower.
+    {
+        Beat lost(rr, prevUs + rrUs + msToUs(RrInterval::kShortestLostBeatMs), 0u);
+        EXPECT_EQ(cont(lost.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::GAP));
+    }
+}
+
+TEST(RrIntervalContinuity, TheBudgetIsInclusiveAtBothEdges)
+{
+    // Where the verdict actually changes. Every other case here probes a budget's
+    // worth either side and so pins the middle of each band rather than its edge —
+    // which leaves the comparison itself free to be off by one in either
+    // direction. GAP is defined as exceeding rr_ms by MORE than the budget, so an
+    // error of exactly the budget is still CONTIGUOUS, and the same at the
+    // reordering edge. Both edges, and the first value past each.
+    const float    rr     = 800.f;
+    const uint64_t prevUs = 5000000ull;
+    const uint64_t rrUs   = 800000ull;
+    const uint64_t tolUs  =
+            static_cast<uint64_t>(RrInterval::kDefaultContinuityToleranceMs * 1000.f);
+
+    {
+        Beat at(rr, prevUs + rrUs + tolUs, 0u);
+        EXPECT_EQ(cont(at.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::CONTIGUOUS)) << "late by exactly the budget";
+        Beat past(rr, prevUs + rrUs + tolUs + 1ull, 0u);
+        EXPECT_EQ(cont(past.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::GAP)) << "one microsecond past it";
+    }
+    {
+        Beat at(rr, prevUs + rrUs - tolUs, 0u);
+        EXPECT_EQ(cont(at.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::CONTIGUOUS)) << "early by exactly the budget";
+        Beat past(rr, prevUs + rrUs - tolUs - 1ull, 0u);
+        EXPECT_EQ(cont(past.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::REORDERED)) << "one microsecond past it";
+    }
+}
+
+TEST(RrIntervalContinuity, AChainReadsContiguousWithinAndAcrossANotification)
+{
+    // The two arrangements a real arrival-reconstructing producer emits, walked
+    // as a consumer walks them: previous stamp in hand, one verdict per frame.
+    //
+    // Within one notification the reconstructed instants are exactly rr apart by
+    // construction, so those pairs carry no transport error at all. Across a
+    // boundary the two instants hang off two different arrivals and the pair
+    // inherits whatever sat between them — the case the loose budget exists for.
+    // Both must read CONTIGUOUS, or a producer following the TIMESTAMP recipe
+    // would see its own output reported as lossy.
+    const float rr[] = { 812.f, 795.f, 838.f, 806.f };
+
+    // One notification's worth, back-dated from a single arrival instant T.
+    const uint64_t tArrive = 30000000ull;
+    uint64_t       stamps[4];
+    {
+        uint64_t tail = 0ull; // SUM(rr[j] for j > i), accumulated backwards
+        for (int i = 3; i >= 0; --i) {
+            stamps[i] = tArrive - tail;
+            tail += msToUs(rr[i]);
+        }
+    }
+
+    uint64_t prevUs = stamps[0] - msToUs(rr[0]); // the beat before this burst
+    for (int i = 0; i < 4; ++i) {
+        Beat b(rr[i], stamps[i], 0u);
+        EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::CONTIGUOUS))
+                << "within-notification pair " << i;
+        prevUs = stamps[i];
+    }
+
+    // The next notification arrives a second later, and its first beat is late by
+    // most of the loose budget — the boundary pair, which is the only place in an
+    // arrival-reconstructed stream where transport jitter can show up.
+    {
+        const float    nextRr = 801.f;
+        const uint64_t skew   = msToUs(RrInterval::kDefaultContinuityToleranceMs - 1.f);
+        Beat           b(nextRr, prevUs + msToUs(nextRr) + skew, 0u);
+        EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::CONTIGUOUS));
+    }
+}
+
+TEST(RrIntervalContinuity, SeveralLostBeatsStillReadAsOneGap)
+{
+    // One lost beat is the threshold case; several is the common one, and the
+    // verdict must not degrade as the hole grows. There is no "how many" in the
+    // answer — a consumer discards the window either way — so the only thing that
+    // must hold is that a bigger hole never reads as anything milder.
+    const float    rr     = 800.f;
+    const uint64_t prevUs = 20000000ull;
+
+    for (int lost = 1; lost <= 5; ++lost) {
+        const uint64_t thisUs = prevUs + msToUs(rr) +
+                static_cast<uint64_t>(lost) * msToUs(rr);
+        Beat b(rr, thisUs, 0u);
+        EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::GAP))
+                << lost << " beats lost";
+    }
+}
+
+TEST(RrIntervalContinuity, ALostBeatIsCaughtAtThePolicyRateAndHiddenAboveTheBudget)
+{
+    // The stated residual, and the one that costs a consumer something because it
+    // is silent. It is NOT "above kGuaranteedDetectableBpm": loss is caught
+    // wherever the interval that went missing still exceeds the budget, and the
+    // margin puts that boundary above the rate. Describing the blind spot as
+    // starting at the rate overstates it by the whole width of the margin, so all
+    // three points are pinned here — caught at the rate, caught in the band above
+    // it, silent past the boundary.
+    const uint64_t prevUs = 5000000ull;
+
+    // One whole beat missing, at a given rate. A lost beat adds the neighbouring
+    // interval, so this is the shape the budget has to sort out.
+    const auto lostBeatAt = [prevUs](float bpm) {
+        const float    rr   = 60000.f / bpm;
+        const uint64_t rrUs = static_cast<uint64_t>(rr * 1000.f);
+        Beat b(rr, prevUs + rrUs + rrUs, 0u);
+        return cont(b.parser().checkContinuity(prevUs));
+    };
+
+    // The undertaking itself, at the rate that names it.
+    EXPECT_EQ(lostBeatAt(RrInterval::kGuaranteedDetectableBpm),
+              cont(RrInterval::Continuity::GAP));
+
+    // The band above it, where detection continues on the margin's account rather
+    // than the contract's. This is what the header declines to state as a boundary,
+    // because it moves with any term — but it must not be described as silent.
+    const float boundaryBpm = 60000.f / RrInterval::kDefaultContinuityToleranceMs;
+    ASSERT_GT(boundaryBpm, RrInterval::kGuaranteedDetectableBpm)
+            << "the margin is what puts the boundary above the rate";
+    EXPECT_EQ(lostBeatAt((RrInterval::kGuaranteedDetectableBpm + boundaryBpm) / 2.f),
+              cont(RrInterval::Continuity::GAP));
+
+    // And past the boundary it really is silent: the whole missing interval now
+    // fits inside the budget, so a consumer is told nothing. Derived rather than
+    // written as a rate, so no figure here needs maintaining alongside the header.
+    EXPECT_EQ(lostBeatAt(boundaryBpm * 1.05f), cont(RrInterval::Continuity::CONTIGUOUS));
+}
+
+TEST(RrIntervalContinuity, TheMillisecondFieldWrapReadsAsOneReordering)
+{
+    // A stated residual, re-derived here rather than asserted: Data's mTimeStamp
+    // is uint32 ms, so a session crossing ~49.7 days of uptime has exactly one
+    // pair whose stamps straddle the wrap. Signed arithmetic sees the post-wrap
+    // stamp as far EARLIER than its predecessor, so that pair reads REORDERED —
+    // not GAP, which is what the unsigned subtraction would have produced.
+    const float    rr      = 800.f;
+    const uint64_t lastMs  = 0xFFFFFFFFull;            // the final representable ms
+    const uint64_t prevUs  = lastMs * 1000ull + 600ull;
+    const uint64_t afterUs = 400ull * 1000ull;         // wrapped: 400 ms past zero
+
+    {
+        Beat b(rr, afterUs, 0u);
+        EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::REORDERED));
+    }
+
+    // And it is ONE pair, not a lasting condition: the very next pair is drawn
+    // from two post-wrap stamps and reads normally again.
+    {
+        const uint64_t nextUs = afterUs + msToUs(rr);
+        Beat           b(rr, nextUs, 0u);
+        EXPECT_EQ(cont(b.parser().checkContinuity(afterUs)),
+                  cont(RrInterval::Continuity::CONTIGUOUS));
+    }
+}
+
+TEST(RrIntervalContinuity, TheFirstFrameOfAStreamAndOfAReconnect)
+{
+    // Both "first" cases, which a consumer hits before it has anything to compare
+    // against and again after every reconnect. Neither may read CONTIGUOUS, and
+    // neither may leave a consumer accumulating across the boundary.
+    const float rr = 800.f;
+
+    // First frame of a stream, flags clear: no previous stamp exists, and 0 is what
+    // a consumer has before it has seen one. Nothing can be said, so UNUSABLE.
+    {
+        Beat b(rr, 40000000ull, 0u);
+        EXPECT_EQ(cont(b.parser().checkContinuity(0ull)),
+                  cont(RrInterval::Continuity::UNUSABLE));
+    }
+
+    // The same frame from a producer that declares the gap it knows about. The
+    // declaration is producer knowledge that does not rest on the stamps, so it is
+    // answered before them and reads GAP rather than UNUSABLE.
+    //
+    // Both answers are right, which is why the order is not arbitrary: at stream
+    // start there is no window to discard either way, so nothing is lost by
+    // reporting the declaration — whereas answering the stamps first would swallow
+    // a declared reconnect whenever its frame happened to arrive unstamped, and
+    // that one does cost a consumer a window it should have thrown away.
+    {
+        Beat b(rr, 40000000ull, RrInterval::Flag::DISCONTINUITY);
+        EXPECT_EQ(cont(b.parser().checkContinuity(0ull)),
+                  cont(RrInterval::Continuity::GAP));
+        // ...and an unstamped frame declaring one is still a declared gap.
+        Beat unstamped(rr, 0ull, RrInterval::Flag::DISCONTINUITY);
+        EXPECT_EQ(cont(unstamped.parser().checkContinuity(40000000ull)),
+                  cont(RrInterval::Continuity::GAP));
+    }
+
+    // First frame after a reconnect: a previous stamp does exist, from before the
+    // drop, and the producer knows the two do not join up. DISCONTINUITY says so
+    // and reads GAP even though the stamps happen to line up — the stamps cannot
+    // be trusted to reveal it, because a reconnect gap can be any length,
+    // including one that lands inside the budget.
+    {
+        const uint64_t prevUs = 40000000ull;
+        Beat           b(rr, prevUs + msToUs(rr), RrInterval::Flag::DISCONTINUITY);
+        EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::GAP));
+    }
+}
+
+TEST(RrIntervalContinuity, AnUnstampedFrameIsUnusableRatherThanContiguous)
+{
+    // The TIMESTAMP rule for a reconstruction that underflows is to emit only the
+    // intervals whose instant is representable and flag the first emitted — not to
+    // clamp to zero. This is what the rule protects against: were a producer to
+    // stamp zero anyway, the frame must not be measurable from, because zero is
+    // also what a malformed frame reports and a valid frame at zero would collide
+    // with it.
+    const float rr = 800.f;
+
+    Beat b(rr, 0ull, 0u);
+    EXPECT_TRUE(b.parser().isDataValid()); // the interval itself is fine
+    EXPECT_EQ(b.parser().getTimestampUs(), 0ull);
+    EXPECT_EQ(cont(b.parser().checkContinuity(msToUs(rr))),
+              cont(RrInterval::Continuity::UNUSABLE));
+
+    // The rule's own path: the surviving frames are stamped normally and the
+    // first carries DISCONTINUITY, so a consumer gets a gap rather than a
+    // fabricated instant.
+    {
+        const uint64_t firstUs = msToUs(rr);
+        Beat           first(rr, firstUs, RrInterval::Flag::DISCONTINUITY);
+        EXPECT_EQ(cont(first.parser().checkContinuity(msToUs(400.f))),
+                  cont(RrInterval::Continuity::GAP));
+        Beat second(rr, firstUs + msToUs(rr), 0u);
+        EXPECT_EQ(cont(second.parser().checkContinuity(firstUs)),
+                  cont(RrInterval::Continuity::CONTIGUOUS));
+    }
+}
+
+TEST(RrIntervalContinuity, TheAdvanceRuleAConsumerHasToFollow)
+{
+    // The CONSUMER OBLIGATION: the stamp passed in is the previous frame whose
+    // isDataValid() held, whatever verdict that frame got. Nothing in the API can
+    // enforce it and both ways of breaking it are silent, so the rule is pinned
+    // here beside the two wrong readings — the shape
+    // TheSubtractionAConsumerWouldWriteGetsReorderingWrong uses, for the same
+    // reason: a rule nobody can see being broken has to be demonstrated.
+    const float    rr = 800.f;
+    const uint64_t b1 = 10000000ull;
+    const uint64_t b2 = b1 + msToUs(rr);
+    const uint64_t b3 = b2 + msToUs(rr); // this beat's interval is never reported
+    const uint64_t b4 = b3 + msToUs(rr);
+
+    Beat good(rr, b2, 0u);
+    Beat malformed(std::numeric_limits<float>::quiet_NaN(), b3, 0u);
+    Beat next(rr, b4, 0u);
+
+    ASSERT_EQ(cont(good.parser().checkContinuity(b1)),
+              cont(RrInterval::Continuity::CONTIGUOUS));
+    ASSERT_EQ(cont(malformed.parser().checkContinuity(b2)),
+              cont(RrInterval::Continuity::UNUSABLE));
+
+    // Following the rule: the last frame whose isDataValid() held was `good`, at
+    // b2. The pair therefore spans two beats and IS a gap — one interval went
+    // unreported, and the window it falls in has a hole in it.
+    EXPECT_EQ(cont(next.parser().checkContinuity(b2)),
+              cont(RrInterval::Continuity::GAP));
+
+    // Breaking it the first way — advancing across the invalid frame — carries its
+    // zero stamp forward, and the gap becomes UNUSABLE: the one verdict the header
+    // defines as needing no window discarded. This is the expensive direction,
+    // because a window with a lost beat in it survives into an HRV figure.
+    EXPECT_EQ(malformed.parser().getTimestampUs(), 0ull);
+    EXPECT_EQ(cont(next.parser().checkContinuity(malformed.parser().getTimestampUs())),
+              cont(RrInterval::Continuity::UNUSABLE));
+
+    // Breaking it the second way — holding the old stamp until something reads
+    // CONTIGUOUS again — never recovers, and the millisecond wrap is where it
+    // shows. The residual the header states is ONE REORDERED; that is a property of
+    // the rule, not of the format, which is the whole reason the rule is written
+    // down.
+    {
+        const uint64_t pre   = 0xFFFFFFFFull * 1000ull + 600ull;
+        const uint64_t after = 400ull * 1000ull; // wrapped: 400 ms past zero
+        Beat wrapped(rr, after, 0u);
+        ASSERT_EQ(cont(wrapped.parser().checkContinuity(pre)),
+                  cont(RrInterval::Continuity::REORDERED));
+
+        Beat following(rr, after + msToUs(rr), 0u);
+        EXPECT_EQ(cont(following.parser().checkContinuity(after)),
+                  cont(RrInterval::Continuity::CONTIGUOUS)) << "advanced per the rule";
+        EXPECT_EQ(cont(following.parser().checkContinuity(pre)),
+                  cont(RrInterval::Continuity::REORDERED)) << "held at the pre-wrap stamp";
+    }
+}
+
+TEST(RrIntervalContinuity, TheBudgetDoesNotKeyOnSource)
+{
+    // Source is the obvious axis and the wrong one. An optical path behind a
+    // batching sub-sensor is arrival-reconstructed while reading OPTICAL, and a
+    // strap whose firmware stamps at the link layer is detector-stamped while
+    // reading EXTERNAL — so how the stamp was obtained cuts across Source and
+    // never follows it. Today no frame content moves the budget at all
+    // (ThereIsExactlyOneBudgetAndNoFrameChangesIt), which makes this trivially
+    // true; it is kept because a reintroduced per-class budget would be reaching
+    // for exactly this field, and it would then have to fail here first.
+    const float    rr     = 800.f;
+    const uint64_t prevUs = 5000000ull;
+    const uint64_t offUs  = msToUs(50.f);
+    const uint64_t thisUs = prevUs + 800000ull + offUs;
+
+    const RrInterval::Source sources[] = {
+        RrInterval::Source::UNKNOWN, RrInterval::Source::OPTICAL,
+        RrInterval::Source::EXTERNAL, RrInterval::Source::ECG,
+    };
+
+    for (RrInterval::Source s : sources) {
+        for (uint32_t flags : { 0u, uint32_t(RrInterval::Flag::DETECTOR_STAMPED) }) {
+            Beat b(rr, thisUs, flags);
+            b.d->mValue[RrInterval::SOURCE].u32 = static_cast<uint32_t>(s);
+            EXPECT_FLOAT_EQ(b.parser().continuityToleranceMs(),
+                            RrInterval::kDefaultContinuityToleranceMs)
+                    << "source=" << src(s) << " flags=" << flags;
+            EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+                      cont(RrInterval::Continuity::CONTIGUOUS))
+                    << "source=" << src(s) << " flags=" << flags;
+        }
+    }
+}
+
+TEST(RrIntervalContinuity, ANarrowerStampIsDeletedRatherThanWidened)
+{
+    // The unit confusion this class is otherwise wide open to. getTimestamp() and
+    // getTimestampUs() sit next to each other, differ by a factor of 1000, and
+    // both convert to uint64_t without complaint — so the wrong one yields a
+    // confident GAP on a contiguous pair, silently, in the one operation the
+    // contract tells consumers not to write themselves. A millisecond stamp is
+    // indistinguishable at runtime from a microsecond stamp of a session 1000x
+    // younger.
+    static_assert(AcceptsStamp<uint64_t>::value,
+                  "a microsecond stamp is what this takes");
+    static_assert(!AcceptsStamp<uint32_t>::value,
+                  "getTimestamp() is milliseconds and must not compile here");
+    static_assert(AcceptsStampAndBudget<uint64_t>::value,
+                  "the two-argument overload takes the same stamp");
+    static_assert(!AcceptsStampAndBudget<uint32_t>::value,
+                  "and refuses the same wrong one");
+
+    // A stamp is an integer instant. A float one is refused for the same reason and
+    // by the same route -- nothing distinguishes float ms from float us at runtime --
+    // and on the two-argument form a float first argument is the arguments
+    // transposed.
+    static_assert(!AcceptsStamp<float>::value,
+                  "a float stamp is not a microsecond instant");
+    static_assert(!AcceptsStamp<double>::value,
+                  "a double stamp is not a microsecond instant");
+    static_assert(!AcceptsStampAndBudget<float>::value,
+                  "and a float first argument is the two arguments swapped");
+    static_assert(!AcceptsStampAndBudget<double>::value,
+                  "and a float first argument is the two arguments swapped");
+    // The other categories that converted silently before the whitelist.
+    static_assert(!AcceptsStamp<UnscopedStamp>::value,
+                  "an enumerator is a compile-time constant, not an instant");
+    static_assert(!AcceptsStamp<int64_t>::value,
+                  "a signed millisecond count is not a stamp either");
+    static_assert(!AcceptsStamp<long long>::value,
+                  "nor a signed one that happens to be wide enough");
+    static_assert(!AcceptsStampAndBudget<UnscopedStamp>::value, "same on both overloads");
+    static_assert(!AcceptsStampAndBudget<int64_t>::value, "same on both overloads");
+    // A user-defined conversion reaches prevUs as silently as a built-in one.
+    static_assert(!AcceptsStamp<ConvertsToStamp>::value,
+                  "a class with operator uint64_t() is not a stamp either");
+    static_assert(!AcceptsStampAndBudget<ConvertsToStamp>::value, "same on both overloads");
+
+    // The transposition refused from the budget's side -- NOT every spelling of it:
+    // the predicates are duals, so a type refused as a stamp is accepted as a budget
+    // and the transposition survives there. See the overload's note. Pinned with the
+    // legal budget spellings, since the argument for closing the closable part is
+    // that it costs none of them.
+    static_assert(!AcceptsBudget<uint64_t>::value,
+                  "an unsigned 64-bit budget is the transposition");
+    // Spelled as the width the predicate keys on, so it holds on a 32-bit target too
+    // (!AcceptsBudget<size_t> would not: size_t is four bytes there).
+    static_assert(!AcceptsBudget<unsigned long long>::value,
+                  "however it is spelled -- and this is the spelling that pins the "
+                  "width form rather than is_same<B, uint64_t>");
+    static_assert(AcceptsBudget<float>::value,   "a budget is float milliseconds");
+    static_assert(AcceptsBudget<double>::value,  "and a double literal still converts");
+    static_assert(AcceptsBudget<int>::value,     "and an int literal: checkContinuity(x, 270)");
+    static_assert(AcceptsBudget<unsigned>::value, "and 270u");
+    static_assert(AcceptsBudget<long>::value,    "and a signed long, which cannot be a stamp");
+
+    // The verdict the deleted overload would have returned, had it existed: the
+    // pair below is contiguous, and a millisecond stamp reads it as a gap.
+    const float    rr     = 800.f;
+    const uint64_t prevUs = 5000000ull;
+    Beat           b(rr, prevUs + 800000ull, 0u);
+    EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+              cont(RrInterval::Continuity::CONTIGUOUS));
+    EXPECT_EQ(cont(b.parser().checkContinuity(static_cast<uint64_t>(prevUs / 1000ull))),
+              cont(RrInterval::Continuity::GAP));
+}
+
+TEST(RrIntervalContinuity, TheSubtractionAConsumerWouldWriteGetsReorderingWrong)
+{
+    // Why this is an exported operation and not an exported number. Given only a
+    // threshold, a consumer writes the comparison itself, and the obvious way to
+    // write it is wrong: getTimestampUs() is unsigned, so on a reordered pair the
+    // subtraction wraps, and converting that to float yields an enormous POSITIVE
+    // gap rather than a negative one. It does not merely misclassify — it reports
+    // the strongest evidence of a lost frame that the stream can produce, for a
+    // pair that is only out of order. Every consumer would have to get this right
+    // independently, and this is the shape they would get wrong.
+    const float    rr     = 800.f;
+    const uint64_t thisUs = 5000000ull;
+    const uint64_t prevUs = thisUs + 400000ull;
+
+    const float naiveDeltaMs = static_cast<float>(thisUs - prevUs) / 1000.f;
+    EXPECT_GT(naiveDeltaMs, 1e12f); // ~1.8e16 ms, where the truth is -400 ms
+
+    Beat b(rr, thisUs, 0u);
+    EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+              cont(RrInterval::Continuity::REORDERED));
+}
+
+TEST(RrIntervalContinuity, AReorderedPairReadsReorderedNotAGiantGap)
+{
+    // The verdict itself, at two magnitudes of reordering. The operation does the
+    // subtraction signed and in the microsecond domain; both stamps are bounded
+    // by kMaxTimestampUs, so the conversion to int64_t is always in range rather
+    // than relying on how an out-of-range unsigned-to-signed conversion happens
+    // to behave — which C++17 leaves implementation-defined.
+    const float    rr     = 800.f;
+    const uint64_t thisUs = 5000000ull;
+
+    // Well past the budget backwards.
+    {
+        Beat b(rr, thisUs, 0u);
+        EXPECT_EQ(cont(b.parser().checkContinuity(thisUs + 400000ull)),
+                  cont(RrInterval::Continuity::REORDERED));
+    }
+
+    // And a pair only barely out of order: the previous stamp is one interval
+    // plus a budget's worth ahead.
+    {
+        Beat b(rr, thisUs, 0u);
+        const uint64_t prevUs = thisUs + 800000ull +
+                msToUs(RrInterval::kDefaultContinuityToleranceMs + 1.f);
+        EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::REORDERED));
+    }
+}
+
+TEST(RrIntervalContinuity, ADeclaredDiscontinuityOutranksTheStamps)
+{
+    // Perfectly spaced stamps, but the producer says it knows there is a gap —
+    // a reconnect, or the first beat of a session. The producer knows better
+    // than the timestamps do, and a check that papered over it would let a
+    // consumer accumulate straight across the boundary.
+    const float    rr     = 800.f;
+    const uint64_t prevUs = 5000000ull;
+
+    Beat b(rr, prevUs + 800000ull, RrInterval::Flag::DISCONTINUITY);
+    EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+              cont(RrInterval::Continuity::GAP));
+    // Still distinguishable from a detected gap.
+    EXPECT_TRUE(b.parser().hasDiscontinuity());
+}
+
+TEST(RrIntervalContinuity, UnusableRatherThanAFalseVerdict)
+{
+    const float    rr     = 800.f;
+    const uint64_t prevUs = 5000000ull;
+    const uint64_t thisUs = prevUs + 800000ull;
+
+    // A malformed frame says nothing about continuity — and must not be reported
+    // as a gap, which would have a consumer discard a window for a frame that
+    // never carried a beat.
+    {
+        Beat b(0.f, thisUs, 0u);
+        EXPECT_FALSE(b.parser().isDataValid());
+        EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::UNUSABLE));
+    }
+
+    // Zero is "not stamped" throughout this class: it is what an invalid frame
+    // reports, and for that reason what the TIMESTAMP contract forbids a producer
+    // to stamp. Neither end is an instant to measure from.
+    {
+        Beat b(rr, 0ull, 0u);
+        EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::UNUSABLE));
+    }
+    {
+        Beat b(rr, thisUs, 0u);
+        EXPECT_EQ(cont(b.parser().checkContinuity(0ull)),
+                  cont(RrInterval::Continuity::UNUSABLE));
+    }
+
+    // A prevUs that cannot have come from getTimestampUs(): both of Data's
+    // timestamp fields are uint32 and the accessor forms ms * 1000 + us, so
+    // nothing beyond that is a stamp from this API, and admitting one would put
+    // the signed conversion out of range.
+    {
+        Beat b(rr, thisUs, 0u);
+        EXPECT_EQ(cont(b.parser().checkContinuity(RrInterval::kMaxTimestampUs + 1ull)),
+                  cont(RrInterval::Continuity::UNUSABLE));
+    }
+
+    // A caller-supplied budget that is not a budget. Reading NaN or a negative
+    // as zero would turn every comparison into a gap.
+    {
+        Beat b(rr, thisUs, 0u);
+        // The exception, pinned because it is one: a declared gap is answered
+        // before the budget is read, so this frame reports GAP and the caller is
+        // never told its budget was nonsense. That follows from the ordering being
+        // deliberate — the declaration does not rest on the budget any more than it
+        // rests on the stamps — but it means the guard below cannot be relied on to
+        // surface a caller's bug.
+        Beat declared(rr, thisUs, RrInterval::Flag::DISCONTINUITY);
+        const float bad[] = { std::numeric_limits<float>::quiet_NaN(),
+                              std::numeric_limits<float>::infinity(),
+                              -1.f };
+        for (float t : bad) {
+            EXPECT_EQ(cont(b.parser().checkContinuity(prevUs, t)),
+                      cont(RrInterval::Continuity::UNUSABLE)) << t;
+            EXPECT_EQ(cont(declared.parser().checkContinuity(prevUs, t)),
+                      cont(RrInterval::Continuity::GAP)) << t;
+        }
+    }
+}
+
+TEST(RrIntervalContinuity, AnIntervalTooLargeToCompareIsUnusableNotUndefined)
+{
+    // The one guard on rr_ms in checkContinuity() that isDataValid() does not imply,
+    // and the reason it cannot be folded away as redundant: this contract passes
+    // any finite positive interval through on purpose (see
+    // ImplausibleButFiniteIntervalsArePassedThrough), so a decode bug can hand the
+    // comparison an rr_ms far outside the range int64_t can hold. The undefined
+    // operation is the float-to-int64 conversion of rr * 1000, which is undefined
+    // from about 9.2e15 ms upward whether or not the multiply itself overflows —
+    // the frame is still valid, so nothing upstream stops it.
+    //
+    // Every value below therefore has to reach a verdict rather than a conversion.
+    const float tooLarge[] = {
+        RrInterval::kMaxComparableRrMs,          // exactly at the bound
+        1e10f,                                   // representable, but past it
+        1e30f,                                   // rr * 1000 is finite (1e33) and
+                                                 // still far outside int64_t
+        std::numeric_limits<float>::max(),       // rr * 1000 overflows float32 too
+    };
+
+    const uint64_t prevUs = 39200000ull;
+    for (float v : tooLarge) {
+        Beat b(v, 40000000ull, 0u);
+        EXPECT_TRUE(b.parser().isDataValid()) << v;      // a valid frame...
+        EXPECT_FLOAT_EQ(b.parser().getRrMs(), v);        // ...reported as given...
+        EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::UNUSABLE)) << v;
+    }
+
+    // And the bound is not merely large: the largest interval that IS comparable
+    // still gets a real verdict, so the guard cuts where it says it does.
+    {
+        Beat b(std::nextafter(RrInterval::kMaxComparableRrMs, 0.f), 40000000ull, 0u);
+        EXPECT_NE(cont(b.parser().checkContinuity(prevUs)),
+                  cont(RrInterval::Continuity::UNUSABLE));
+    }
+}
+
+TEST(RrIntervalContinuity, ACallerCanSupplyItsOwnBudget)
+{
+    // The escape hatch the derivation requires. The arrival-reconstructed budget
+    // is the widest the lost-beat ceiling permits, not a bound on any real link
+    // — nothing in this SDK bounds the connection interval — so a consumer that
+    // has measured its own jitter, or a layer that knows the link parameters,
+    // supplies a figure instead of accepting this one.
+    const float    rr     = 800.f;
+    const uint64_t prevUs = 5000000ull;
+    const uint64_t thisUs = prevUs + 800000ull + msToUs(100.f);
+
+    Beat b(rr, thisUs, 0u);
+
+    // The default budget absorbs 100 ms...
+    EXPECT_EQ(cont(b.parser().checkContinuity(prevUs)),
+              cont(RrInterval::Continuity::CONTIGUOUS));
+    // ...a consumer on a link it knows to be tighter than that does not have to.
+    EXPECT_EQ(cont(b.parser().checkContinuity(prevUs, 50.f)),
+              cont(RrInterval::Continuity::GAP));
+    // A zero budget is legal and means "exact or nothing" — both halves, since a
+    // boundary that excluded its own edge would make "exact" unreachable and turn
+    // a zero budget into "always GAP".
+    EXPECT_EQ(cont(b.parser().checkContinuity(prevUs, 0.f)),
+              cont(RrInterval::Continuity::GAP));
+    {
+        Beat exact(rr, prevUs + 800000ull, 0u);
+        EXPECT_EQ(cont(exact.parser().checkContinuity(prevUs, 0.f)),
+                  cont(RrInterval::Continuity::CONTIGUOUS));
+    }
+    // ...and "exact" means exact in MICROSECONDS. The 800 ms above cannot show that:
+    // it is a whole number of milliseconds, so truncating rr_ms before the comparison
+    // is a no-op on it. A real strap interval is a whole number of 1/1024 s ticks.
+    {
+        const float    tickRr   = 876.f * 125.f / 128.f; // 855.46875 ms
+        const uint64_t tickRrUs = static_cast<uint64_t>(tickRr * 1000.f);
+        ASSERT_NE(tickRrUs, static_cast<uint64_t>(tickRr) * 1000ull)
+                << "the fixture must be fractional in milliseconds or it pins nothing";
+        Beat exactUs(tickRr, prevUs + tickRrUs, 0u);
+        EXPECT_EQ(cont(exactUs.parser().checkContinuity(prevUs, 0.f)),
+                  cont(RrInterval::Continuity::CONTIGUOUS));
+        Beat exactMsOnly(tickRr, prevUs + static_cast<uint64_t>(tickRr) * 1000ull, 0u);
+        EXPECT_EQ(cont(exactMsOnly.parser().checkContinuity(prevUs, 0.f)),
+                  cont(RrInterval::Continuity::REORDERED))
+                << "a whole-millisecond interval is not this interval";
+    }
+
+    // A budget too large to compare is refused like any other unrepresentable one.
+    // The NaN and infinity cases elsewhere never reach this bound: these are
+    // finite, non-negative and pass every other test a budget faces.
+    for (float t : { 1e10f, 1e30f, std::numeric_limits<float>::max(),
+                     RrInterval::kMaxComparableRrMs }) {
+        EXPECT_EQ(cont(b.parser().checkContinuity(prevUs, t)),
+                  cont(RrInterval::Continuity::UNUSABLE)) << t;
+    }
+    // And the bound cuts where it says: the largest budget still comparable gets a
+    // real verdict rather than falling into the same refusal.
+    EXPECT_NE(cont(b.parser().checkContinuity(
+                      prevUs, std::nextafter(RrInterval::kMaxComparableRrMs, 0.f))),
+              cont(RrInterval::Continuity::UNUSABLE));
+}
+
+TEST(RrIntervalParser, ImplausibleButFiniteIntervalsArePassedThrough)
+{
+    // The parser is not an artefact filter — that policy belongs to the consumer
+    // (and to ARTIFACT_SUSPECT). A 5 ms and a 40 s interval are both nonsense
+    // physiologically and both parse.
+    const float odd[] = { 5.f, 40000.f };
+
+    for (float v : odd) {
+        RrData m;
+        m->mValue[RrInterval::RR_MS].f = v;
+
+        RrInterval p(SDK::Sensor::DataView(*m.data(), 1));
+
+        EXPECT_TRUE(p.isDataValid());
+        EXPECT_FLOAT_EQ(p.getRrMs(), v);
+        EXPECT_FLOAT_EQ(p.getBpm(), 60000.f / v);
+    }
+}
+
+TEST(RrIntervalParser, BpmNeverReturnsInfinity)
+{
+    // Finite and positive, so the frame is valid and getRrMs() reports it — but
+    // 60000/rr overflows, and an infinity is not a reading.
+    RrData m;
+    m->mValue[RrInterval::RR_MS].f = 1e-40f;
+
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 1));
+
+    EXPECT_TRUE(p.isDataValid());
+    EXPECT_FLOAT_EQ(p.getRrMs(), 1e-40f);
+    EXPECT_TRUE(std::isfinite(p.getBpm()));
+    EXPECT_FLOAT_EQ(p.getBpm(), 0.f);
+}
+
+TEST(RrIntervalParser, ZeroFieldFrameIsInvalid)
+{
+    RrData m;
+    m->mValue[RrInterval::RR_MS].f = 800.f;
+
+    // A malformed / empty frame: getters read safe zeros, never a false gap.
+    RrInterval p(SDK::Sensor::DataView(*m.data(), 0));
+
+    EXPECT_FALSE(p.isDataValid());
+    EXPECT_FLOAT_EQ(p.getRrMs(), 0.f);
+    EXPECT_FLOAT_EQ(p.getBpm(), 0.f);
+    EXPECT_EQ(src(p.getSource()), src(RrInterval::Source::UNKNOWN));
+    EXPECT_FALSE(p.hasDiscontinuity());
+}


### PR DESCRIPTION
# feat(sensor): experimental RR_INTERVAL beat-to-beat pathway

An R-R interval is the gap between one heartbeat and the next. RMSSD, SDNN and DFA-alpha1 are computed from those gaps, and readiness, recovery and training-threshold metrics are built on those in turn.

Nothing in the SDK carries them. `HEART_RATE` and `HEART_RATE_EX` both carry a rate. A Bluetooth strap already sends the intervals to the watch in the same `0x2A37` notification the kernel reads for BPM, where the decoder drops them, so an app has nothing to compute HRV from. This adds the SDK side of a sensor type that keeps them: `SDK::Sensor::Type::RR_INTERVAL` (0x44) and a parser for it, opt-in and experimental. There is no firmware producer yet, so 0x44 is not stable until one has been written against it.

None of this is Polar specific. R-R intervals are a standard field of the Bluetooth Heart Rate Service, so any compliant strap provides them the same way.

The firmware ask is to stop discarding the R-R field; the kernel already parses `0x2A37` for BPM and the intervals are in the same bytes. One warning for whoever writes that. The R-R array is the last field of the notification and its offset moves, because flags bit 3 inserts a two byte energy-expended field ahead of it. Get that wrong and every interval is misread on a strap that reports it, and the misread values still look like plausible intervals. `ExternalSensors.md` has the layout.

---

## Decisions

The header keeps the consumer contract, `ExternalSensors.md` owns the producer half, and the reasoning below lives here rather than in either. In short:

Two producers are in view, a strap and a wrist-optical path, and the contract is shaped for both rather than for one. That is why the continuity budget does not key on `Source`, and why field `[3]` is reserved for a graded per-beat confidence rather than defined now.

One interval per frame. `Data` has no length field, so a notification carrying several intervals arrives as several frames.

`rr_ms` is float milliseconds; `source` and `flags` are u32, since a bitmask carried in a float is only exact below 2^24.

The frame timestamp is the beat instant its interval ends on. This is the one decision that cannot be relaxed later, because a consumer relying on true beat instants breaks the moment a producer stops supplying them.

Loss detection is an exported operation, `checkContinuity()`, rather than an exported threshold. The comparison has to be signed and in microseconds or a reordered pair wraps to an enormous forward gap, which is the shape every consumer given a bare number would get wrong independently. It also deletes the overloads that would widen a narrower stamp: `getTimestamp()` sits next to `getTimestampUs()` and differs by a factor of 1000, so passing the wrong one returns a confident `GAP` on a contiguous pair with no diagnostic, and no runtime guard can catch that. How far that deletion reaches is under Open.

Artefact policy belongs to the consumer, which is what `ARTIFACT_SUSPECT` is for. No sequence number: it would be a second loss-detection mechanism whose obligation falls on a producer that does not exist, when `DISCONTINUITY` already covers the loss a producer knows about. Appending one stays safe, so that is revisitable.

## Pivots

`kContiguityToleranceMs` is gone, replaced by `checkContinuity()` and a derived budget. Not because 250 ms was wrong, but because this repository cannot defend it. It was sized partly on the connection interval our accessory central negotiates, and the whole accessory surface here is `Kind`, `State` and a device name. @rryles holds a figure this repository does not, and if it should be applied, the right shape is the two-argument overload called from the layer that knows the link.

There is one continuity budget rather than one per stamping class. A tighter budget for `DETECTOR_STAMPED` was written and then removed: its dominant term is detector-to-stamp jitter, nothing here can measure it, and neither producer in view sets the flag. The magnitude would have been a guess that producers were then required to hold under, and a producer that exceeded it would have every window discarded, which is the false positive this contract treats as the expensive error. The flag keeps its bit and its meaning, so a second budget lands with the detector that can size one, and `continuityToleranceMs()` stays a member function so that costs no consumer a call site.

The 170 bpm sizing basis became `kGuaranteedDetectableBpm` at 200 bpm, pinned to 220-minus-age at age 20.

The minimum delivery period is restored as a producer obligation, and is now anchored to the producer's own shortest interval rather than to the simulator's rate adapter, so it carries no borrowed authority. A lost beat reads `CONTIGUOUS` once the whole missing interval fits inside the budget, which the margin puts at a rate above `kGuaranteedDetectableBpm` rather than at it; a stated residual with a test.

You asked whether the producer half belonged in `ExternalSensors.md` beside the `0x2A37` decode notes, leaving the header with the consumer contract and a pointer. I said no. That was the wrong call and I have reversed it.

Concentrating the prose in the header did not prevent drift; it put the copy that rots into the artifact that ships, and the duplication it was meant to avoid existed anyway. So the split is the one you proposed: the header keeps the consumer contract, `ExternalSensors.md` owns the producer half beside the `0x2A37` walk it already owned, and this description carries the reasoning.

## Open

- `Source::ECG = 3` is not held by a `static_assert`. The kernel HR arbiter defines these values and has none for ECG, unlike the other three. If the arbiter later assigns 3 to something else, every frame already written is mislabelled, so this wants settling before anything ships against 0x44.
- `kLostBeatMarginFraction` is chosen with no measurement behind its magnitude, and it may point the wrong way. A larger margin narrows the budget and so buys more false positives, and HRV has largely collapsed by 200 bpm, so a smaller figure looks more consistent with the rest of the file. Beat-to-beat variation measured near the detection ceiling would settle it.
- The simulator's missing event-based bypass is a TODO (removed from the scope of this PR)
- The compile-time refusal of a wrong stamp is narrower than it looks. The deleted overloads are bypassed by a braced-init-list, which is a non-deduced context, so `checkContinuity({getTimestamp()})` compiles and reads a confident `GAP` on a contiguous pair; and by a pointer-to-member, which names the surviving overload directly. Widening the overload set closes one route and opens another, because a predicate can only refuse the spellings someone thought of. Closing the class wants a tagged microsecond instant instead, and the only callers today are this file's own tests, so it is cheaper now than at any later point.
- Why a new type rather than `HEART_BEAT` (0x40): it is declared but has no parser and no field layout, and differencing beat-peak instants would put the interval reconstruction, and the loss detection with it, in every consumer.
- `HeartRateEx::getSource()` has the same unguarded float narrowing this fixed

