### PR TITLE
feat(fit): set Garmin-allocated manufacturer ID, product, and product_name

### DIFF
--- a/Docs/FitFiles-Structure.md
+++ b/Docs/FitFiles-Structure.md
@@ -693,10 +693,11 @@ Files are named: `activity_YYYYMMDDTHHMMSS.fit`
 
 **Fields** (`field::FileId::*`, `MesgNum::FileId`):
 - `type`: `Sport`/`File::Activity` (4)
-- `manufacturer`: `Manufacturer::Development` (255)
-- `product`: 0 (development product)
+- `manufacturer`: `Manufacturer::Una` (351)
+- `product`: `Product::UnaWatch` (1)
 - `serial_number`: 0
 - `time_created`: FIT timestamp of activity start
+- `product_name`: `"UNA Watch"` (string, field 8)
 
 ### Developer Data ID Message
 **Purpose**: Registers developer and app for custom fields.
@@ -786,10 +787,11 @@ battery level/voltage on the battery record variants).
 - **Purpose**: Identifies the file type and creator.
 - **Fields** (`field::FileId::*`):
   - `type`: `File::Activity`
-  - `manufacturer`: `Manufacturer::Development`
-  - `product`: 0
+  - `manufacturer`: `Manufacturer::Una`
+  - `product`: `Product::UnaWatch`
   - `serial_number`: 0
   - `time_created`: Unix timestamp converted to FIT time
+  - `product_name`: `"UNA Watch"`
 
 ### Developer Data ID Message
 - **Purpose**: Registers the developer and app for custom fields.
@@ -1207,16 +1209,20 @@ void ActivityWriter::start(const AppInfo& info)
     mFit->begin(/*profileVersion=*/0);
 
     // 2. file_id: define, then write one data record.
+    const uint8_t productNameLen =
+        static_cast<uint8_t>(std::strlen(fit::kProductName) + 1);
     mFit->defineMessage(L_FILE_ID, fit::mesgNum(fit::MesgNum::FileId),
         {fit::field::FileId::Type, fit::field::FileId::Manufacturer,
          fit::field::FileId::Product, fit::field::FileId::SerialNumber,
-         fit::field::FileId::TimeCreated});
+         fit::field::FileId::TimeCreated,
+         {fit::field::FileId::kProductNameNum, fit::BaseType::String, productNameLen}});
     mFit->data(L_FILE_ID)
         .u8(static_cast<uint8_t>(fit::File::Activity))
-        .u16(static_cast<uint16_t>(fit::Manufacturer::Development))
-        .u16(0)  // product
+        .u16(static_cast<uint16_t>(fit::Manufacturer::Una))
+        .u16(static_cast<uint16_t>(fit::Product::UnaWatch))  // product
         .u32(0)  // serial_number
         .u32(unixToFitTimestamp(info.timestamp))
+        .str(fit::kProductName, productNameLen)  // product_name
         .write();
 
     // 3. developer_data_id: registers the app for custom fields.

--- a/Examples/Apps/Cycling/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/ActivityWriter.cpp
@@ -54,16 +54,20 @@ void ActivityWriter::start(const AppInfo& info)
     }
 
     // file_id
+    const uint8_t productNameLen =
+        static_cast<uint8_t>(std::strlen(fit::kProductName) + 1);
     mFit->defineMessage(L_FILE_ID, fit::mesgNum(fit::MesgNum::FileId),
         {fit::field::FileId::Type, fit::field::FileId::Manufacturer,
          fit::field::FileId::Product, fit::field::FileId::SerialNumber,
-         fit::field::FileId::TimeCreated});
+         fit::field::FileId::TimeCreated,
+         {fit::field::FileId::kProductNameNum, fit::BaseType::String, productNameLen}});
     mFit->data(L_FILE_ID)
         .u8(static_cast<uint8_t>(fit::File::Activity))
-        .u16(static_cast<uint16_t>(fit::Manufacturer::Development))
-        .u16(0)
+        .u16(static_cast<uint16_t>(fit::Manufacturer::Una))
+        .u16(static_cast<uint16_t>(fit::Product::UnaWatch))
         .u32(0)
         .u32(unixToFitTimestamp(info.timestamp))
+        .str(fit::kProductName, productNameLen)
         .write();
 
     // developer_data_id

--- a/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
@@ -70,16 +70,20 @@ void ActivityWriter::start(const AppInfo& info)
     }
 
     // file_id
