### PR TITLE
ci: add MSVS/Makefile source-list sync check

### DIFF
--- a/.github/scripts/check_msvs_sources.py
+++ b/.github/scripts/check_msvs_sources.py
@@ -77,14 +77,17 @@ def parse_makefile_sources(makefile_path):
         entries.append(value.strip())
         i += 1
         for entry in entries:
-            entry = entry.strip()
-            # Heads up: if the last source line keeps its trailing "\", Make
-            # just glues the next line onto this value, doesn't care that it
-            # looks like a new variable. We've actually seen
-            # "ADDITIONAL_SOURCES :=" show up as a "source" because of this.
-            # Filtering to .cpp/.c files keeps that junk out.
-            if entry and re.search(r"\.(cpp|c)$", entry):
-                sources.append(strip_leading_dotdots(entry.replace("\\", "/")))
+            # Make separates sources on whitespace, so one line can hold several
+            # of them. Split before filtering or "a.cpp b.cpp" lands in the set
+            # as a single bogus path and every real file on it reads as drift.
+            for token in entry.split():
+                # Heads up: if the last source line keeps its trailing "\", Make
+                # just glues the next line onto this value, doesn't care that it
+                # looks like a new variable. We've actually seen
+                # "ADDITIONAL_SOURCES :=" show up as a "source" because of this.
+                # Filtering to .cpp/.c files keeps that junk out.
+                if re.search(r"\.(cpp|c)$", token):
+                    sources.append(strip_leading_dotdots(token.replace("\\", "/")))
     return set(sources)
 
 
@@ -168,6 +171,25 @@ def run_selftest():
             "trailing-backslash-quirk Makefile",
             parse_makefile_sources(makefile_quirk),
             {"Libs/Source/UnaLogger/Logger.cpp", "Libs/Source/Fit/FitCrc.cpp"},
+        )
+
+        # Make is happy to put several sources on one line, with or without a
+        # continuation; each has to come out as its own path.
+        makefile_multi = os.path.join(tmp, "Makefile.multi")
+        with open(makefile_multi, "w") as f:
+            f.write(
+                "ADDITIONAL_SOURCES_UNA := ../../Libs/Sources/Service.cpp Libs/Source/Fit/FitCrc.cpp\\\n"
+                "Libs/Source/UnaLogger/Logger.cpp   Libs/Source/Fit/FitEncoder.cpp\n"
+            )
+        check(
+            "multiple sources per line",
+            parse_makefile_sources(makefile_multi),
+            {
+                "Libs/Sources/Service.cpp",
+                "Libs/Source/Fit/FitCrc.cpp",
+                "Libs/Source/UnaLogger/Logger.cpp",
+                "Libs/Source/Fit/FitEncoder.cpp",
+            },
         )
 
         vcxproj = os.path.join(tmp, "Application.vcxproj")

