### PR TITLE
fix(sensor): recover a lost sensor subscribe (GPS position missing when an activity starts before fix)

### DIFF
--- a/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
@@ -114,6 +114,7 @@ private:
     Track::State mTrackState          = Track::State::INACTIVE;
     bool         mPreviousGpsFixState = false;
     bool         mGpsInitialConnectFailed = false;  ///< GPS_LOCATION subscribe lost the startup ack race; the retry logs the recovery.
+    bool         mGpsWanted = false;                 ///< GPS_LOCATION should stay connected (pre-activity + active track); cleared in disconnect() so the retry never re-wakes the GNSS post-activity.
     bool         mSessionNotEmpty     = false;
     bool         mLapNotEmpty         = false;
     Track::Data  mTrackData{};

--- a/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
@@ -113,6 +113,7 @@ private:
     LapDivSource mLapDivSource        = LapDivSource::OFF;
     Track::State mTrackState          = Track::State::INACTIVE;
     bool         mPreviousGpsFixState = false;
+    bool         mGpsInitialConnectFailed = false;  ///< GPS_LOCATION subscribe lost the startup ack race; the retry logs the recovery.
     bool         mSessionNotEmpty     = false;
     bool         mLapNotEmpty         = false;
     Track::Data  mTrackData{};

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -287,12 +287,13 @@ void Service::disconnect()
     }
 
     // The activity is over (stopTrack) or the app is stopping: GPS is no longer
-    // wanted, so the run() retry must not re-wake it. Release it if still up.
+    // wanted, so the run() retry must not re-wake it. Release unconditionally --
+    // disconnect() is a no-op if never subscribed, and firing it whenever a
+    // handle is held is what releases a listener whose connect-ack timed out
+    // (isConnected() would be false in exactly that case).
     mGpsWanted = false;