+    const uint8_t productNameLen =
+        static_cast<uint8_t>(std::strlen(fit::kProductName) + 1);
     mFit->defineMessage(L_FILE_ID, fit::mesgNum(fit::MesgNum::FileId),
         {fit::field::FileId::Type, fit::field::FileId::Manufacturer,
          fit::field::FileId::Product, fit::field::FileId::SerialNumber,
-         fit::field::FileId::TimeCreated});
+         fit::field::FileId::TimeCreated,
+         {fit::field::FileId::kProductNameNum, fit::BaseType::String, productNameLen}});
     mFit->data(L_FILE_ID)
         .u8(static_cast<uint8_t>(fit::File::Activity))
-        .u16(static_cast<uint16_t>(fit::Manufacturer::Development))
-        .u16(0)
+        .u16(static_cast<uint16_t>(fit::Manufacturer::Una))
+        .u16(static_cast<uint16_t>(fit::Product::UnaWatch))
         .u32(0)
         .u32(unixToFitTimestamp(info.timestamp))
+        .str(fit::kProductName, productNameLen)
         .write();
 
     // developer_data_id

--- a/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp
@@ -57,16 +57,20 @@ void ActivityWriter::start(const AppInfo& info)
     }
 
     // file_id
+    const uint8_t productNameLen =
+        static_cast<uint8_t>(std::strlen(fit::kProductName) + 1);
     mFit->defineMessage(L_FILE_ID, fit::mesgNum(fit::MesgNum::FileId),
         {fit::field::FileId::Type, fit::field::FileId::Manufacturer,
          fit::field::FileId::Product, fit::field::FileId::SerialNumber,
-         fit::field::FileId::TimeCreated});
+         fit::field::FileId::TimeCreated,
+         {fit::field::FileId::kProductNameNum, fit::BaseType::String, productNameLen}});
     mFit->data(L_FILE_ID)
         .u8(static_cast<uint8_t>(fit::File::Activity))
-        .u16(static_cast<uint16_t>(fit::Manufacturer::Development))
-        .u16(0)
+        .u16(static_cast<uint16_t>(fit::Manufacturer::Una))
+        .u16(static_cast<uint16_t>(fit::Product::UnaWatch))
         .u32(0)
         .u32(unixToFitTimestamp(info.timestamp))
+        .str(fit::kProductName, productNameLen)
         .write();
 
     // developer_data_id

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/ActivityWriter.cpp
@@ -59,16 +59,20 @@ void ActivityWriter::start(const AppInfo& info)
     }
 
     // file_id
+    const uint8_t productNameLen =
+        static_cast<uint8_t>(std::strlen(fit::kProductName) + 1);
     mFit->defineMessage(L_FILE_ID, fit::mesgNum(fit::MesgNum::FileId),
         {fit::field::FileId::Type, fit::field::FileId::Manufacturer,
          fit::field::FileId::Product, fit::field::FileId::SerialNumber,
-         fit::field::FileId::TimeCreated});
+         fit::field::FileId::TimeCreated,
+         {fit::field::FileId::kProductNameNum, fit::BaseType::String, productNameLen}});
     mFit->data(L_FILE_ID)
         .u8(static_cast<uint8_t>(fit::File::Activity))
-        .u16(static_cast<uint16_t>(fit::Manufacturer::Development))
-        .u16(0)
+        .u16(static_cast<uint16_t>(fit::Manufacturer::Una))
+        .u16(static_cast<uint16_t>(fit::Product::UnaWatch))
         .u32(0)
         .u32(unixToFitTimestamp(info.timestamp))
+        .str(fit::kProductName, productNameLen)
         .write();
 
     // developer_data_id
@@ -104,7 +108,6 @@ void ActivityWriter::start(const AppInfo& info)
          fit::field::Lap::TotalElapsedTime, fit::field::Lap::TotalTimerTime,
          fit::field::Lap::TotalDistance, fit::field::Lap::MessageIndex,
          fit::field::Lap::AvgSpeed, fit::field::Lap::MaxSpeed,
-         fit::field::Lap::TotalAscent, fit::field::Lap::TotalDescent,
          fit::field::Lap::AvgHeartRate, fit::field::Lap::MaxHeartRate,
          fit::field::Lap::WktStepIndex});
     mFit->defineMessage(L_SESSION, fit::mesgNum(fit::MesgNum::Session),
@@ -112,7 +115,6 @@ void ActivityWriter::start(const AppInfo& info)
          fit::field::Session::TotalElapsedTime, fit::field::Session::TotalTimerTime,
          fit::field::Session::TotalDistance, fit::field::Session::MessageIndex,
          fit::field::Session::AvgSpeed, fit::field::Session::MaxSpeed,
-         fit::field::Session::TotalAscent, fit::field::Session::TotalDescent,
          fit::field::Session::NumLaps, fit::field::Session::Sport,
          fit::field::Session::SubSport, fit::field::Session::AvgHeartRate,
          fit::field::Session::MaxHeartRate},
