### PR TITLE
feat(variant): multi-activity variants - Walking on the Hiking binary (M2)

### DIFF
--- a/Examples/Apps/Hiking/Software/Apps/Hiking-CMake/CMakeLists.txt
+++ b/Examples/Apps/Hiking/Software/Apps/Hiking-CMake/CMakeLists.txt
@@ -53,11 +53,16 @@ if(DEFINED TOUCHGFX_PATH)
         ${TOUCHGFX_SOURCES}
         ${UNA_SDK_SOURCES_COMMON}
         ${UNA_SDK_SOURCES_GUI}
+        # The GUI reads the variant config directly (screen titles), so it
+        # needs the reader and its JSON machinery in this link too.
+        ${UNA_SDK_SOURCES_VARIANT}
+        ${UNA_SDK_SOURCES_JSON}
     )
     set(GUI_INCLUDE_DIRS
         ${LIBS_INCLUDE_DIRS}
         ${UNA_SDK_INCLUDE_DIRS_COMMON}
         ${UNA_SDK_INCLUDE_DIRS_GUI}
+        ${UNA_SDK_INCLUDE_DIRS_JSON}
         ${TOUCHGFX_INCLUDE_DIRS}
     )
     una_app_build_gui(${APP_NAME}GUI.elf)

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/common/FrontendApplication.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/common/FrontendApplication.hpp
@@ -19,6 +19,8 @@ public:
     FrontendApplication(Model& m, FrontendHeap& heap);
     virtual ~FrontendApplication() { }
 
+    Model& getModel() { return model; }
+
     virtual void handleTickEvent()
     {
 #if defined(SIMULATOR)

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
@@ -61,6 +61,7 @@ public:
 
     // ---- Chrome ------------------------------------------------------------
     void setTitle(TypedTextId msgId);
+    void setTitle(const char* text);
     void showTitle(bool state);
 
     void setBackground(touchgfx::colortype color);

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -7,6 +7,7 @@
 #include <images/BitmapDatabase.hpp>
 
 #include "SDK/Kernel/Kernel.hpp"
+#include "SDK/Variant/VariantConfig.hpp"
 #include "SDK/Interfaces/IGuiLifeCycleCallback.hpp"
 #include "SDK/Interfaces/ICustomMessageHandler.hpp"
 #include <SDK/Utils/Utils.hpp>
@@ -110,10 +111,16 @@ public:
     bool isTrackSummaryAvailable() const;
     const ActivitySummary& getTrackSummary() const;
 
+    // Variant identity: the uppercased display name for screen titles, or
+    // nullptr when this binary runs as its classic self (use the typed text).
+    const char* variantTitle() const;
+
 private:
     ModelListener*        modelListener;
     const SDK::Kernel&    mKernel;
     CustomMessage::Sender mSrvSender;
+    SDK::Variant::Config  mVariant;
+    char                  mVariantTitle[16] {};
 
     // IGuiLifeCycleCallback
     void onStart()   override;

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
@@ -105,6 +105,11 @@ void MainMenuLayout::setTitle(TypedTextId msgId)
     title.set(msgId);
 }
 
