### PR TITLE
fix(simulator): move HALSDL2 include from Mock/System.hpp to System.cpp

### DIFF
--- a/Libs/Header/SDK/Simulator/Kernel/Mock/AppMemory.hpp
+++ b/Libs/Header/SDK/Simulator/Kernel/Mock/AppMemory.hpp
@@ -13,6 +13,7 @@
 
 #include "SDK/Interfaces/IAppMemory.hpp"
 #include <cstdio>
+#include <cstdlib>
 #include <memory>
 
 namespace SDK::Simulator::Mock

--- a/Libs/Header/SDK/Simulator/Kernel/Mock/System.hpp
+++ b/Libs/Header/SDK/Simulator/Kernel/Mock/System.hpp
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "SDK/Interfaces/ISystem.hpp"
-#include <platform/hal/simulator/sdl2/HALSDL2.hpp>
 #include "SDK/Simulator/OS/OS.hpp"
 #include <chrono>
 

--- a/Libs/Source/Simulator/Components/Sensors/SensorBatteryLevel.cpp
+++ b/Libs/Source/Simulator/Components/Sensors/SensorBatteryLevel.cpp
@@ -16,6 +16,7 @@
 
 #include "SDK/Simulator/Components/Sensors/SensorBatteryLevel.hpp"
 #include "SDK/SensorLayer/DataParsers/SensorDataParserBatteryLevel.hpp"
+#include <cmath>
 #include <SDK/Simulator/Kernel/Mock/System.hpp>
 #include "SDK/Simulator/OS/OS.hpp"
 #include "SDK/Simulator/Components/ComponentSimulator.hpp"
@@ -104,7 +105,7 @@ void BatteryLevel::sensorRefresh()
     float level = mBattLevel.getBattLevel();
 
     OS::MutexCS cs(mDataMutex);
-    if (mPrevLevel > 0 && abs(mPrevLevel - level) < 0.1) {
+    if (mPrevLevel > 0 && std::fabs(mPrevLevel - level) < 0.1) {
         LOG_DEBUG("EXIT\n");
         return;
     }

--- a/Libs/Source/Simulator/Kernel/Mock/System.cpp
+++ b/Libs/Source/Simulator/Kernel/Mock/System.cpp
@@ -1,5 +1,6 @@
 
 #include "SDK/Simulator/Kernel/Mock/System.hpp"
+#include <platform/hal/simulator/sdl2/HALSDL2.hpp>
 #include <cstdint>
 
 // GetTickCount64() and Sleep() are Windows-only. Provide portable replacements.


### PR DESCRIPTION
`Mock/System.hpp` includes TouchGFX's `HALSDL2.hpp` but doesn't use anything from it. The only use is `SystemGUI::exit()` in `System.cpp`. The include forces every simulator component that pulls in the `Mock/System.hpp` (e.g., sensor manager, sensor sources, kernel dispatcher, etc) to depend on TouchGFX and the SDL2, so none of them can build headless.

Move the include to the TU that needs it and give the two files that were silently relying on the transitive dependency their own: `<cstlib>` for `AppMemory.hpp` and `<cmath>` + `std::fabs` for `SensorBatteryLevel.cpp`. As noted in the review, `<cstdlib>` is deliberately _not_ the fix for the `SensorBatteryLevel.cpp` as it binds `::abs(int)`, truncating the float delta to 0 (making a mess of the publish interval as well)