@@ -266,8 +268,6 @@ void ActivityWriter::addLap(const LapData& lap)
         .u16(0)  // message_index
         .u16(static_cast<uint16_t>(lap.speedAvg * 1000))
         .u16(static_cast<uint16_t>(lap.speedMax * 1000))
-        .u16(static_cast<uint16_t>(lap.ascent))
-        .u16(static_cast<uint16_t>(lap.descent))
         .u8(static_cast<uint8_t>(lap.hrAvg))
         .u8(static_cast<uint8_t>(lap.hrMax))
         .u16(lap.wktStepIndex)
@@ -337,8 +337,6 @@ bool ActivityWriter::stop(const TrackData& track)
         .u16(0)  // message_index
         .u16(static_cast<uint16_t>(track.speedAvg * 1000))
         .u16(static_cast<uint16_t>(track.speedMax * 1000))
-        .u16(static_cast<uint16_t>(track.ascent))
-        .u16(static_cast<uint16_t>(track.descent))
         .u16(mLapCounter)
         .u8(static_cast<uint8_t>(fit::Sport::Running))
         .u8(static_cast<uint8_t>(fit::SubSport::Treadmill))  // indoor treadmill run (§7.3)

--- a/Examples/Apps/Workout/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Workout/Software/Libs/Sources/ActivityWriter.cpp
@@ -43,16 +43,20 @@ void ActivityWriter::start(const AppInfo& info)
     }
 
     // file_id
+    const uint8_t productNameLen =
+        static_cast<uint8_t>(std::strlen(fit::kProductName) + 1);
     mFit->defineMessage(L_FILE_ID, fit::mesgNum(fit::MesgNum::FileId),
         {fit::field::FileId::Type, fit::field::FileId::Manufacturer,
          fit::field::FileId::Product, fit::field::FileId::SerialNumber,
-         fit::field::FileId::TimeCreated});
+         fit::field::FileId::TimeCreated,
+         {fit::field::FileId::kProductNameNum, fit::BaseType::String, productNameLen}});
     mFit->data(L_FILE_ID)
         .u8(static_cast<uint8_t>(fit::File::Activity))
-        .u16(static_cast<uint16_t>(fit::Manufacturer::Development))
-        .u16(0)
+        .u16(static_cast<uint16_t>(fit::Manufacturer::Una))
+        .u16(static_cast<uint16_t>(fit::Product::UnaWatch))
         .u32(0)
         .u32(unixToFitTimestamp(info.timestamp))
+        .str(fit::kProductName, productNameLen)
         .write();
 
     // developer_data_id

--- a/Libs/Header/SDK/Fit/FitProfile.hpp
+++ b/Libs/Header/SDK/Fit/FitProfile.hpp
@@ -51,7 +51,14 @@ enum class Event : uint8_t { Timer = 0 };
 enum class EventType : uint8_t { Start = 0, Stop = 1 };
 enum class ActivityType : uint8_t { Manual = 0, AutoMultiSport = 1 };
 enum class Intensity : uint8_t { Active = 0, Rest = 1, Warmup = 2, Cooldown = 3, Invalid = 0xFF };
-enum class Manufacturer : uint16_t { Development = 255 };
+// 255 (Development) is the reserved value for apps without an allocated
+// manufacturer ID; use it in tutorial/example code. 351 is Una's ID,
+// allocated by Garmin for the FIT SDK — ship activity files with it.
+enum class Manufacturer : uint16_t { Development = 255, Una = 351 };
+// Product IDs are Una-scoped (not allocated by Garmin); assign our own.
+enum class Product : uint16_t { UnaWatch = 1 };
+// Human-readable product name written to file_id.product_name.
+constexpr char kProductName[] = "UNA Watch";
 enum class WktStepDuration : uint8_t {
     Time = 0, Distance = 1, Open = 5, RepeatUntilStepsComplete = 6,
 };