--- a/.github/scripts/check_msvs_sources.py
+++ b/.github/scripts/check_msvs_sources.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Every example app and tutorial keeps two source lists in sync by hand: the
+gcc Makefile's ADDITIONAL_SOURCES(_UNA) and the MSVS Application.vcxproj's
+ClCompile items. Nobody's watching that second one, since CI only ever builds
+the gcc side (Linux simulator, STM32CubeIDE), so when a file gets added to one
+list and not the other, nothing complains until someone opens Visual Studio
+and hits a link error.
+
+This isn't hypothetical: #180 and #203 each fixed a missing-source link error
+by patching the gcc side and left the vcxproj still broken; #207 fixed the
+vcxproj but only for the two files it named, missing others that had been
+drifting since #133; #76 and #53 show the two lists were out of sync from
+the start.
+
+This script just diffs the two lists per project. No MSVC, no Windows needed;
+it runs anywhere Python 3 does.
+"""
+import os
+import re
+import sys
+import tempfile
+
+REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
+SEARCH_ROOTS = ["Examples/Apps", "Docs/Tutorials"]
+
+# vcxproj gets to the SDK root via $(SdkPath); the Makefile gets there with a
+# pile of "../" instead. Same place, different spelling, so treat them as equal.
+SDK_ROOT_MACROS = ("$(SdkPath)",)
+# Framework sources never show up in ADDITIONAL_SOURCES; the Makefile finds
+# them on its own via framework_source, so they're not ours to compare.
+FRAMEWORK_MACROS = ("$(TouchGFXReleasePath)",)
+# Same deal for anything under generated/ or gui/, plus the simulator entry
+# point: the Makefile's source_paths scan already picks these up on its own.
+AUTO_DISCOVERED_PREFIXES = ("generated/", "gui/")
+AUTO_DISCOVERED_EXACT = ("simulator/main.cpp",)
+
+
+def find_projects():
+    for root in SEARCH_ROOTS:
+        base = os.path.join(REPO_ROOT, root)
+        for dirpath, _dirnames, filenames in os.walk(base):
+            if "Makefile" not in filenames:
+                continue
+            if os.path.basename(dirpath) != "gcc" or os.path.basename(os.path.dirname(dirpath)) != "simulator":
+                continue
+            makefile_path = os.path.join(dirpath, "Makefile")
+            simulator_dir = os.path.dirname(dirpath)
+            vcxproj_path = os.path.join(simulator_dir, "msvs", "Application.vcxproj")
+            if os.path.isfile(vcxproj_path):
+                yield makefile_path, vcxproj_path
+
+
+def strip_leading_dotdots(path):
+    while path.startswith("../"):
+        path = path[3:]
+    return path
+
+
+def parse_makefile_sources(makefile_path):
+    with open(makefile_path, "r") as f:
+        lines = f.readlines()
+
+    sources = []
+    i = 0
+    var_re = re.compile(r"^(ADDITIONAL_SOURCES(?:_UNA)?)\s*:=\s*(.*)$")
+    while i < len(lines):
+        m = var_re.match(lines[i].rstrip("\n"))
+        if not m:
+            i += 1
+            continue
+        value = m.group(2)
+        entries = []
+        while value.rstrip().endswith("\\"):
+            entries.append(value.rstrip()[:-1].strip())
+            i += 1
+            value = lines[i].rstrip("\n") if i < len(lines) else ""
+        entries.append(value.strip())
+        i += 1
+        for entry in entries:
+            entry = entry.strip()
+            # Heads up: if the last source line keeps its trailing "\", Make
+            # just glues the next line onto this value, doesn't care that it
+            # looks like a new variable. We've actually seen
+            # "ADDITIONAL_SOURCES :=" show up as a "source" because of this.
+            # Filtering to .cpp/.c files keeps that junk out.
+            if entry and re.search(r"\.(cpp|c)$", entry):
+                sources.append(strip_leading_dotdots(entry.replace("\\", "/")))
+    return set(sources)
+
+
+CLCOMPILE_RE = re.compile(r'<ClCompile\s+Include="([^"]+)"\s*/?>')
+
+
+def parse_vcxproj_sources(vcxproj_path):
+    with open(vcxproj_path, "r") as f:
+        text = f.read()
+
+    tracked = set()
+    for raw in CLCOMPILE_RE.findall(text):
+        path = raw.replace("\\", "/")
+
+        if any(path.startswith(macro + "/") for macro in FRAMEWORK_MACROS):
+            continue
+
+        for macro in SDK_ROOT_MACROS:
+            prefix = macro + "/"
+            if path.startswith(prefix):
+                path = path[len(prefix):]
+                break
+        else:
+            # Didn't match $(SdkPath) above? Try $(ApplicationRoot) too,
+            # since once we strip the dotdots, both roads land on the same path.
+            for macro in ("$(ApplicationRoot)",):
+                app_prefix = macro + "/"
+                if path.startswith(app_prefix):
+                    path = path[len(app_prefix):]
+                    break
+
+        path = strip_leading_dotdots(path)
+
+        if path in AUTO_DISCOVERED_EXACT or path.startswith(AUTO_DISCOVERED_PREFIXES):
+            continue
+
+        tracked.add(path)
+    return tracked
+
+
+def project_label(makefile_path):
+    rel = os.path.relpath(makefile_path, REPO_ROOT)
+    return rel[: -len("/simulator/gcc/Makefile")]
+
+
+def run_selftest():
+    """--selftest runs these checks against fixtures baked right into this
+    file, so you can catch a parsing regression without an SDK checkout."""
+    failures = []
+
+    def check(name, actual, expected):
+        if actual != expected:
+            failures.append(f"{name}: expected {sorted(expected)!r}, got {sorted(actual)!r}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        makefile_normal = os.path.join(tmp, "Makefile.normal")
+        with open(makefile_normal, "w") as f:
+            f.write(
+                "ADDITIONAL_SOURCES_UNA :=\\\n"
+                "../../Libs/Sources/Service.cpp\\\n"
+                "Libs/Source/UnaLogger/Logger.cpp\n"
+                "ADDITIONAL_SOURCES :=\n"
+            )
+        check(
+            "normal Makefile",
+            parse_makefile_sources(makefile_normal),
+            {"Libs/Sources/Service.cpp", "Libs/Source/UnaLogger/Logger.cpp"},
+        )
+
+        # Same trailing-"\" gotcha as parse_makefile_sources above,
+        # making sure we don't regress it.
+        makefile_quirk = os.path.join(tmp, "Makefile.quirk")
+        with open(makefile_quirk, "w") as f:
+            f.write(
+                "ADDITIONAL_SOURCES_UNA :=\\\n"
+                "Libs/Source/UnaLogger/Logger.cpp\\\n"
+                "Libs/Source/Fit/FitCrc.cpp\\\n"
+                "ADDITIONAL_SOURCES :=\n"
+            )
+        check(
+            "trailing-backslash-quirk Makefile",
+            parse_makefile_sources(makefile_quirk),
+            {"Libs/Source/UnaLogger/Logger.cpp", "Libs/Source/Fit/FitCrc.cpp"},
+        )
+
+        vcxproj = os.path.join(tmp, "Application.vcxproj")
+        with open(vcxproj, "w") as f:
+            f.write(
+                '<Project><ItemGroup>\n'
+                # framework noise, skip it
+                '<ClCompile Include="$(TouchGFXReleasePath)\\framework\\source\\x.cpp"/>\n'
+                # the sim entry point; Makefile finds this on its own
+                '<ClCompile Include="$(ApplicationRoot)\\simulator\\main.cpp"/>\n'
+                # generated code, same deal
+                '<ClCompile Include="$(ApplicationRoot)\\generated\\simulator\\src\\mainBase.cpp"/>\n'
+                '<ClCompile Include="..\\..\\gui\\src\\model\\Model.cpp"/>\n'
+                # $(SdkPath) and a pile of dots should land on the same path
+                '<ClCompile Include="$(SdkPath)\\Libs\\Source\\UnaLogger\\Logger.cpp"/>\n'
+                '<ClCompile Include="..\\..\\..\\..\\Libs\\Sources\\Service.cpp"/>\n'
+                '</ItemGroup></Project>\n'
+            )
+        check(
+            "vcxproj",
+            parse_vcxproj_sources(vcxproj),
+            {"Libs/Source/UnaLogger/Logger.cpp", "Libs/Sources/Service.cpp"},
+        )
+
+    if failures:
+        print("SELFTEST FAILED:")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print("Selftest OK.")
+    return 0
+
+
+def main():
+    if "--selftest" in sys.argv[1:]:
+        return run_selftest()
+
+    projects = sorted(find_projects(), key=lambda p: p[0])
+    if not projects:
+        print("No project pairs (simulator/gcc/Makefile + simulator/msvs/Application.vcxproj) found.")
+        return 1
+
+    failures = 0
+    for makefile_path, vcxproj_path in projects:
+        label = project_label(makefile_path)
+        make_sources = parse_makefile_sources(makefile_path)
+        vcxproj_sources = parse_vcxproj_sources(vcxproj_path)
+
+        missing_from_vcxproj = sorted(make_sources - vcxproj_sources)
+        extra_in_vcxproj = sorted(vcxproj_sources - make_sources)
+
+        if not missing_from_vcxproj and not extra_in_vcxproj:
+            print(f"OK    {label} ({len(make_sources)} sources)")
+            continue
+
+        failures += 1
+        print(f"DRIFT {label}")
+        for path in missing_from_vcxproj:
+            print(f"    in Makefile, missing from Application.vcxproj: {path}")
+        for path in extra_in_vcxproj:
+            print(f"    in Application.vcxproj, missing from Makefile: {path}")
+
+    if failures:
+        print(f"\n{failures} of {len(projects)} project(s) have Makefile/vcxproj source drift.")
+        return 1
+
+    print(f"\nAll {len(projects)} project(s) have matching Makefile/vcxproj source lists.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/msvs-source-sync.yml
+++ b/.github/workflows/msvs-source-sync.yml
@@ -1,0 +1,34 @@
+name: MSVS Source Sync
+
+# Nothing else here builds the MSVS side (that needs MSVC/Windows), so if a
+# source file gets added to the vcxproj or its Makefile but not both, nobody
+# finds out until someone opens Visual Studio. check_msvs_sources.py has the
+# backstory on how many times that's already happened.
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    paths:
+      - 'Examples/Apps/**/simulator/gcc/Makefile'
+      - 'Examples/Apps/**/simulator/msvs/Application.vcxproj'
+      - 'Docs/Tutorials/**/simulator/gcc/Makefile'
+      - 'Docs/Tutorials/**/simulator/msvs/Application.vcxproj'
+      - '.github/scripts/check_msvs_sources.py'
+      - '.github/workflows/msvs-source-sync.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Selftest the checker itself
+        run: python3 .github/scripts/check_msvs_sources.py --selftest
+
+      - name: Compare Makefile and Application.vcxproj source lists
+        run: python3 .github/scripts/check_msvs_sources.py


### PR DESCRIPTION
This is an attempt at catching a class of Windows-specific regressions. Every simulator project maintains two independent source lists: the gcc Makefile's ADDITIONAL_SOURCES(_UNA) and the MSVS Application.vcxproj's ClCompile items. Because the Visual Studio project needs Windows, no workflow currently builds them. A file added to one list and not the other goes unnoticed until someone opens Visual Studio and hits a link error.

This regression has been noticed and addressed a bunch of times so far, e.g. #180, #203, #207...

Diff the two files to surface any issues proactively (it looks like there are 4 of these regressions simmering). There's an alternate world where one of these is definitive and the other is derived, but this seemed like a quick-and-easy stopgap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated validation comparing simulator source lists between Makefiles and Microsoft Visual Studio projects.
  * Reports missing or extra source files when lists differ.
  * Added built-in self-tests for path handling, source parsing, and filtering.

* **Chores**
  * Integrated source synchronization checks into continuous integration for relevant project and simulator changes.
  * Validation now runs automatically on applicable pushes and pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->