+void MainMenuLayout::setTitle(const char* text)
+{
+    title.set(text);
+}
+
 void MainMenuLayout::showTitle(bool state)
 {
     title.setVisible(state);

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
@@ -15,7 +15,11 @@ void MainView::setupScreen()
 
     setupItems();
     menuLayout.setAnimationSteps(App::Config::kMenuAnimationSteps);
-    menuLayout.setTitle(T_TEXT_APP_NAME_UC);
+    if (const char* variant = application().getModel().variantTitle()) {
+        menuLayout.setTitle(variant);
+    } else {
+        menuLayout.setTitle(T_TEXT_APP_NAME_UC);
+    }
     menuLayout.setInfoMsg(TYPED_TEXT_INVALID);   // GPS status now shown by the icon row
     menuLayout.setUpdateItemCallback(mUpdateItemCb);
     menuLayout.setUpdateCenterItemCallback(mUpdateCenterItemCb);

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -5,6 +5,8 @@
 #include "SDK/Kernel/KernelProviderGUI.hpp"
 #include "SDK/Port/TouchGFX/TouchGFXCommandProcessor.hpp"
 
+#include <cctype>
+
 #define LOG_MODULE_PRX      "Model"
 #define LOG_MODULE_LEVEL    LOG_LEVEL_INFO
 #include "SDK/UnaLogger/Logger.h"
@@ -13,10 +15,25 @@ Model::Model()
     : modelListener(nullptr)
     , mKernel(SDK::KernelProviderGUI::GetInstance().getKernel())
     , mSrvSender(mKernel)
+    , mVariant(mKernel)
 {
     SDK::TouchGFXCommandProcessor::GetInstance().setAppLifeCycleCallback(this);
     SDK::TouchGFXCommandProcessor::GetInstance().setCustomMessageHandler(this);
     memcpy(mHrThresholds, CustomMessage::kHrThresholdsDefault, sizeof(mHrThresholds));
+
+    // Screen titles show the variant's name in upper case; the compiled
+    // typed text keeps serving the classic binary.
+    if (mVariant.isVariant()) {
+        const char* name = mVariant.name(nullptr);
+        if (name != nullptr) {
+            size_t i = 0;
+            for (; name[i] != '\0' && i < sizeof(mVariantTitle) - 1; i++) {
+                mVariantTitle[i] = static_cast<char>(toupper(
+                        static_cast<unsigned char>(name[i])));
+            }
+            mVariantTitle[i] = '\0';
+        }
+    }
 
 #if defined(SIMULATOR)
     std::string fsPath = SDK::Simulator::KernelHolder::Get().getFsPath();
@@ -36,6 +53,11 @@ FrontendApplication& Model::application()
 App::MenuNav::Nav& Model::menu()
 {
     return mMenu;
+}
+
+const char* Model::variantTitle() const
+{
+    return (mVariantTitle[0] != '\0') ? mVariantTitle : nullptr;
 }
 
 void Model::invalidate()

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/trackdiscarded_screen/TrackDiscardedView.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/trackdiscarded_screen/TrackDiscardedView.cpp
@@ -11,7 +11,11 @@ void TrackDiscardedView::setupScreen()
 {
     TrackDiscardedViewBase::setupScreen();
 
-    title.set(T_TEXT_APP_NAME_UC);
+    if (const char* variant = application().getModel().variantTitle()) {
+        title.set(variant);
+    } else {
+        title.set(T_TEXT_APP_NAME_UC);
+    }
 
     mDismissTimer.setDuration(kDismissTicks);
     mDismissTimer.setCallback(mDismissCb);

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/tracksaved_screen/TrackSavedView.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/tracksaved_screen/TrackSavedView.cpp
@@ -11,7 +11,11 @@ void TrackSavedView::setupScreen()
 {
     TrackSavedViewBase::setupScreen();
 
-    title.set(T_TEXT_APP_NAME_UC);
+    if (const char* variant = application().getModel().variantTitle()) {
+        title.set(variant);
+    } else {
+        title.set(T_TEXT_APP_NAME_UC);
+    }
 
     mDismissTimer.setDuration(kDismissTicks);
     mDismissTimer.setCallback(mDismissCb);

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/trackstartconfirmation_screen/TrackStartConfirmationView.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/trackstartconfirmation_screen/TrackStartConfirmationView.cpp
@@ -9,7 +9,11 @@ void TrackStartConfirmationView::setupScreen()
 {
     TrackStartConfirmationViewBase::setupScreen();
 
-    title.set(T_TEXT_APP_NAME_UC);
+    if (const char* variant = application().getModel().variantTitle()) {
+        title.set(variant);
+    } else {
+        title.set(T_TEXT_APP_NAME_UC);
+    }
 
     buttons.setL1(Buttons::NONE);
     buttons.setL2(Buttons::NONE);

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/gcc/Makefile
@@ -40,6 +40,7 @@ Libs/Source/Wrappers/StdLibWrappers.c\
 ThirdParty/coreJSON/source/core_json.c\
 Libs/Source/JSON/JsonStreamReader.cpp\
 Libs/Source/JSON/JsonStreamWriter.cpp\
+Libs/Source/Variant/VariantConfig.cpp\
 Libs/Source/TrackMap/TrackMapBuilder.cpp\
 Libs/Source/Kernel/KernelBuilder.cpp\
 Libs/Source/Port/TouchGFX/TouchGFXCommandProcessor.cpp\

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -29,6 +29,7 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Wrappers\StdLibWrappers.c"/>
     <ClCompile Include="$(SdkPath)\ThirdParty\coreJSON\source\core_json.c"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\JSON\JsonStreamReader.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Variant\VariantConfig.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\JSON\JsonStreamWriter.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\TrackMap\TrackMapBuilder.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Kernel\KernelBuilder.cpp"/>

--- a/Examples/Apps/Hiking/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/ActivityWriter.hpp
@@ -100,7 +100,12 @@ public:
         uint32_t    floors    = 0;      // count
     };
 
-    ActivityWriter(const SDK::Kernel& kernel, const char* pathToDir);
+    /// sport/subSport parameterize the FIT session identity so a variant
+    /// (e.g. Walking) can reuse this binary; the defaults keep the classic
+    /// Hiking behaviour when no variant config is present.
+    ActivityWriter(const SDK::Kernel& kernel, const char* pathToDir,
+                   SDK::Fit::Sport sport = SDK::Fit::Sport::Hiking,
+                   SDK::Fit::SubSport subSport = SDK::Fit::SubSport::Generic);
 
     void start(const AppInfo& info);
     void pause(std::time_t timestamp);
@@ -157,6 +162,10 @@ private:
 
     const SDK::Kernel& mKernel;
     const char*        mPath = nullptr;
+
+    /// FIT session identity (variant configuration point).
+    SDK::Fit::Sport    mSport    = SDK::Fit::Sport::Hiking;
+    SDK::Fit::SubSport mSubSport = SDK::Fit::SubSport::Generic;
 
     std::unique_ptr<SDK::Interface::IFile> mFile = nullptr;
     std::unique_ptr<SDK::Fit::FitWriter>   mFit  = nullptr;

--- a/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
@@ -3,6 +3,7 @@
 #define SERVICE_HPP
 
 #include "SDK/Kernel/Kernel.hpp"
+#include "SDK/Variant/VariantConfig.hpp"
 #include "SDK/SensorLayer/SensorConnection.hpp"
 #include "SDK/SensorLayer/SensorDataBatch.hpp"
 #include "SDK/TrackMap/TrackMapBuilder.hpp"
@@ -45,6 +46,9 @@ private:
 
     // -- Settings & persistence -----------------------------------------------
 
+    // Declared before mActivityWriter: the variant config supplies the FIT
+    // identity the writer is constructed with.
+    SDK::Variant::Config      mVariant;
     Settings                  mSettings;
     bool                      mIsImperial = false;
     bool                      mTimeFormat12h = false;

--- a/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
@@ -32,6 +32,20 @@ namespace {
     };
 }  // namespace
 
+/// The .json sidecar's activity_type string for a FIT sport (variants report
+/// their own identity, e.g. Walking on the Hiking binary).
+static const char* sportName(fit::Sport sport)
+{
+    switch (sport) {
+    case fit::Sport::Running:  return "running";
+    case fit::Sport::Cycling:  return "cycling";
+    case fit::Sport::Training: return "training";
+    case fit::Sport::Walking:  return "walking";
+    case fit::Sport::Hiking:   return "hiking";
+    default:                   return "generic";
+    }
+}
+
 ActivityWriter::ActivityWriter(const SDK::Kernel& kernel, const char* pathToDir,
                                SDK::Fit::Sport sport, SDK::Fit::SubSport subSport)
     : mKernel(kernel), mPath(pathToDir), mSport(sport), mSubSport(subSport),
@@ -450,7 +464,7 @@ bool ActivityWriter::saveSummary(const TrackData& track)
     writer.add("distance", track.distance);
     writer.add("hr_avg", track.hrAvg);
     writer.add("elevation", track.ascent - track.descent);
-    writer.add("activity_type", "hiking");
+    writer.add("activity_type", sportName(mSport));
     writer.endMap();
 
     const bool ok = mFile->flush();

--- a/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
@@ -32,8 +32,10 @@ namespace {
     };
 }  // namespace
 
-ActivityWriter::ActivityWriter(const SDK::Kernel& kernel, const char* pathToDir)
-    : mKernel(kernel), mPath(pathToDir), mMarker(kernel.fs, pathToDir)
+ActivityWriter::ActivityWriter(const SDK::Kernel& kernel, const char* pathToDir,
+                               SDK::Fit::Sport sport, SDK::Fit::SubSport subSport)
+    : mKernel(kernel), mPath(pathToDir), mSport(sport), mSubSport(subSport),
+      mMarker(kernel.fs, pathToDir)
 {
     assert(pathToDir != nullptr);
 }
@@ -306,8 +308,8 @@ bool ActivityWriter::stop(const TrackData& track)
         .u16(static_cast<uint16_t>(track.ascent))
         .u16(static_cast<uint16_t>(track.descent))
         .u16(mLapCounter)
-        .u8(static_cast<uint8_t>(fit::Sport::Hiking))
-        .u8(static_cast<uint8_t>(fit::SubSport::Generic))
+        .u8(static_cast<uint8_t>(mSport))
+        .u8(static_cast<uint8_t>(mSubSport))
         .u8(static_cast<uint8_t>(track.hrAvg))
         .u8(static_cast<uint8_t>(track.hrMax))
         // developer fields: steps, floors

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -54,11 +54,16 @@ Service::Service(SDK::Kernel &kernel)
         : mKernel(kernel)
         , mGuiStarted(false)
         , mGuiSender(kernel)
+        , mVariant(kernel)
         , mSettings{}
         , mSettingsSerializer(mKernel, "settings.json")
         , mSummary{}
         , mActivitySummarySerializer(mKernel, "Activity/summary.json")
-        , mActivityWriter(mKernel, "Activity")
+        , mActivityWriter(mKernel, "Activity",
+                static_cast<SDK::Fit::Sport>(mVariant.fitSport(
+                        static_cast<uint8_t>(SDK::Fit::Sport::Hiking))),
+                static_cast<SDK::Fit::SubSport>(mVariant.fitSubSport(
+                        static_cast<uint8_t>(SDK::Fit::SubSport::Generic))))
         , mTrackMapBuilder{}
         , mSensorGpsLocation(SDK::Sensor::Type::GPS_LOCATION, skSamplePeriod, skSampleLatency)
         , mSensorGpsSpeed(SDK::Sensor::Type::GPS_SPEED, skSamplePeriod, skSampleLatency)

--- a/Libs/Header/SDK/Fit/FitProfile.hpp
+++ b/Libs/Header/SDK/Fit/FitProfile.hpp
@@ -43,8 +43,10 @@ constexpr uint16_t mesgNum(MesgNum m) { return static_cast<uint16_t>(m); }
 // --- Enum value sets the apps set on enum fields ----------------------------
 
 enum class File : uint8_t { Activity = 4 };
-enum class Sport : uint8_t { Generic = 0, Running = 1, Cycling = 2, Hiking = 17 };
-enum class SubSport : uint8_t { Generic = 0, Treadmill = 1 };
+enum class Sport : uint8_t { Generic = 0, Running = 1, Cycling = 2, Training = 10,
+                             Walking = 11, Hiking = 17 };
+enum class SubSport : uint8_t { Generic = 0, Treadmill = 1, Street = 2, Trail = 3,
+                                Track = 4, IndoorCycling = 6 };
 enum class Event : uint8_t { Timer = 0 };
 enum class EventType : uint8_t { Start = 0, Stop = 1 };
 enum class ActivityType : uint8_t { Manual = 0, AutoMultiSport = 1 };

--- a/Libs/Header/SDK/Variant/VariantConfig.hpp
+++ b/Libs/Header/SDK/Variant/VariantConfig.hpp
@@ -1,0 +1,97 @@
+/**
+ ******************************************************************************
+ * @file    VariantConfig.hpp
+ * @brief   App-side reader for the embedded variant config.
+ * @details A variant is a code-less alias .uapp in the app's own sandbox
+ *          directory (see Docs/Multi-Activity-Apps-Design.md in the kernel
+ *          repo). At startup the app opens the single .uapp in its sandbox
+ *          root: a real binary means the app IS the base activity (all
+ *          defaults apply); an alias carries an embedded JSON config that
+ *          renames the activity and adjusts its FIT identity and
+ *          family-specific features. A bad or unreadable config must never
+ *          brick a launch, so every getter falls back to the caller's
+ *          default.
+ ******************************************************************************
+ *
+ ******************************************************************************
+ */
+
+#ifndef SDK_VARIANT_CONFIG_HPP
+#define SDK_VARIANT_CONFIG_HPP
+
+#include "SDK/Kernel/Kernel.hpp"
+#include "SDK/JSON/JsonStreamReader.hpp"
+
+#include <cstdint>
+#include <memory>
+
+namespace SDK::Variant {
+
+class Config {
+public:
+    /**
+     * @brief   Discover the variant identity from the app's sandbox root.
+     * @param   kernel: The app's kernel facade (service or GUI side).
+     */
+    explicit Config(const SDK::Kernel &kernel);
+
+    /// True when a valid alias with a parseable config was found.
+    bool isVariant() const { return mIsVariant; }
+
+    /**
+     * @brief   The variant's display name for in-app titles.
+     * @param   defaultName: Returned for the base activity (no alias).
+     */
+    const char *name(const char *defaultName) const
+    {
+        return (mIsVariant && mName[0] != '\0') ? mName : defaultName;
+    }
+
+    /// FIT sport, defaulting to the family binary's classic value.
+    uint8_t fitSport(uint8_t defaultSport) const
+    {
+        return mHasSport ? mSport : defaultSport;
+    }
+
+    /// FIT sub-sport, defaulting to the family binary's classic value.
+    uint8_t fitSubSport(uint8_t defaultSubSport) const
+    {
+        return mHasSubSport ? mSubSport : defaultSubSport;
+    }
+
+    /**
+     * @brief   Family-vocabulary lookups under the "features" subtree.
+     *
+     * The subtree is opaque to this shared parser: each family documents its
+     * own keys and unknown entries are inert. Missing key or no variant ==>
+     * the caller's default.
+     */
+    bool featureBool(const char *key, bool defaultValue) const;
+    uint32_t featureU32(const char *key, uint32_t defaultValue) const;
+
+private:
+    /// Config schema major this parser understands. An unknown major falls
+    /// back to defaults entirely (never a bricked launch).
+    static constexpr uint32_t skSchemaSupported = 1;
+
+    /// Max name length including the terminator (matches the launcher field).
+    static constexpr size_t skNameLen = 16;
+
+    bool mIsVariant = false;
+    char mName[skNameLen] {};
+    bool mHasSport = false;
+    bool mHasSubSport = false;
+    uint8_t mSport = 0;
+    uint8_t mSubSport = 0;
+
+    /// The embedded JSON, kept for feature queries (<= 8 KB by contract).
+    std::unique_ptr<char[]> mConfig;
+    size_t mConfigLen = 0;
+
+    bool queryFeature(const char *key, SDK::JsonStreamReader &reader,
+                      char *queryBuf, size_t queryBufSize) const;
+};
+
+} // namespace SDK::Variant
+
+#endif // SDK_VARIANT_CONFIG_HPP

--- a/Libs/Source/Variant/VariantConfig.cpp
+++ b/Libs/Source/Variant/VariantConfig.cpp
@@ -19,13 +19,14 @@ namespace {
 // On-disk .uapp layout facts this reader depends on (the authoritative
 // definition lives kernel-side in App/AppHeaders.hpp; the byte layout is
 // locked by the kernel's host tests and by make_variant.py).
-constexpr uint32_t kFlagVariantAlias = 0x40;
-constexpr size_t   kMainHeaderSize   = 48;
-constexpr size_t   kFlagsOffset      = 20;   // after uappID u64 + 3x u32
-constexpr size_t   kPayloadOffset    = kMainHeaderSize + 3600 + 900;
-constexpr size_t   kConfigOffset     = kPayloadOffset + 32;
-constexpr size_t   kConfigSizeOffset = kPayloadOffset + 17;  // u32, unaligned
-constexpr uint32_t kConfigSizeMax    = 8192;
+constexpr uint32_t kFlagVariantAlias  = 0x40;
+constexpr size_t   kMainHeaderSize    = 48;
+constexpr size_t   kFlagsOffset       = 20;   // after uappID u64 + 3x u32
+constexpr size_t   kPayloadOffset     = kMainHeaderSize + 3600 + 900;
+constexpr size_t   kConfigOffset      = kPayloadOffset + 32;
+constexpr size_t   kConfigSizeOffset  = kPayloadOffset + 17;  // u32, unaligned
+constexpr uint32_t kConfigSizeMax     = 8192;
+constexpr uint32_t kPayloadVersion    = 1;    // the layout this reader parses
 
 bool hasUappExtension(const char *name)
 {
@@ -34,12 +35,30 @@ bool hasUappExtension(const char *name)
     return len > strlen(kExt) && strcmp(&name[len - strlen(kExt)], kExt) == 0;
 }
 
+/// Read the app-flags word of a .uapp; false when unreadable.
+bool readFlags(const SDK::Kernel &kernel, const char *path, uint32_t &flags)
+{
+    std::unique_ptr<SDK::Interface::IFile> file = kernel.fs.file(path);
+    if (!file || !file->open()) {
+        return false;
+    }
+    size_t br = 0;
+    bool ok = file->seek(kFlagsOffset) &&
+            file->read(reinterpret_cast<char*>(&flags), sizeof(flags), br) &&
+            br == sizeof(flags);
+    file->close();
+    return ok;
+}
+
 } // namespace
 
 Config::Config(const SDK::Kernel &kernel)
 {
-    // The sandbox root holds exactly one .uapp: the app's own binary, or the
-    // alias this variant was launched through.
+    // Pick the same file the kernel's scan picked (mixed-dir determinism,
+    // design doc section 3.4): any real (non-alias) .uapp in the sandbox
+    // root means the app runs as its classic self; otherwise the first
+    // alias-flagged .uapp is this variant's identity. An unreadable
+    // candidate counts as a real app, mirroring the kernel's routing.
     char path[SDK::Interface::IFileSystem::skMaxPathLen] {};
     {
         std::unique_ptr<SDK::Interface::IDirectory> dir = kernel.fs.dir("/");
@@ -47,17 +66,33 @@ Config::Config(const SDK::Kernel &kernel)
             return;
         }
 
+        char candidate[SDK::Interface::IFileSystem::skMaxPathLen] {};
         SDK::Interface::IFileSystem::ObjectInfo item {};
+        bool realAppSeen = false;
         while (dir->readNext(item)) {
-            if (!item.isDir && hasUappExtension(item.name)) {
-                snprintf(path, sizeof(path), "/%s", item.name);
+            if (item.isDir || !hasUappExtension(item.name)) {
+                continue;
+            }
+            snprintf(candidate, sizeof(candidate), "/%s", item.name);
+            uint32_t flags = 0;
+            if (!readFlags(kernel, candidate, flags) ||
+                    (flags & kFlagVariantAlias) == 0) {
+                realAppSeen = true;
                 break;
+            }
+            if (path[0] == '\0') {
+                snprintf(path, sizeof(path), "%s", candidate);
             }
         }
         dir->close();
+
+        if (realAppSeen) {
+            path[0] = '\0';
+        }
     }
 
     if (path[0] == '\0') {
+        // The app is its classic self.
         return;
     }
 
@@ -67,23 +102,26 @@ Config::Config(const SDK::Kernel &kernel)
     }
 
     bool ok = false;
-    uint32_t flags = 0;
+    uint32_t payloadVersion = 0;
     uint32_t configSize = 0;
 
     do {
         size_t br = 0;
-        if (!file->seek(kFlagsOffset) ||
-                !file->read(reinterpret_cast<char*>(&flags), sizeof(flags), br)) {
-            break;
-        }
 
-        if ((flags & kFlagVariantAlias) == 0) {
-            // A real binary: the app is its classic self.
+        // Only the payload layout this reader was built for: a future kernel
+        // may accept newer payloads, but a shipped binary must never guess
+        // at rearranged fields -- unknown version ==> classic defaults.
+        if (!file->seek(kPayloadOffset) ||
+                !file->read(reinterpret_cast<char*>(&payloadVersion),
+                        sizeof(payloadVersion), br) ||
+                br != sizeof(payloadVersion) ||
+                payloadVersion != kPayloadVersion) {
             break;
         }
 
         if (!file->seek(kConfigSizeOffset) ||
-                !file->read(reinterpret_cast<char*>(&configSize), sizeof(configSize), br)) {
+                !file->read(reinterpret_cast<char*>(&configSize), sizeof(configSize), br) ||
+                br != sizeof(configSize)) {
             break;
         }
 

--- a/Libs/Source/Variant/VariantConfig.cpp
+++ b/Libs/Source/Variant/VariantConfig.cpp
@@ -1,0 +1,181 @@
+/**
+ ******************************************************************************
+ * @file    VariantConfig.cpp
+ * @brief   App-side reader for the embedded variant config.
+ ******************************************************************************
+ *
+ ******************************************************************************
+ */
+
+#include "SDK/Variant/VariantConfig.hpp"
+
+#include <cstdio>
+#include <cstring>
+
+namespace SDK::Variant {
+
+namespace {
+
+// On-disk .uapp layout facts this reader depends on (the authoritative
+// definition lives kernel-side in App/AppHeaders.hpp; the byte layout is
+// locked by the kernel's host tests and by make_variant.py).
+constexpr uint32_t kFlagVariantAlias = 0x40;
+constexpr size_t   kMainHeaderSize   = 48;
+constexpr size_t   kFlagsOffset      = 20;   // after uappID u64 + 3x u32
+constexpr size_t   kPayloadOffset    = kMainHeaderSize + 3600 + 900;
+constexpr size_t   kConfigOffset     = kPayloadOffset + 32;
+constexpr size_t   kConfigSizeOffset = kPayloadOffset + 17;  // u32, unaligned
+constexpr uint32_t kConfigSizeMax    = 8192;
+
+bool hasUappExtension(const char *name)
+{
+    constexpr char kExt[] = ".uapp";
+    size_t len = strlen(name);
+    return len > strlen(kExt) && strcmp(&name[len - strlen(kExt)], kExt) == 0;
+}
+
+} // namespace
+
+Config::Config(const SDK::Kernel &kernel)
+{
+    // The sandbox root holds exactly one .uapp: the app's own binary, or the
+    // alias this variant was launched through.
+    char path[SDK::Interface::IFileSystem::skMaxPathLen] {};
+    {
+        std::unique_ptr<SDK::Interface::IDirectory> dir = kernel.fs.dir("/");
+        if (!dir || !dir->open()) {
+            return;
+        }
+
+        SDK::Interface::IFileSystem::ObjectInfo item {};
+        while (dir->readNext(item)) {
+            if (!item.isDir && hasUappExtension(item.name)) {
+                snprintf(path, sizeof(path), "/%s", item.name);
+                break;
+            }
+        }
+        dir->close();
+    }
+
+    if (path[0] == '\0') {
+        return;
+    }
+
+    std::unique_ptr<SDK::Interface::IFile> file = kernel.fs.file(path);
+    if (!file || !file->open()) {
+        return;
+    }
+
+    bool ok = false;
+    uint32_t flags = 0;
+    uint32_t configSize = 0;
+
+    do {
+        size_t br = 0;
+        if (!file->seek(kFlagsOffset) ||
+                !file->read(reinterpret_cast<char*>(&flags), sizeof(flags), br)) {
+            break;
+        }
+
+        if ((flags & kFlagVariantAlias) == 0) {
+            // A real binary: the app is its classic self.
+            break;
+        }
+
+        if (!file->seek(kConfigSizeOffset) ||
+                !file->read(reinterpret_cast<char*>(&configSize), sizeof(configSize), br)) {
+            break;
+        }
+
+        if (configSize == 0 || configSize > kConfigSizeMax) {
+            break;
+        }
+
+        mConfig = std::unique_ptr<char[]>(new (std::nothrow) char[configSize]);
+        if (!mConfig) {
+            break;
+        }
+
+        if (!file->seek(kConfigOffset) ||
+                !file->read(mConfig.get(), configSize, br) || br != configSize) {
+            mConfig.reset();
+            break;
+        }
+
+        ok = true;
+    } while (false);
+
+    file->close();
+
+    if (!ok) {
+        return;
+    }
+
+    SDK::JsonStreamReader reader(mConfig.get(), configSize);
+    if (!reader.validate()) {
+        mConfig.reset();
+        return;
+    }
+
+    uint32_t schema = 0;
+    if (!reader.get("schema", schema) || schema != skSchemaSupported) {
+        // Unknown major: run as the classic self rather than misread keys.
+        mConfig.reset();
+        return;
+    }
+
+    mConfigLen = configSize;
+    mIsVariant = true;
+
+    const char *name = nullptr;
+    size_t nameLen = 0;
+    if (reader.get("name", name, nameLen)) {
+        snprintf(mName, sizeof(mName), "%.*s", static_cast<int>(nameLen), name);
+    }
+
+    mHasSport = reader.get("fit.sport", mSport);
+    mHasSubSport = reader.get("fit.subSport", mSubSport);
+
+}
+
+bool Config::featureBool(const char *key, bool defaultValue) const
+{
+    if (!mIsVariant || !mConfig) {
+        return defaultValue;
+    }
+
+    SDK::JsonStreamReader reader(mConfig.get(), mConfigLen);
+    char query[64];
+    bool value = defaultValue;
+    if (!queryFeature(key, reader, query, sizeof(query)) ||
+            !reader.get(query, value)) {
+        return defaultValue;
+    }
+    return value;
+}
+
+uint32_t Config::featureU32(const char *key, uint32_t defaultValue) const
+{
+    if (!mIsVariant || !mConfig) {
+        return defaultValue;
+    }
+
+    SDK::JsonStreamReader reader(mConfig.get(), mConfigLen);
+    char query[64];
+    uint32_t value = defaultValue;
+    if (!queryFeature(key, reader, query, sizeof(query)) ||
+            !reader.get(query, value)) {
+        return defaultValue;
+    }
+    return value;
+}
+
+bool Config::queryFeature(const char *key, SDK::JsonStreamReader &reader,
+                          char *queryBuf, size_t queryBufSize) const
+{
+    (void)reader;
+    int written = snprintf(queryBuf, queryBufSize, "features.%s", key);
+    return written > 0 && static_cast<size_t>(written) < queryBufSize;
+}
+
+} // namespace SDK::Variant

--- a/Utilities/Scripts/app_merging/make_variant.py
+++ b/Utilities/Scripts/app_merging/make_variant.py
@@ -1,0 +1,181 @@
+"""Build a code-less variant-alias .uapp (see Docs/Multi-Activity-Apps-Design.md).
+
+An alias reuses the real app's MainHeader layout, discriminated by flag bit
+0x40 (FLAG_APP_VARIANT_ALIAS), carries no code (serviceSize = 0, libcVersion
+= 0), and embeds the app-facing variant config after a fixed-size payload:
+
+    [MainHeader 48][normal icon 3600][small icon 900]
+    [VariantAliasPayload 32][config JSON, configSize bytes][CRC32 4]
+
+The emitted file is the byte-level contract shared with the kernel validator
+(Validator::aliasIsValid) and the phone; the layout is locked by host tests
+in the kernel repo (Tests/Host/kernel/VariantAlias_test.cpp).
+"""
+
+import argparse
+import json
+import logging
+import re
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+APP_TYPES = {
+    "Activity"  : 0,
+    "Utility"   : 1,
+    "Glance"    : 2,
+    "Clockface" : 3
+}
+
+FLAG_APP_VARIANT_ALIAS = 0x40
+
+MAIN_HEADER_SIZE  = 48
+NORMAL_ICON_SIZE  = 60 * 60   # ABGR2222: 1 byte per pixel
+SMALL_ICON_SIZE   = 30 * 30
+PAYLOAD_VERSION   = 1
+CONFIG_SIZE_MAX   = 8192
+
+ORIGINS = {"shipped": 0, "user": 1}
+
+
+def parse_appid_64(s: str) -> int:
+    s = s.strip()
+    if len(s) != 16 or not re.fullmatch(r"[0-9a-fA-F]{16}", s):
+        raise argparse.ArgumentTypeError("AppID must be exactly 16 hex characters (e.g., 0123ABCD89EF4560).")
+    return int(s, 16)
+
+
+def parse_semver_u32(s: str) -> tuple[int, str]:
+    s = s.strip().lstrip('vV')
+    m = re.match(r"(\d+)\.(\d+)\.(\d+)", s)
+    if not m:
+        raise argparse.ArgumentTypeError("Version must start with A.B.C format (e.g., 1.2.3).")
+    a, b, c = (int(m.group(i)) for i in (1, 2, 3))
+    for v, name in [(a, "A"), (b, "B"), (c, "C")]:
+        if not (0 <= v <= 255):
+            raise argparse.ArgumentTypeError(f"Version component {name} must be 0..255.")
+    return (a << 16) | (b << 8) | c, s
+
+
+def make_file_safe_name(name: str, fallback: str = "variant") -> str:
+    safe = re.sub(r'_+', '_', re.sub(r'[^\w.-]', '_', re.sub(r'\s+', '_', name.strip()), flags=re.UNICODE)).strip(' ._')
+    return safe or fallback
+
+
+def convert_icon_to_abgr2222(png_path: Path) -> bytes:
+    """Convert RGBA PNG to ABGR2222 (same packing as app_merging.py)."""
+    from PIL import Image
+    img = Image.open(png_path).convert("RGBA")
+    if img.width != img.height:
+        raise ValueError("Image must be square")
+    bmp_data = bytearray()
+    for y in range(img.height):
+        for x in range(img.width):
+            r, g, b, a = img.getpixel((x, y))
+            bmp_data.append((((a >> 6) & 3) << 6) | (((b >> 6) & 3) << 4) | (((g >> 6) & 3) << 2) | ((r >> 6) & 3))
+    return bytes(bmp_data)
+
+
+def icons_from_uapp(uapp_path: Path) -> tuple[bytes, bytes]:
+    """Extract both icons from an existing .uapp (real app or alias) at the
+    fixed post-MainHeader offsets -- the same copy the kernel's CreateVariant
+    handler performs for user-created variants."""
+    data = uapp_path.read_bytes()
+    need = MAIN_HEADER_SIZE + NORMAL_ICON_SIZE + SMALL_ICON_SIZE
+    if len(data) < need:
+        raise ValueError(f"{uapp_path} is too short to contain the standard icons")
+    normal = data[MAIN_HEADER_SIZE:MAIN_HEADER_SIZE + NORMAL_ICON_SIZE]
+    small = data[MAIN_HEADER_SIZE + NORMAL_ICON_SIZE:need]
+    return normal, small
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    parser = argparse.ArgumentParser(description="Build a code-less variant-alias .uapp")
+    parser.add_argument("-name", required=True, help="Variant launcher name (max 15 chars, ASCII)")
+    parser.add_argument("-appid", type=parse_appid_64, required=True,
+                        help="The variant's OWN unique 16-hex AppID (not the target's)")
+    parser.add_argument("-target_appid", type=parse_appid_64, required=True,
+                        help="16-hex AppID of the base app this variant runs")
+    parser.add_argument("-config", type=Path, required=True,
+                        help="Path to the variant config JSON to embed")
+    parser.add_argument("-type", required=True, choices=list(APP_TYPES.keys()),
+                        help="Application type (must match the target's)")
+    parser.add_argument("-appver", type=parse_semver_u32, default=(0x00010000, "1.0.0"),
+                        help="Alias content revision A.B.C (default 1.0.0)")
+    parser.add_argument("-min_target_version", type=parse_semver_u32, default=(0, "0.0.0"),
+                        help="Minimum target app version A.B.C (default: any)")
+    parser.add_argument("-origin", choices=list(ORIGINS.keys()), default="shipped",
+                        help="Who owns this variant dir on update (default: shipped)")
+    parser.add_argument("-normal_icon", type=Path, default=None, help="Path to normal 60x60 icon PNG")
+    parser.add_argument("-small_icon", type=Path, default=None, help="Path to small 30x30 icon PNG")
+    parser.add_argument("-icons_from", type=Path, default=None,
+                        help="Copy both icons out of an existing .uapp instead of PNGs")
+    parser.add_argument("-out", type=Path, default=Path("Output"), help="Output directory")
+    args = parser.parse_args()
+
+    name_utf8 = args.name.encode("utf-8")
+    if len(name_utf8) > 15:
+        parser.error("-name must fit 15 bytes (NUL-terminated 16-byte field)")
+
+    if args.icons_from is not None:
+        if args.normal_icon or args.small_icon:
+            parser.error("-icons_from and -normal_icon/-small_icon are mutually exclusive")
+        normal_icon, small_icon = icons_from_uapp(args.icons_from)
+    else:
+        if args.normal_icon is None or args.small_icon is None:
+            parser.error("provide -normal_icon and -small_icon, or -icons_from")
+        normal_icon = convert_icon_to_abgr2222(args.normal_icon)
+        small_icon = convert_icon_to_abgr2222(args.small_icon)
+
+    if len(normal_icon) != NORMAL_ICON_SIZE or len(small_icon) != SMALL_ICON_SIZE:
+        raise ValueError("Icon payloads must be exactly 3600 / 900 bytes")
+
+    config_bytes = args.config.read_bytes()
+    json.loads(config_bytes)  # authoring-side syntax check; the kernel never parses it
+    if len(config_bytes) > CONFIG_SIZE_MAX:
+        raise ValueError(f"Config exceeds the kernel's {CONFIG_SIZE_MAX}-byte bound")
+
+    app_version_u32, app_version = args.appver
+    min_target_u32, min_target = args.min_target_version
+    flags = APP_TYPES[args.type] | FLAG_APP_VARIANT_ALIAS
+
+    # MainHeader: [AppID u64][AppVersion u32][LibCVersion u32 = 0]
+    #             [service_size u32 = 0][flags u32][AppName char[16]]
+    #             [normal_icon_size u32][small_icon_size u32]
+    header = struct.pack("<QIIII16sII",
+                         args.appid, app_version_u32, 0,
+                         0, flags, name_utf8.ljust(16, b"\0"),
+                         NORMAL_ICON_SIZE, SMALL_ICON_SIZE)
+
+    # VariantAliasPayload: [payloadVersion u32][targetAppID u64]
+    #                      [minTargetVersion u32][origin u8]
+    #                      [configSize u32][reserved u8[11]]
+    payload = struct.pack("<IQIBI11s",
+                          PAYLOAD_VERSION, args.target_appid,
+                          min_target_u32, ORIGINS[args.origin],
+                          len(config_bytes), b"\0" * 11)
+
+    blob = header + normal_icon + small_icon + payload + config_bytes
+    final = blob + struct.pack("<I", zlib.crc32(blob) & 0xFFFFFFFF)
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    output_path = args.out / f"{make_file_safe_name(args.name)}_{app_version}.uapp"
+    output_path.write_bytes(final)
+
+    logging.info(f"Name            : {args.name}")
+    logging.info(f"ID              : {args.appid:016X}")
+    logging.info(f"Target ID       : {args.target_appid:016X}")
+    logging.info(f"Alias revision  : {app_version}")
+    logging.info(f"Min target ver  : {min_target}")
+    logging.info(f"Origin          : {args.origin}")
+    logging.info(f"Flags           : 0x{flags:08X}")
+    logging.info(f"Config          : {args.config} ({len(config_bytes)} bytes)")
+    logging.info(f"Alias           : {output_path} ({len(final)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Utilities/Scripts/app_merging/make_variant.py
+++ b/Utilities/Scripts/app_merging/make_variant.py
@@ -121,6 +121,9 @@ def main() -> int:
         parser.error("-name must fit 15 bytes (NUL-terminated 16-byte field)")
     if not args.name.isascii():
         parser.error("-name must be ASCII (the wildcard fonts cover ASCII only)")
+    if args.appid == args.target_appid:
+        parser.error("-appid must differ from -target_appid (an alias cannot claim "
+                     "the target's own identity; the kernel rejects the collision at scan)")
 
     if args.icons_from is not None:
         if args.normal_icon or args.small_icon:
@@ -136,7 +139,11 @@ def main() -> int:
         raise ValueError("Icon payloads must be exactly 3600 / 900 bytes")
 
     config_bytes = args.config.read_bytes()
-    json.loads(config_bytes)  # authoring-side syntax check; the kernel never parses it
+    config_json = json.loads(config_bytes)  # authoring-side syntax check; the kernel never parses it
+    if config_json.get("schema") != 1:
+        parser.error('config JSON must carry "schema": 1 -- the app-side reader '
+                     "falls back to classic defaults on anything else, so the "
+                     "variant would build but never activate")
     if len(config_bytes) > CONFIG_SIZE_MAX:
         raise ValueError(f"Config exceeds the kernel's {CONFIG_SIZE_MAX}-byte bound")
 

--- a/Utilities/Scripts/app_merging/make_variant.py
+++ b/Utilities/Scripts/app_merging/make_variant.py
@@ -119,6 +119,8 @@ def main() -> int:
     name_utf8 = args.name.encode("utf-8")
     if len(name_utf8) > 15:
         parser.error("-name must fit 15 bytes (NUL-terminated 16-byte field)")
+    if not args.name.isascii():
+        parser.error("-name must be ASCII (the wildcard fonts cover ASCII only)")
 
     if args.icons_from is not None:
         if args.normal_icon or args.small_icon:

--- a/cmake/una-sdk.cmake
+++ b/cmake/una-sdk.cmake
@@ -36,6 +36,12 @@ set(UNA_SDK_SOURCES_TRACKMAP
     "$ENV{UNA_SDK}/Libs/Source/TrackMap/TrackMapBuilder.cpp"
 )
 
+# Variant-alias config reader (SDK::Variant). Needs UNA_SDK_SOURCES_JSON in
+# the same link (the GUI process must add both to read the config directly).
+set(UNA_SDK_SOURCES_VARIANT
+    "$ENV{UNA_SDK}/Libs/Source/Variant/VariantConfig.cpp"
+)
+
 set(UNA_SDK_SOURCES_CALIBRATION
     "$ENV{UNA_SDK}/Libs/Source/Calibration/OutdoorStrideCalibrator.cpp"
     "$ENV{UNA_SDK}/Libs/Source/Calibration/StrideLut.cpp"
@@ -51,6 +57,7 @@ set(UNA_SDK_SOURCES_SERVICE
     "${UNA_SDK_SOURCES_SENSOR}"
     "${UNA_SDK_SOURCES_TRACKMAP}"
     "${UNA_SDK_SOURCES_CALIBRATION}"
+    "${UNA_SDK_SOURCES_VARIANT}"
 )
 
 set(UNA_SDK_SOURCES_GUI


### PR DESCRIPTION
Implements **M2** of the multi-activity variants design (una-kernel `Docs/Multi-Activity-Apps-Design.md`, merged in kernel PR #245): the app-side half of "one binary, many launcher activities", with **Walking on the Hiking binary** as the first shipped variant.

Pairs with the kernel M1 PR (alias scanning/resolution); a variant needs both, but this is independently safe: without an alias present every binary behaves byte-for-byte as its classic self, and old kernels reject alias files at scan.

## What's here

- **`make_variant.py`** (app_merging): packs a code-less variant-alias `.uapp` — `MainHeader` with flag `0x40`, icons (PNG or copied out of an existing `.uapp` via `-icons_from`), `VariantAliasPayload`, embedded JSON config, trailing CRC32. ASCII names only (wildcard fonts).
- **`SDK::Variant::Config`**: app-side reader. Finds the `.uapp` in the sandbox root using the kernel's exact mixed-dir rule (any real binary wins over an alias), gates on `payloadVersion == 1`, parses `schema`/`name`/`fit.*` plus an opaque per-family `features` subtree. Any bad/unknown config ⇒ classic defaults — a config can never brick a launch. Constructor does no logging (the sim logger isn't up yet at construction; this access-violated the simulator during bring-up).
- **FitProfile**: real FIT interop values — `Sport::Walking=11`, `Training=10`; `SubSport` Street/Trail/Track/IndoorCycling.
- **Hiking parameterized (the pattern for the other four apps)**: `ActivityWriter` takes sport/sub-sport (defaults = classic Hiking), `Service` wires them from the variant config, the `.json` sidecar's `activity_type` follows the sport, and the menu/track-saved/discarded/start-confirmation titles render the uppercased variant name through the existing wildcard text areas — no font regen.
- Build wiring: `UNA_SDK_SOURCES_VARIANT` group; the Hiking GUI links the reader + JSON; simulator manifests updated.

## Verification

- **Simulator A/B**: alias in the sandbox ⇒ WALKING titles + `session.sport=11/subSport=0`; no alias ⇒ HIKING + `sport=17`.
- **ARM**: `.uapp` builds clean (cmake + Ninja).
- **On watch, on wrist**: two Walking recordings on real hardware — FIT decodes `sport=walking`, own `Activity/` history in the variant's sandbox, sidecar `activity_type:"walking"`.
- Subagent code review run over the kernel+SDK changeset as a whole; all findings addressed (kernel-mirrored file pick, `payloadVersion` gate, short-read checks, ASCII-name enforcement here; the rest kernel-side).

The alias byte layout is locked by golden-bytes host tests in the kernel repo (including a CRC32 literal proving the kernel CRC matches this packer's zlib CRC).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for variant-specific app configuration, including feature lookups with safe fallback values.
  * UI screen and main menu titles now adapt to the active variant when provided.
  * Activity metadata now supports variant-configured sport and sub-sport, with expanded FIT sport/sub-sport options (e.g., training, walking, trail, track, indoor cycling).
  * Added tooling to generate variant-alias app packages (including icon handling and embedded config).
* **Build / Simulator Updates**
  * Updated build inputs so the variant configuration reader is included in GUI and simulator builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->