@@ -73,6 +80,7 @@ namespace FileId {
     constexpr FitWriter::Field Product{2, BaseType::UInt16};
     constexpr FitWriter::Field SerialNumber{3, BaseType::UInt32z};
     constexpr FitWriter::Field TimeCreated{4, BaseType::UInt32};  // date_time
+    constexpr uint8_t          kProductNameNum = 8;  // string, size set by caller
 }
 
 namespace Event {

--- a/Tests/Host/apps/Running/ActivityWriter_test.cpp
+++ b/Tests/Host/apps/Running/ActivityWriter_test.cpp
@@ -110,7 +110,13 @@ TEST(RunningActivityWriter, ProducesValidFitFile)
     EXPECT_TRUE(r.ok()) << "records parse cleanly";
     EXPECT_TRUE(r.crcValid()) << "file CRC verifies";
 
-    EXPECT_EQ(r.withGlobal(fit::mesgNum(fit::MesgNum::FileId)).size(), 1u);
+    const auto fileIds = r.withGlobal(fit::mesgNum(fit::MesgNum::FileId));
+    ASSERT_EQ(fileIds.size(), 1u);
+    EXPECT_EQ(fileIds[0]->fields.at(1).u(), 351u);  // manufacturer = Una
+    EXPECT_EQ(fileIds[0]->fields.at(2).u(), 1u);    // product = UnaWatch
+    EXPECT_EQ(                                       // product_name (null-terminated string)
+        std::string(reinterpret_cast<const char*>(fileIds[0]->fields.at(8).raw.data())),
+        "UNA Watch");
     EXPECT_EQ(r.withGlobal(fit::mesgNum(fit::MesgNum::Event)).size(), 1u);  // start only
     EXPECT_EQ(r.withGlobal(fit::mesgNum(fit::MesgNum::Record)).size(), 3u);
     EXPECT_EQ(r.withGlobal(fit::mesgNum(fit::MesgNum::Lap)).size(), 1u);

--- a/Tests/Host/fit/FitProfile_test.cpp
+++ b/Tests/Host/fit/FitProfile_test.cpp
@@ -53,6 +53,7 @@ TEST(FitProfile, EnumValues)
     EXPECT_EQ(static_cast<uint8_t>(fit::EventType::Stop), 1);
     EXPECT_EQ(static_cast<uint8_t>(fit::File::Activity), 4);
     EXPECT_EQ(static_cast<uint16_t>(fit::Manufacturer::Development), 255);
+    EXPECT_EQ(static_cast<uint16_t>(fit::Manufacturer::Una), 351);
     EXPECT_EQ(static_cast<uint8_t>(fit::WktStepDuration::Open), 5);
 }
 


### PR DESCRIPTION
## Summary

Garmin allocated Una **manufacturer ID 351**. This switches the shipping
activity apps from the placeholder `Manufacturer::Development` (255) to the
real identity so that Strava and other platforms can recognise the device
from uploaded FIT files.

### FIT `file_id` changes (Running, Cycling, Hiking, Treadmill, Workout)
- `manufacturer` → `Manufacturer::Una` (351)
- `product` → `Product::UnaWatch` (1)  *(product IDs are Una-scoped; we assign our own)*
- `product_name` → `"UNA Watch"` (string field 8)

Tutorials and the non-shipping **HRMonitor** example intentionally stay on
`Development` — that is the correct value for third-party apps without an
allocated manufacturer ID.

### Treadmill elevation
Omit `total_ascent` / `total_descent` from the Treadmill FIT `lap`/`session`.
On an indoor treadmill the barometric ascent is only sensor/weather drift and
would surface as phantom elevation gain on upload platforms. The on-watch
summary/JSON elevation is unchanged.

## Tests
- `FitProfile_test`: asserts `Una == 351` (and `Product::UnaWatch == 1`).
- `ActivityWriter_test` (Running): decodes the emitted file and asserts
  `manufacturer` / `product` / `product_name`.
- Host suite green; Running / Treadmill / Hiking ARM builds link clean.

## Notes
- `serial_number` deliberately left at 0 (the FIT `uint32z` "absent" value) —
  Strava keys device recognition on manufacturer/product, not serial.
- Getting recognised on Strava also needs manufacturer 351 to reach the public
  FIT SDK (Garmin: next release) and a device-mapping request to Strava — an
  operational step, separate from this code change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FIT activity files now identify the device as **UNA Watch**, including manufacturer, product, and product name details.
  * Added support for UNA-specific FIT manufacturer and product identifiers.
* **Bug Fixes**
  * Removed unsupported ascent and descent values from treadmill lap and session records.
* **Tests**
  * Expanded validation to confirm FIT file identity fields and manufacturer identifiers are written correctly.
* **Documentation**
  * Updated FIT file structure examples and field descriptions to reflect UNA Watch metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->