-    if (mSensorGpsLocation.isConnected()) {
-        LOG_DEBUG("Disconnect from GPS sensor...\n");
-        mSensorGpsLocation.disconnect();
-    }
+    LOG_DEBUG("Disconnect from GPS sensor...\n");
+    mSensorGpsLocation.disconnect();
 }
 
 void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -201,6 +201,20 @@ void Service::run()
             if (processedUtc != utc) {
                 processedUtc = utc;
 
+                // GPS_LOCATION is subscribed once at GUI start so acquisition
+                // begins on the pre-activity screen. That first attempt can lose
+                // a ~100 ms connect race during app startup, which would strand
+                // position logging for the entire session (distance/speed still
+                // record via the kernel's own GPS_LOCATION listener, so the run
+                // looks complete but has no map). Retry until it takes.
+                if (!mSensorGpsLocation.isConnected()) {
+                    connectGps();
+                    if (mGpsInitialConnectFailed && mSensorGpsLocation.isConnected()) {
+                        mGpsInitialConnectFailed = false;
+                        LOG_INFO("GPS location subscription recovered after a lost startup connect\n");
+                    }
+                }
+
                 // Send to GUI real "local time" to display
                 std::tm tmNow = mTimeTracker.getLocalTime(std::time(nullptr));
                 mGuiSender.time(tmNow);
@@ -243,18 +257,18 @@ void Service::connectGps()
 
 void Service::connectSensors()
 {
-    if (!mIsSensorsConnected) {
-        LOG_DEBUG("Connect to sensors...\n");
+    // Idempotent + self-healing: connect only sensors not already connected,
+    // so a subscribe that lost the ~100 ms ack race at track start is retried
+    // (pumped from processTrack each tick) instead of dropped for the whole
+    // session. Already-connected sensors are skipped, so there is no churn.
+    if (!mSensorBatteryLevel.isConnected())   { mSensorBatteryLevel.connect(); }
+    if (!mSensorBatteryMetrics.isConnected()) { mSensorBatteryMetrics.connect(); }
+    if (!mSensorGpsSpeed.isConnected())       { mSensorGpsSpeed.connect(); }
+    if (!mSensorGpsDistance.isConnected())    { mSensorGpsDistance.connect(); }
+    if (!mSensorPressure.isConnected())       { mSensorPressure.connect(); }
+    if (!mSensorHr.isConnected())             { mSensorHr.connect(); }
 
-        mSensorBatteryLevel.connect();
-        mSensorBatteryMetrics.connect();
-        mSensorGpsSpeed.connect();
-        mSensorGpsDistance.connect();
-        mSensorPressure.connect();
-        mSensorHr.connect();
-
-        mIsSensorsConnected = true;
-    }
+    mIsSensorsConnected = true;
 }
 
 void Service::disconnect()
@@ -354,8 +368,14 @@ void Service::onStartGUI()
     setCapabilities();
     requestAccessoryPrepare();   // pre-warm external HR while on the pre-activity screen
 
-    // Subscribe to GPS to get fix
+    // Subscribe to GPS to get fix. If this first attempt loses the ~100 ms
+    // startup ack race, the run() loop retries; flag it so the recovery is
+    // logged (and field/monitoring logs reveal how often the race fires).
     connectGps();
+    if (!mSensorGpsLocation.isConnected()) {
+        mGpsInitialConnectFailed = true;
+        LOG_WARNING("GPS location subscribe lost the startup race; will retry\n");
+    }
 
     mSensorWristMotion.connect();
 
@@ -668,6 +688,12 @@ void Service::startTrack(std::time_t utc)
 void Service::processTrack()
 {
     LOG_DEBUG("Time: %u / %u\n", static_cast<uint32_t>(mTimeCounter.getValueActive()), static_cast<uint32_t>(mTimeCounter.getValueTotal()));
+
+    // Retry any track-sensor subscription that lost the connect-ack race at
+    // track start. connectSensors() is idempotent, so this is a cheap no-op
+    // once everything is connected, and it runs only while the track is active
+    // (processTrack) so it never re-powers sensors after the track ends.
+    connectSensors();
 
     // Creating map
     SDK::TrackMapBuilder::GpsPoint newPoint{ mGps.latitude, mGps.longitude };

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -207,7 +207,7 @@ void Service::run()
                 // position logging for the entire session (distance/speed still
                 // record via the kernel's own GPS_LOCATION listener, so the run
                 // looks complete but has no map). Retry until it takes.
-                if (!mSensorGpsLocation.isConnected()) {
+                if (mGpsWanted && !mSensorGpsLocation.isConnected()) {
                     connectGps();
                     if (mGpsInitialConnectFailed && mSensorGpsLocation.isConnected()) {
                         mGpsInitialConnectFailed = false;
@@ -286,6 +286,9 @@ void Service::disconnect()
         mIsSensorsConnected = false;
     }
 
+    // The activity is over (stopTrack) or the app is stopping: GPS is no longer
+    // wanted, so the run() retry must not re-wake it. Release it if still up.
+    mGpsWanted = false;
     if (mSensorGpsLocation.isConnected()) {
         LOG_DEBUG("Disconnect from GPS sensor...\n");
         mSensorGpsLocation.disconnect();
@@ -368,12 +371,17 @@ void Service::onStartGUI()
     setCapabilities();
     requestAccessoryPrepare();   // pre-warm external HR while on the pre-activity screen
 
+    // GPS stays wanted from the pre-activity screen until the activity ends
+    // (cleared in disconnect()), so the run() loop keeps it connected during the
+    // activity but never re-wakes the GNSS on the post-activity summary screen.
+    mGpsWanted = true;
+
     // Subscribe to GPS to get fix. If this first attempt loses the ~100 ms
-    // startup ack race, the run() loop retries; flag it so the recovery is
-    // logged (and field/monitoring logs reveal how often the race fires).
+    // startup ack race, the run() loop retries; track the outcome so the retry
+    // logs the recovery (and field logs reveal how often the race fires).
     connectGps();
-    if (!mSensorGpsLocation.isConnected()) {
-        mGpsInitialConnectFailed = true;
+    mGpsInitialConnectFailed = !mSensorGpsLocation.isConnected();
+    if (mGpsInitialConnectFailed) {
         LOG_WARNING("GPS location subscribe lost the startup race; will retry\n");
     }
 

--- a/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
@@ -122,6 +122,7 @@ private:
     LapDivSource mLapDivSource        = LapDivSource::OFF;
     Track::State mTrackState          = Track::State::INACTIVE;
     bool         mPreviousGpsFixState = false;
+    bool         mGpsInitialConnectFailed = false;  ///< GPS_LOCATION subscribe lost the startup ack race; the retry logs the recovery.
     bool         mSessionNotEmpty     = false;
     bool         mLapNotEmpty         = false;
     Track::Data  mTrackData{};

--- a/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
@@ -123,6 +123,7 @@ private:
     Track::State mTrackState          = Track::State::INACTIVE;
     bool         mPreviousGpsFixState = false;
     bool         mGpsInitialConnectFailed = false;  ///< GPS_LOCATION subscribe lost the startup ack race; the retry logs the recovery.
+    bool         mGpsWanted = false;                 ///< GPS_LOCATION should stay connected (pre-activity + active track); cleared in disconnect() so the retry never re-wakes the GNSS post-activity.
     bool         mSessionNotEmpty     = false;
     bool         mLapNotEmpty         = false;
     Track::Data  mTrackData{};

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -212,6 +212,20 @@ void Service::run()
             if (processedUtc != utc) {
                 processedUtc = utc;
 
+                // GPS_LOCATION is subscribed once at GUI start so acquisition
+                // begins on the pre-activity screen. That first attempt can lose
+                // a ~100 ms connect race during app startup, which would strand
+                // position logging for the entire session (distance/speed still
+                // record via the kernel's own GPS_LOCATION listener, so the run
+                // looks complete but has no map). Retry until it takes.
+                if (!mSensorGpsLocation.isConnected()) {
+                    connectGps();
+                    if (mGpsInitialConnectFailed && mSensorGpsLocation.isConnected()) {
+                        mGpsInitialConnectFailed = false;
+                        LOG_INFO("GPS location subscription recovered after a lost startup connect\n");
+                    }
+                }
+
                 // Send to GUI real "local time" to display
                 std::tm tmNow = mTimeTracker.getLocalTime(std::time(nullptr));
                 mGuiSender.time(tmNow);
@@ -254,20 +268,20 @@ void Service::connectGps()
 
 void Service::connectSensors()
 {
-    if (!mIsSensorsConnected) {
-        LOG_DEBUG("Connect to sensors...\n");
+    // Idempotent + self-healing: connect only sensors not already connected,
+    // so a subscribe that lost the ~100 ms ack race at track start is retried
+    // (pumped from processTrack each tick) instead of dropped for the whole
+    // session. Already-connected sensors are skipped, so there is no churn.
+    if (!mSensorBatteryLevel.isConnected())   { mSensorBatteryLevel.connect(); }
+    if (!mSensorBatteryMetrics.isConnected()) { mSensorBatteryMetrics.connect(); }
+    if (!mSensorGpsSpeed.isConnected())       { mSensorGpsSpeed.connect(); }
+    if (!mSensorGpsDistance.isConnected())    { mSensorGpsDistance.connect(); }
+    if (!mSensorStepCounter.isConnected())    { mSensorStepCounter.connect(); }
+    if (!mSensorFloorCounter.isConnected())   { mSensorFloorCounter.connect(); }
+    if (!mSensorPressure.isConnected())       { mSensorPressure.connect(); }
+    if (!mSensorHr.isConnected())             { mSensorHr.connect(); }
 
-        mSensorBatteryLevel.connect();
-        mSensorBatteryMetrics.connect();
-        mSensorGpsSpeed.connect();
-        mSensorGpsDistance.connect();
-        mSensorStepCounter.connect();
-        mSensorFloorCounter.connect();
-        mSensorPressure.connect();
-        mSensorHr.connect();
-
-        mIsSensorsConnected = true;
-    }
+    mIsSensorsConnected = true;
 }
 
 void Service::disconnect()
@@ -382,8 +396,14 @@ void Service::onStartGUI()
     setCapabilities();
     requestAccessoryPrepare();   // pre-warm external HR while on the pre-activity screen
 
-    // Subscribe to GPS to get fix
+    // Subscribe to GPS to get fix. If this first attempt loses the ~100 ms
+    // startup ack race, the run() loop retries; flag it so the recovery is
+    // logged (and field/monitoring logs reveal how often the race fires).
     connectGps();
+    if (!mSensorGpsLocation.isConnected()) {
+        mGpsInitialConnectFailed = true;
+        LOG_WARNING("GPS location subscribe lost the startup race; will retry\n");
+    }
 
     mSensorWristMotion.connect();
 
@@ -698,6 +718,12 @@ void Service::startTrack(std::time_t utc)
 void Service::processTrack()
 {
     LOG_DEBUG("Time: %u / %u\n", static_cast<uint32_t>(mTimeCounter.getValueActive()), static_cast<uint32_t>(mTimeCounter.getValueTotal()));
+
+    // Retry any track-sensor subscription that lost the connect-ack race at
+    // track start. connectSensors() is idempotent, so this is a cheap no-op
+    // once everything is connected, and it runs only while the track is active
+    // (processTrack) so it never re-powers sensors after the track ends.
+    connectSensors();
 
     // Creating map
     SDK::TrackMapBuilder::GpsPoint newPoint{ mGps.latitude, mGps.longitude };

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -218,7 +218,7 @@ void Service::run()
                 // position logging for the entire session (distance/speed still
                 // record via the kernel's own GPS_LOCATION listener, so the run
                 // looks complete but has no map). Retry until it takes.
-                if (!mSensorGpsLocation.isConnected()) {
+                if (mGpsWanted && !mSensorGpsLocation.isConnected()) {
                     connectGps();
                     if (mGpsInitialConnectFailed && mSensorGpsLocation.isConnected()) {
                         mGpsInitialConnectFailed = false;
@@ -301,6 +301,9 @@ void Service::disconnect()
         mIsSensorsConnected = false;
     }
 
+    // The activity is over (stopTrack) or the app is stopping: GPS is no longer
+    // wanted, so the run() retry must not re-wake it. Release it if still up.
+    mGpsWanted = false;
     if (mSensorGpsLocation.isConnected()) {
         LOG_DEBUG("Disconnect from GPS sensor...\n");
         mSensorGpsLocation.disconnect();
@@ -396,12 +399,17 @@ void Service::onStartGUI()
     setCapabilities();
     requestAccessoryPrepare();   // pre-warm external HR while on the pre-activity screen
 
+    // GPS stays wanted from the pre-activity screen until the activity ends
+    // (cleared in disconnect()), so the run() loop keeps it connected during the
+    // activity but never re-wakes the GNSS on the post-activity summary screen.
+    mGpsWanted = true;
+
     // Subscribe to GPS to get fix. If this first attempt loses the ~100 ms
-    // startup ack race, the run() loop retries; flag it so the recovery is
-    // logged (and field/monitoring logs reveal how often the race fires).
+    // startup ack race, the run() loop retries; track the outcome so the retry
+    // logs the recovery (and field logs reveal how often the race fires).
     connectGps();
-    if (!mSensorGpsLocation.isConnected()) {
-        mGpsInitialConnectFailed = true;
+    mGpsInitialConnectFailed = !mSensorGpsLocation.isConnected();
+    if (mGpsInitialConnectFailed) {
         LOG_WARNING("GPS location subscribe lost the startup race; will retry\n");
     }
 

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -302,12 +302,13 @@ void Service::disconnect()
     }
 
     // The activity is over (stopTrack) or the app is stopping: GPS is no longer
-    // wanted, so the run() retry must not re-wake it. Release it if still up.
+    // wanted, so the run() retry must not re-wake it. Release unconditionally --
+    // disconnect() is a no-op if never subscribed, and firing it whenever a
+    // handle is held is what releases a listener whose connect-ack timed out
+    // (isConnected() would be false in exactly that case).
     mGpsWanted = false;
-    if (mSensorGpsLocation.isConnected()) {
-        LOG_DEBUG("Disconnect from GPS sensor...\n");
-        mSensorGpsLocation.disconnect();
-    }
+    LOG_DEBUG("Disconnect from GPS sensor...\n");
+    mSensorGpsLocation.disconnect();
 }
 
 void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)

--- a/Examples/Apps/Running/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Service.hpp
@@ -141,6 +141,7 @@ private:
     LapDivSource mLapDivSource        = LapDivSource::OFF;
     Track::State mTrackState          = Track::State::INACTIVE;
     bool         mPreviousGpsFixState = false;
+    bool         mGpsInitialConnectFailed = false;  ///< GPS_LOCATION subscribe lost the startup ack race; the retry logs the recovery.
     bool         mSessionNotEmpty     = false;
     bool         mLapNotEmpty         = false;
     Track::Data  mTrackData{};

--- a/Examples/Apps/Running/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Service.hpp
@@ -142,6 +142,7 @@ private:
     Track::State mTrackState          = Track::State::INACTIVE;
     bool         mPreviousGpsFixState = false;
     bool         mGpsInitialConnectFailed = false;  ///< GPS_LOCATION subscribe lost the startup ack race; the retry logs the recovery.
+    bool         mGpsWanted = false;                 ///< GPS_LOCATION should stay connected (pre-activity + active track); cleared in disconnect() so the retry never re-wakes the GNSS post-activity.
     bool         mSessionNotEmpty     = false;
     bool         mLapNotEmpty         = false;
     Track::Data  mTrackData{};

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -320,12 +320,13 @@ void Service::disconnect()
     }
 
     // The activity is over (stopTrack) or the app is stopping: GPS is no longer
-    // wanted, so the run() retry must not re-wake it. Release it if still up.
+    // wanted, so the run() retry must not re-wake it. Release unconditionally --
+    // disconnect() is a no-op if never subscribed, and firing it whenever a
+    // handle is held is what releases a listener whose connect-ack timed out
+    // (isConnected() would be false in exactly that case).
     mGpsWanted = false;
-    if (mSensorGpsLocation.isConnected()) {
-        LOG_DEBUG("Disconnect from GPS sensor...\n");
-        mSensorGpsLocation.disconnect();
-    }
+    LOG_DEBUG("Disconnect from GPS sensor...\n");
+    mSensorGpsLocation.disconnect();
 }
 
 

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -228,6 +228,20 @@ void Service::run()
             if (processedUtc != utc) {
                 processedUtc = utc;
 
+                // GPS_LOCATION is subscribed once at GUI start so acquisition
+                // begins on the pre-activity screen. That first attempt can lose
+                // a ~100 ms connect race during app startup, which would strand
+                // position logging for the entire session (distance/speed still
+                // record via the kernel's own GPS_LOCATION listener, so the run
+                // looks complete but has no map). Retry until it takes.
+                if (!mSensorGpsLocation.isConnected()) {
+                    connectGps();
+                    if (mGpsInitialConnectFailed && mSensorGpsLocation.isConnected()) {
+                        mGpsInitialConnectFailed = false;
+                        LOG_INFO("GPS location subscription recovered after a lost startup connect\n");
+                    }
+                }
+
                 // Send to GUI real "local time" to display
                 std::tm tmNow = mTimeTracker.getLocalTime(std::time(nullptr));
                 mGuiSender.time(tmNow);
@@ -270,21 +284,21 @@ void Service::connectGps()
 
 void Service::connectSensors()
 {
-    if (!mIsSensorsConnected) {
-        LOG_DEBUG("Connect to sensors...\n");
+    // Idempotent + self-healing: connect only sensors not already connected,
+    // so a subscribe that lost the ~100 ms ack race at track start is retried
+    // (pumped from processTrack each tick) instead of dropped for the whole
+    // session. Already-connected sensors are skipped, so there is no churn.
+    if (!mSensorBatteryLevel.isConnected())   { mSensorBatteryLevel.connect(); }
+    if (!mSensorBatteryMetrics.isConnected()) { mSensorBatteryMetrics.connect(); }
+    if (!mSensorGpsSpeed.isConnected())       { mSensorGpsSpeed.connect(); }
+    if (!mSensorGpsDistance.isConnected())    { mSensorGpsDistance.connect(); }
+    if (!mSensorPressure.isConnected())       { mSensorPressure.connect(); }
+    if (!mSensorHr.isConnected())             { mSensorHr.connect(); }
+    if (!mSensorFusion.isConnected())         { mSensorFusion.connect(); }
+    if (!mSensorRunningCadence.isConnected()) { mSensorRunningCadence.connect(); }
+    if (!mSensorGrade.isConnected())          { mSensorGrade.connect(); }
 
-        mSensorBatteryLevel.connect();
-        mSensorBatteryMetrics.connect();
-        mSensorGpsSpeed.connect();
-        mSensorGpsDistance.connect();
-        mSensorPressure.connect();
-        mSensorHr.connect();
-        mSensorFusion.connect();
-        mSensorRunningCadence.connect();
-        mSensorGrade.connect();
-
-        mIsSensorsConnected = true;
-    }
+    mIsSensorsConnected = true;
 }
 
 void Service::disconnect()
@@ -439,8 +453,14 @@ void Service::onStartGUI()
     setCapabilities();
     requestAccessoryPrepare();   // pre-warm external HR while on the pre-activity screen
 
-    // Subscribe to GPS to get fix
+    // Subscribe to GPS to get fix. If this first attempt loses the ~100 ms
+    // startup ack race, the run() loop retries; flag it so the recovery is
+    // logged (and field/monitoring logs reveal how often the race fires).
     connectGps();
+    if (!mSensorGpsLocation.isConnected()) {
+        mGpsInitialConnectFailed = true;
+        LOG_WARNING("GPS location subscribe lost the startup race; will retry\n");
+    }
 
     mSensorWristMotion.connect();
 
@@ -814,6 +834,12 @@ void Service::startTrack(std::time_t utc)
 void Service::processTrack()
 {
     LOG_DEBUG("Time: %u / %u\n", static_cast<uint32_t>(mTimeCounter.getValueActive()), static_cast<uint32_t>(mTimeCounter.getValueTotal()));
+
+    // Retry any track-sensor subscription that lost the connect-ack race at
+    // track start. connectSensors() is idempotent, so this is a cheap no-op
+    // once everything is connected, and it runs only while the track is active
+    // (processTrack) so it never re-powers sensors after the track ends.
+    connectSensors();
 
     // Creating map
     SDK::TrackMapBuilder::GpsPoint newPoint{ mGps.latitude, mGps.longitude };

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -234,7 +234,7 @@ void Service::run()
                 // position logging for the entire session (distance/speed still
                 // record via the kernel's own GPS_LOCATION listener, so the run
                 // looks complete but has no map). Retry until it takes.
-                if (!mSensorGpsLocation.isConnected()) {
+                if (mGpsWanted && !mSensorGpsLocation.isConnected()) {
                     connectGps();
                     if (mGpsInitialConnectFailed && mSensorGpsLocation.isConnected()) {
                         mGpsInitialConnectFailed = false;
@@ -319,6 +319,9 @@ void Service::disconnect()
         mIsSensorsConnected = false;
     }
 
+    // The activity is over (stopTrack) or the app is stopping: GPS is no longer
+    // wanted, so the run() retry must not re-wake it. Release it if still up.
+    mGpsWanted = false;
     if (mSensorGpsLocation.isConnected()) {
         LOG_DEBUG("Disconnect from GPS sensor...\n");
         mSensorGpsLocation.disconnect();
@@ -453,12 +456,17 @@ void Service::onStartGUI()
     setCapabilities();
     requestAccessoryPrepare();   // pre-warm external HR while on the pre-activity screen
 
+    // GPS stays wanted from the pre-activity screen until the activity ends
+    // (cleared in disconnect()), so the run() loop keeps it connected during the
+    // activity but never re-wakes the GNSS on the post-activity summary screen.
+    mGpsWanted = true;
+
     // Subscribe to GPS to get fix. If this first attempt loses the ~100 ms
-    // startup ack race, the run() loop retries; flag it so the recovery is
-    // logged (and field/monitoring logs reveal how often the race fires).
+    // startup ack race, the run() loop retries; track the outcome so the retry
+    // logs the recovery (and field logs reveal how often the race fires).
     connectGps();
-    if (!mSensorGpsLocation.isConnected()) {
-        mGpsInitialConnectFailed = true;
+    mGpsInitialConnectFailed = !mSensorGpsLocation.isConnected();
+    if (mGpsInitialConnectFailed) {
         LOG_WARNING("GPS location subscribe lost the startup race; will retry\n");
     }
 

--- a/Examples/Apps/Workout/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Workout/Software/Libs/Sources/Service.cpp
@@ -215,22 +215,22 @@ void Service::run()
 
 void Service::connectSensors()
 {
-    if (!mIsSensorsConnected) {
-        LOG_DEBUG("Connect to sensors...\n");
+    // Idempotent + self-healing: connect only sensors not already connected,
+    // so a subscribe that lost the ~100 ms ack race at track start is retried
+    // (pumped from processTrack each tick) instead of dropped for the whole
+    // session. Already-connected sensors are skipped, so there is no churn.
+    if (!mSensorBatteryLevel.isConnected())   { mSensorBatteryLevel.connect(); }
+    if (!mSensorBatteryMetrics.isConnected()) { mSensorBatteryMetrics.connect(); }
+    if (!mSensorPressure.isConnected())       { mSensorPressure.connect(); }
+    if (!mSensorHr.isConnected())             { mSensorHr.connect(); }
+    if (!mSensorFusion.isConnected())         { mSensorFusion.connect(); }
 
-        mSensorBatteryLevel.connect();
-        mSensorBatteryMetrics.connect();
-        mSensorPressure.connect();
-        mSensorHr.connect();
-        mSensorFusion.connect();
+    // External HR strap is pre-acquired at the pre-activity screen via the
+    // accessoryKinds capability (WP-S4), not here — so it is already
+    // connecting before the workout starts. Its readings arrive through the
+    // normal HEART_RATE sensor (the kernel arbitrates external vs optical).
 
-        // External HR strap is pre-acquired at the pre-activity screen via the
-        // accessoryKinds capability (WP-S4), not here — so it is already
-        // connecting before the workout starts. Its readings arrive through the
-        // normal HEART_RATE sensor (the kernel arbitrates external vs optical).
-
-        mIsSensorsConnected = true;
-    }
+    mIsSensorsConnected = true;
 }
 
 void Service::disconnect()
@@ -636,6 +636,12 @@ void Service::startTrack(std::time_t utc)
 void Service::processTrack()
 {
     LOG_DEBUG("Time: %u / %u\n", static_cast<uint32_t>(mTimeCounter.getValueActive()), static_cast<uint32_t>(mTimeCounter.getValueTotal()));
+
+    // Retry any track-sensor subscription that lost the connect-ack race at
+    // track start. connectSensors() is idempotent, so this is a cheap no-op
+    // once everything is connected, and it runs only while the track is active
+    // (processTrack) so it never re-powers sensors after the track ends.
+    connectSensors();
 
     // Time, s
     mTrackData.totalTime = mTimeCounter.getValueActive();

--- a/Libs/Source/SensorLayer/SensorConnection.cpp
+++ b/Libs/Source/SensorLayer/SensorConnection.cpp
@@ -110,8 +110,11 @@ void Connection::disconnect()
     if (request) {
         request->handle = mHandle;
         request.send();
-        mIsConnected = false;
     }
+    // Clear regardless of whether the message could be allocated: disconnect()
+    // means this Connection no longer considers itself connected, and nothing
+    // retries disconnect().
+    mIsConnected = false;
 }
 
 bool Connection::matchesDriver(uint16_t handle)

--- a/Libs/Source/SensorLayer/SensorConnection.cpp
+++ b/Libs/Source/SensorLayer/SensorConnection.cpp
@@ -60,9 +60,13 @@ bool Connection::connect()
     reqConnect->period  = mPeriod;
     reqConnect->latency = mLatency;
 
-    if (reqConnect.send(100) || reqConnect.ok()) {
-        mIsConnected = true;
-    }
+    // Connected only when the kernel actually returned SUCCESS. sendMessage()
+    // returns true even when only the *response* timed out (not just on a real
+    // reply), so the old `send() || ok()` latched mIsConnected on a timed-out
+    // ack -- the field failure mode -- as well as on FAIL, then never retried.
+    // Gating on ok() leaves mIsConnected false on timeout/FAIL so the caller
+    // can retry. Mirrors subscribe()'s `!send() || !ok()`.
+    mIsConnected = reqConnect.send(100) && reqConnect.ok();
 
     return mIsConnected;
 }
@@ -96,13 +100,17 @@ void Connection::disconnect()
         return;
     }
 
-    if (mIsConnected) {
-        auto request = SDK::make_msg<SDK::Message::Sensor::RequestDisconnect>(mKernel);
-        if (request) {
-            request->handle = mHandle;
-            request.send();
-            mIsConnected = false;
-        }
+    // Disconnect whenever we hold a handle, not only when mIsConnected is set.
+    // A connect() whose ack timed out can still have registered the listener
+    // kernel-side (sendMessage returns true on a response timeout), leaving
+    // mIsConnected false; gating on it would leak that listener -- and any
+    // duty-cycled hardware behind it -- until app stop. Disconnecting an
+    // unregistered listener is a safe kernel-side no-op.
+    auto request = SDK::make_msg<SDK::Message::Sensor::RequestDisconnect>(mKernel);
+    if (request) {
+        request->handle = mHandle;
+        request.send();
+        mIsConnected = false;
     }
 }
 

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(una-sdk-host-tests
     sensorlayer/HeartRateExParser_test.cpp
     simulator/FileSystemMock_test.cpp
     sensorlayer/GyroscopeParser_test.cpp
+    sensorlayer/SensorConnection_test.cpp
     metrics/MonotonicCounter_test.cpp
     utils/ClockTime_test.cpp
     support/KernelTestDoubles_test.cpp
@@ -65,6 +66,7 @@ add_executable(una-sdk-host-tests
     "${UNA_SDK_ROOT}/Libs/Source/Fit/FitWriter.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/Fit/FitRecordCadence.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/Fit/RecordingMarker.cpp"
+    "${UNA_SDK_ROOT}/Libs/Source/SensorLayer/SensorConnection.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/JSON/JsonStreamReader.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/JSON/JsonStreamWriter.cpp"
     "${COREJSON_DIR}/core_json.c"

--- a/Tests/Host/sensorlayer/SensorConnection_test.cpp
+++ b/Tests/Host/sensorlayer/SensorConnection_test.cpp
@@ -1,0 +1,227 @@
+/**
+ * Host unit tests for SDK::Sensor::Connection — the app-side sensor-subscription
+ * wrapper. These pin the fix for the field bug where a Running activity started
+ * before GPS fix recorded a full activity (HR/speed/distance) but ZERO position:
+ * the app's one GPS_LOCATION subscribe, issued during the busy app-startup
+ * window, could lose the 100 ms ack round-trip and was never retried, so the app
+ * ignored location for the whole session.
+ *
+ * The race can't be reproduced on demand on hardware, so we drive the client
+ * logic deterministically here with a scripted comm that reproduces the exact
+ * timeout/FAIL replies (sendMessage returns true even on a response timeout,
+ * mirroring the device DualAppComm — see DualAppComm.cpp).
+ */
+
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "KernelTestDoubles.hpp"
+
+#include "SDK/Kernel/KernelProviderService.hpp"
+#include "SDK/Messages/MessageBase.hpp"
+#include "SDK/Messages/SensorLayerMessages.hpp"
+#include "SDK/SensorLayer/SensorConnection.hpp"
+#include "SDK/SensorLayer/SensorTypes.hpp"
+
+using namespace SDK::TestSupport;
+
+namespace {
+
+// Kernel comm whose replies to the sensor subscribe/connect/disconnect messages
+// are scripted per test, so we can reproduce the ack-timeout race the fix
+// targets without any hardware or real IPC.
+class ScriptedComm : public StubAppComm {
+public:
+    // Script: number of leading calls that "time out". A timeout returns true
+    // (send succeeded, only the response timed out) with result != SUCCESS,
+    // exactly as the device comm does.
+    int      defaultTimeouts = 0;   // RequestDefault (subscribe) timeouts before success
+    int      connectTimeouts = 0;   // RequestConnect timeouts before success
+    bool     connectFails    = false;  // RequestConnect replies FAIL (not a timeout)
+    uint32_t handle          = 42;  // handle a successful RequestDefault returns
+
+    // Observability.
+    int      defaultCalls         = 0;
+    int      connectCalls         = 0;
+    int      disconnectCalls      = 0;
+    uint32_t lastDisconnectHandle = 0;
+
+    void reset()
+    {
+        defaultTimeouts = 0;
+        connectTimeouts = 0;
+        connectFails    = false;
+        handle          = 42;
+        defaultCalls         = 0;
+        connectCalls         = 0;
+        disconnectCalls      = 0;
+        lastDisconnectHandle = 0;
+    }
+
+    bool sendMessage(SDK::MessageBase* msg, uint32_t /*timeoutMs*/) override
+    {
+        using namespace SDK::Message::Sensor;
+        switch (msg->getType()) {
+        case SDK::MessageType::REQUEST_SENSOR_LAYER_GET_DEFAULT: {
+            ++defaultCalls;
+            if (defaultTimeouts > 0) {
+                --defaultTimeouts;
+                msg->setResult(SDK::MessageResult::TIMEOUT);
+                return true;  // device returns true even on a response timeout
+            }
+            static_cast<RequestDefault*>(msg)->handle = handle;
+            msg->setResult(SDK::MessageResult::SUCCESS);
+            return true;
+        }
+        case SDK::MessageType::REQUEST_SENSOR_LAYER_CONNECT: {
+            ++connectCalls;
+            if (connectTimeouts > 0) {
+                --connectTimeouts;
+                msg->setResult(SDK::MessageResult::TIMEOUT);
+                return true;
+            }
+            msg->setResult(connectFails ? SDK::MessageResult::FAIL
+                                        : SDK::MessageResult::SUCCESS);
+            return true;
+        }
+        case SDK::MessageType::REQUEST_SENSOR_LAYER_DISCONNECT: {
+            ++disconnectCalls;
+            lastDisconnectHandle = static_cast<RequestDisconnect*>(msg)->handle;
+            msg->setResult(SDK::MessageResult::SUCCESS);
+            return true;
+        }
+        default:
+            return true;
+        }
+    }
+};
+
+// One kernel + scripted comm installed process-wide. KernelProviderService
+// latches the first CreateInstance(), and Connection resolves its kernel from
+// that singleton, so a single shared harness is the only workable shape; each
+// test resets the comm's script.
+struct Harness {
+    StubSystem         system;
+    StubLogger         logger;
+    StubAppMemory      memory;
+    ScriptedComm       comm;
+    InMemoryFileSystem fs;
+    SDK::Kernel        kernel;
+
+    Harness()
+        : kernel(system, logger, memory, comm, fs)
+    {
+        SDK::KernelProviderService::CreateInstance(&kernel);
+    }
+};
+
+ScriptedComm& scriptedComm()
+{
+    static Harness h;  // constructed + installed on first use
+    return h.comm;
+}
+
+constexpr SDK::Sensor::Type kGps = SDK::Sensor::Type::GPS_LOCATION;
+
+}  // namespace
+
+// Baseline: a clean subscribe+connect succeeds in one attempt.
+TEST(SensorConnection, ConnectsWhenKernelSucceeds)
+{
+    ScriptedComm& comm = scriptedComm();
+    comm.reset();
+
+    SDK::Sensor::Connection conn(kGps, 1000, 1000);
+    EXPECT_TRUE(conn.connect());
+    EXPECT_TRUE(conn.isConnected());
+    EXPECT_TRUE(conn.isValid());
+    EXPECT_EQ(comm.defaultCalls, 1);
+    EXPECT_EQ(comm.connectCalls, 1);
+    EXPECT_TRUE(conn.matchesDriver(42));
+}
+
+// The field bug + fix. A subscribe (RequestDefault) timeout must leave the
+// connection un-resolved (no handle, RequestConnect never sent) — and a later
+// retry must fully recover it. Pre-fix the app never retried, so a lost startup
+// subscribe stranded position data for the entire session.
+TEST(SensorConnection, RecoversAfterSubscribeTimeout)
+{
+    ScriptedComm& comm = scriptedComm();
+    comm.reset();
+    comm.defaultTimeouts = 1;  // first RequestDefault times out, then succeeds
+
+    SDK::Sensor::Connection conn(kGps, 1000, 1000);
+
+    // First attempt: subscribe times out.
+    EXPECT_FALSE(conn.connect());
+    EXPECT_FALSE(conn.isConnected());
+    EXPECT_FALSE(conn.isValid());
+    EXPECT_EQ(comm.defaultCalls, 1);
+    EXPECT_EQ(comm.connectCalls, 0);  // never reached RequestConnect
+
+    // Retry (what the app's 1 Hz loop now does): subscribe + connect succeed.
+    EXPECT_TRUE(conn.connect());
+    EXPECT_TRUE(conn.isConnected());
+    EXPECT_TRUE(conn.isValid());
+    EXPECT_EQ(comm.defaultCalls, 2);
+    EXPECT_EQ(comm.connectCalls, 1);
+}
+
+// The connect() `send() && ok()` fix. A RequestConnect whose reply only times
+// out must leave isConnected() false so the caller retries. Pre-fix
+// (`send() || ok()`) latched connected on a timed-out ack — the actual field
+// failure mode — because send() returns true on a response timeout.
+TEST(SensorConnection, ConnectTimeoutDoesNotLatchConnected)
+{
+    ScriptedComm& comm = scriptedComm();
+    comm.reset();
+    comm.connectTimeouts = 1;  // subscribe ok; first RequestConnect times out
+
+    SDK::Sensor::Connection conn(kGps, 1000, 1000);
+
+    EXPECT_FALSE(conn.connect());  // would be TRUE under the old `send() || ok()`
+    EXPECT_FALSE(conn.isConnected());
+    EXPECT_TRUE(conn.isValid());   // handle already resolved
+    EXPECT_EQ(comm.defaultCalls, 1);
+    EXPECT_EQ(comm.connectCalls, 1);
+
+    // Retry connects without re-subscribing (handle is already held).
+    EXPECT_TRUE(conn.connect());
+    EXPECT_TRUE(conn.isConnected());
+    EXPECT_EQ(comm.defaultCalls, 1);
+    EXPECT_EQ(comm.connectCalls, 2);
+}
+
+// A FAIL reply to RequestConnect must likewise not latch connected.
+TEST(SensorConnection, ConnectFailDoesNotLatchConnected)
+{
+    ScriptedComm& comm = scriptedComm();
+    comm.reset();
+    comm.connectFails = true;
+
+    SDK::Sensor::Connection conn(kGps, 1000, 1000);
+    EXPECT_FALSE(conn.connect());
+    EXPECT_FALSE(conn.isConnected());
+}
+
+// The disconnect() hardening (review finding #1). disconnect() must send
+// RequestDisconnect whenever a handle is held, even if a connect-ack timeout
+// left mIsConnected false while the kernel registered the listener late.
+// Pre-fix disconnect() gated on mIsConnected and leaked the listener — and any
+// duty-cycled hardware behind it — until app stop.
+TEST(SensorConnection, DisconnectReleasesHandleEvenIfConnectFlagFalse)
+{
+    ScriptedComm& comm = scriptedComm();
+    comm.reset();
+    comm.connectTimeouts = 99;  // every RequestConnect times out: handle held, flag false
+
+    SDK::Sensor::Connection conn(kGps, 1000, 1000);
+    EXPECT_FALSE(conn.connect());
+    EXPECT_FALSE(conn.isConnected());
+    EXPECT_TRUE(conn.isValid());
+
+    conn.disconnect();
+    EXPECT_EQ(comm.disconnectCalls, 1);  // would be 0 under the old mIsConnected gate
+    EXPECT_EQ(comm.lastDisconnectHandle, 42u);
+}

--- a/Tests/Host/sensorlayer/SensorConnection_test.cpp
+++ b/Tests/Host/sensorlayer/SensorConnection_test.cpp
@@ -37,6 +37,7 @@ public:
     // (send succeeded, only the response timed out) with result != SUCCESS,
     // exactly as the device comm does.
     int      defaultTimeouts = 0;   // RequestDefault (subscribe) timeouts before success
+    int      defaultFails    = 0;   // RequestDefault replies FAIL (not a timeout) before success
     int      connectTimeouts = 0;   // RequestConnect timeouts before success
     bool     connectFails    = false;  // RequestConnect replies FAIL (not a timeout)
     uint32_t handle          = 42;  // handle a successful RequestDefault returns
@@ -50,6 +51,7 @@ public:
     void reset()
     {
         defaultTimeouts = 0;
+        defaultFails    = 0;
         connectTimeouts = 0;
         connectFails    = false;
         handle          = 42;
@@ -69,6 +71,11 @@ public:
                 --defaultTimeouts;
                 msg->setResult(SDK::MessageResult::TIMEOUT);
                 return true;  // device returns true even on a response timeout
+            }
+            if (defaultFails > 0) {
+                --defaultFails;
+                msg->setResult(SDK::MessageResult::FAIL);
+                return true;
             }
             static_cast<RequestDefault*>(msg)->handle = handle;
             msg->setResult(SDK::MessageResult::SUCCESS);
@@ -224,4 +231,50 @@ TEST(SensorConnection, DisconnectReleasesHandleEvenIfConnectFlagFalse)
     conn.disconnect();
     EXPECT_EQ(comm.disconnectCalls, 1);  // would be 0 under the old mIsConnected gate
     EXPECT_EQ(comm.lastDisconnectHandle, 42u);
+}
+
+// A reconnect after a clean connect+disconnect re-sends RequestConnect but NOT
+// RequestDefault (the handle is retained) and comes back connected. This is the
+// contract the apps rely on when GPS is torn down and later wanted again.
+TEST(SensorConnection, ReconnectsWithoutResubscribing)
+{
+    ScriptedComm& comm = scriptedComm();
+    comm.reset();
+
+    SDK::Sensor::Connection conn(kGps, 1000, 1000);
+    EXPECT_TRUE(conn.connect());
+    EXPECT_EQ(comm.defaultCalls, 1);
+    EXPECT_EQ(comm.connectCalls, 1);
+
+    conn.disconnect();
+    EXPECT_FALSE(conn.isConnected());
+    EXPECT_TRUE(conn.isValid());  // handle retained
+    EXPECT_EQ(comm.disconnectCalls, 1);
+
+    EXPECT_TRUE(conn.connect());
+    EXPECT_TRUE(conn.isConnected());
+    EXPECT_EQ(comm.defaultCalls, 1);  // no re-subscribe: handle already held
+    EXPECT_EQ(comm.connectCalls, 2);
+}
+
+// A subscribe that FAILs (rather than times out) also leaves the connection
+// unresolved, and a retry recovers once the kernel resolves the handle.
+TEST(SensorConnection, RecoversAfterSubscribeFail)
+{
+    ScriptedComm& comm = scriptedComm();
+    comm.reset();
+    comm.defaultFails = 1;  // first RequestDefault replies FAIL, then succeeds
+
+    SDK::Sensor::Connection conn(kGps, 1000, 1000);
+
+    EXPECT_FALSE(conn.connect());
+    EXPECT_FALSE(conn.isConnected());
+    EXPECT_FALSE(conn.isValid());
+    EXPECT_EQ(comm.defaultCalls, 1);
+    EXPECT_EQ(comm.connectCalls, 0);
+
+    EXPECT_TRUE(conn.connect());
+    EXPECT_TRUE(conn.isConnected());
+    EXPECT_EQ(comm.defaultCalls, 2);
+    EXPECT_EQ(comm.connectCalls, 1);
 }


### PR DESCRIPTION
## Problem

A field user reported activities uploading with **no map**. A sample FIT confirmed it: a full 38-minute run — HR, speed, cadence, **5.3 km of distance with three 1-mile auto-laps** — but **zero GPS position records** for the entire activity. Since distance on 1.2.0 is the haversine of *valid* GPS coordinates, the GNSS clearly had real fixes throughout; only the app-recorded position was missing. It reproduces (rarely) when the user starts the activity **before GPS fix is acquired**.

## Root cause

Per-record position is written only when the app's own `GPS_LOCATION` subscription yields a fix. The app subscribes to `GPS_LOCATION` once, early, at GUI start (so acquisition begins on the pre-activity screen). `SensorConnection::subscribe()`/`connect()` use a 100 ms message timeout; during the busy app-startup window the `RequestDefault` round-trip can exceed it, so `subscribe()` fails, `mHandle` stays `0`, `matchesDriver()` never matches, and the app ignores location for the **whole session** — with no retry. Distance/speed still record via the kernel's own in-kernel `GPS_LOCATION` listener (the `GPS_DISTANCE` sub-sensor), which masks the outage — so the activity looks complete but has no map.

Also, `connect()` used `send(100) || ok()`; `sendMessage()` returns `true` even on a response *timeout*, so it latched "connected" on a timed-out ack and never recovered.

## Fix

- **`SensorConnection::connect()`**: `mIsConnected = send(100) && ok()` — connected only on a real SUCCESS reply, so a timeout/FAIL leaves it retryable.
- **`SensorConnection::disconnect()`**: send `RequestDisconnect` whenever a handle is held (not only when `mIsConnected`) — a connect whose ack timed out can still have registered the listener kernel-side; gating on `mIsConnected` leaked it (and the duty-cycled hardware behind it) until app stop.
- **Apps (Running/Cycling/Hiking/Workout)**: retry the subscription until it takes.
  - `GPS_LOCATION`: retried from the 1 Hz loop, gated on a new `mGpsWanted` intent (set at `onStartGUI`, cleared in `disconnect()`), so acquisition still starts on the pre-activity screen but the GNSS is never re-woken on the post-activity summary screen.
  - Track sensors: `connectSensors()` made idempotent (per-sensor `isConnected()` guard) and pumped from `processTrack()` (runs only while the track is active). Workout uses no GPS, so it gets only this part.
  - A `WARNING` is logged when the startup subscribe is lost and an `INFO` when the retry recovers it, so field/monitoring logs show when the race actually fires.

## Testing

- New host tests `Tests/Host/sensorlayer/SensorConnection_test.cpp` (7 cases) covering subscribe timeout/FAIL recovery, the `send && ok` connect flag, the disconnect hardening, and reconnect-without-resubscribe. The race can't be reproduced on demand on hardware, so these drive the client logic deterministically with a scripted comm that mirrors the device (`sendMessage` returns `true` on a response timeout).
- **Verified with a negative control**: reverting the two `SensorConnection` changes turns exactly the three fix-dependent tests red.
- Full host suite: **175/175**. All four activity service ELFs link for ARM.

## Notes / out of scope

- Treadmill has the same one-shot `connectSensors()` but is being folded into Running via activity variants, so it is intentionally left untouched.
- On-device confirmation is optional now that the host tests are the deterministic acceptance; the new recovery log lets the field confirm the fix engaging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GPS reliability by automatically retrying connections when startup acknowledgements are missed.
  - Added sensor connection recovery during active tracking without reconnecting sensors that are already online.
  - Prevented stale sensor connections after interrupted or timed-out connection attempts.
  - Ensured GPS does not reconnect after the activity or app has stopped.

- **Tests**
  - Added comprehensive coverage for sensor connection failures, retries, timeouts, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->