### PR TITLE
feat(sdk): app-pushed home-screen widget IPC channel

### DIFF
--- a/Libs/Header/SDK/HomeWidget/HomeWidget.hpp
+++ b/Libs/Header/SDK/HomeWidget/HomeWidget.hpp
@@ -14,10 +14,12 @@ namespace SDK {
 namespace detail {
 
 /**
- * @brief Copy a UTF-8 string into a fixed buffer, NUL-terminated.
+ * @brief Copy a UTF-8 string into a fixed buffer, always NUL-terminated.
  *
- * Never splits a multi-byte sequence: if @p src does not fit, it is truncated
- * back to the last whole character so the buffer always holds valid UTF-8.
+ * @p src is assumed to be valid UTF-8. On truncation the copy backs off to a
+ * character boundary, so a valid @p src is never split mid-sequence. The routine
+ * does not validate @p src: malformed input is copied as-is (still bounded and
+ * terminated), never rejected.
  * @p dst holds at most @p cap - 1 payload bytes plus the terminator; a @p cap of
  * 0 writes nothing and a null @p src yields an empty string.
  *

--- a/Libs/Header/SDK/HomeWidget/HomeWidget.hpp
+++ b/Libs/Header/SDK/HomeWidget/HomeWidget.hpp
@@ -77,7 +77,7 @@ public:
     /** @brief Release the slot; the kernel removes the element. */
     bool stop()  { return send<SDK::Message::RequestWidgetStop>(); }
 
-    /** @brief Show a label and a 0..100 progress bar (both fields). */
+    /** @brief Show a label and a 0..100 progress bar filled from its start (both fields). */
     bool update(float percent, const char* text)
     {
         return update(SDK::Message::WIDGET_SHOW_TEXT | SDK::Message::WIDGET_SHOW_PERCENT,
@@ -89,6 +89,8 @@ public:
      *
      * Fields not in @p shown are hidden. @p text is UTF-8 and only used when
      * WIDGET_SHOW_TEXT is set; @p percent only when WIDGET_SHOW_PERCENT is set.
+     * Add WIDGET_PROGRESS_FROM_END to pin the fill to the bar's end -- a countdown
+     * that empties from the start.
      */
     bool update(uint32_t shown, float percent, const char* text)
     {

--- a/Libs/Header/SDK/HomeWidget/HomeWidget.hpp
+++ b/Libs/Header/SDK/HomeWidget/HomeWidget.hpp
@@ -1,0 +1,110 @@
+#ifndef HOMEWIDGET_HPP
+#define HOMEWIDGET_HPP
+
+#include <SDK/Kernel/Kernel.hpp>
+#include <SDK/Messages/CommandMessages.hpp>
+#include <SDK/Messages/MessageGuard.hpp>
+
+#include <cstddef>
+#include <cstring>
+
+namespace SDK {
+
+/**
+ * @brief Ergonomic wrapper for the home-screen widget a running app pushes.
+ *
+ * A running app (its Service) can surface a small live element on the kernel's
+ * home screen -- a status label and/or a completion bar -- for the duration of
+ * an ongoing activity. Bracket it with @ref start / @ref stop; refresh
+ * it with an @ref update whenever the app chooses (there is no fixed cadence). The
+ * app is identified by its process, so its name and icon come from the .uapp.
+ *
+ * An update is authoritative: the WidgetShow mask says exactly what the widget
+ * shows now; fields not in the mask are hidden. All sends are fire-and-forget.
+ * @code
+ *   SDK::HomeWidget widget(mKernel);
+ *   widget.start();
+ *   widget.update(42.0f, "02:35");                               // label + bar
+ *   widget.update(SDK::Message::WIDGET_SHOW_PERCENT, 42.0f, ""); // bar only
+ *   ...
+ *   widget.stop();
+ * @endcode
+ */
+class HomeWidget {
+public:
+    explicit HomeWidget(const SDK::Kernel& kernel) : mKernel(kernel) {}
+
+    /** @brief Claim the widget slot; the kernel starts showing the element. */
+    bool start() { return send<SDK::Message::RequestWidgetStart>(); }
+
+    /** @brief Release the slot; the kernel removes the element. */
+    bool stop()  { return send<SDK::Message::RequestWidgetStop>(); }
+
+    /** @brief Show a label and a 0..100 progress bar (both fields). */
+    bool update(float percent, const char* text)
+    {
+        return update(SDK::Message::WIDGET_SHOW_TEXT | SDK::Message::WIDGET_SHOW_PERCENT,
+                      percent, text);
+    }
+
+    /**
+     * @brief Show exactly the fields in @p shown (a WidgetShow mask).
+     *
+     * Fields not in @p shown are hidden. @p text is UTF-8 and only used when
+     * WIDGET_SHOW_TEXT is set; @p percent only when WIDGET_SHOW_PERCENT is set.
+     */
+    bool update(uint32_t shown, float percent, const char* text)
+    {
+        auto msg = SDK::make_msg<SDK::Message::RequestWidgetUpdate>(mKernel);
+        if (!msg) {
+            return false;
+        }
+        msg->shown   = shown & SDK::Message::WIDGET_SHOW_ALL;   // never emit stray bits
+        // Clamp to the documented range; the >= test also maps NaN and -inf to 0.
+        msg->percent = (percent >= 0.0f) ? (percent > 100.0f ? 100.0f : percent) : 0.0f;
+        copyUtf8(msg->text, SDK::Message::WIDGET_TEXT_BYTES, text);
+        return msg.send();
+    }
+
+private:
+    template <typename T>
+    bool send()
+    {
+        auto msg = SDK::make_msg<T>(mKernel);
+        return msg && msg.send();
+    }
+
+    /**
+     * @brief Copy a UTF-8 string into a fixed buffer, NUL-terminated.
+     *
+     * Never splits a multi-byte sequence: if @p src does not fit, it is truncated
+     * back to the last whole character so the buffer always holds valid UTF-8.
+     */
+    static void copyUtf8(char* dst, std::size_t cap, const char* src)
+    {
+        if (cap == 0) {
+            return;
+        }
+        std::size_t max = cap - 1;                 // reserve the NUL
+        std::size_t n   = 0;
+        if (src != nullptr) {
+            while (src[n] != '\0' && n < max) {
+                ++n;
+            }
+            // Stopped at the limit mid-sequence? Drop the partial trailing char.
+            if (src[n] != '\0') {
+                while (n > 0 && (static_cast<unsigned char>(src[n]) & 0xC0) == 0x80) {
+                    --n;
+                }
+            }
+            std::memcpy(dst, src, n);
+        }
+        dst[n] = '\0';
+    }
+
+    const SDK::Kernel& mKernel;
+};
+
+} // namespace SDK
+
+#endif // HOMEWIDGET_HPP

--- a/Libs/Header/SDK/HomeWidget/HomeWidget.hpp
+++ b/Libs/Header/SDK/HomeWidget/HomeWidget.hpp
@@ -87,6 +87,19 @@ public:
     }
 
     /**
+     * @brief Integer/double percent forwarders to the (float, text) overload.
+     *
+     * update(intVar, text) is the most natural percent call an app writes. Without
+     * these, int->float and int->uint32_t are both conversion-rank, so the deleted
+     * update(uint32_t, const char*) guard below makes such a call ambiguous rather
+     * than resolving to the float overload (same for double). These exact matches
+     * win over both deleted conversions, while a lone WidgetShow enum and an OR-ed
+     * uint32_t mask still exact-match the deleted guards and fail to compile.
+     */
+    bool update(int percent, const char* text)    { return update(static_cast<float>(percent), text); }
+    bool update(double percent, const char* text) { return update(static_cast<float>(percent), text); }
+
+    /**
      * @brief Show exactly the fields in @p shown (a WidgetShow mask).
      *
      * Fields not in @p shown are hidden. @p text is UTF-8 and only used when

--- a/Libs/Header/SDK/HomeWidget/HomeWidget.hpp
+++ b/Libs/Header/SDK/HomeWidget/HomeWidget.hpp
@@ -6,9 +6,46 @@
 #include <SDK/Messages/MessageGuard.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 
 namespace SDK {
+
+namespace detail {
+
+/**
+ * @brief Copy a UTF-8 string into a fixed buffer, NUL-terminated.
+ *
+ * Never splits a multi-byte sequence: if @p src does not fit, it is truncated
+ * back to the last whole character so the buffer always holds valid UTF-8.
+ * @p dst holds at most @p cap - 1 payload bytes plus the terminator; a @p cap of
+ * 0 writes nothing and a null @p src yields an empty string.
+ *
+ * Internal helper (the @c detail namespace); not part of the stable SDK surface.
+ */
+inline void copyUtf8(char* dst, std::size_t cap, const char* src)
+{
+    if (cap == 0) {
+        return;
+    }
+    std::size_t max = cap - 1;                 // reserve the NUL
+    std::size_t n   = 0;
+    if (src != nullptr) {
+        while (src[n] != '\0' && n < max) {
+            ++n;
+        }
+        // Stopped at the limit mid-sequence? Drop the partial trailing char.
+        if (src[n] != '\0') {
+            while (n > 0 && (static_cast<unsigned char>(src[n]) & 0xC0) == 0x80) {
+                --n;
+            }
+        }
+        std::memcpy(dst, src, n);
+    }
+    dst[n] = '\0';
+}
+
+}  // namespace detail
 
 /**
  * @brief Ergonomic wrapper for the home-screen widget a running app pushes.
@@ -62,9 +99,21 @@ public:
         msg->shown   = shown & SDK::Message::WIDGET_SHOW_ALL;   // never emit stray bits
         // Clamp to the documented range; the >= test also maps NaN and -inf to 0.
         msg->percent = (percent >= 0.0f) ? (percent > 100.0f ? 100.0f : percent) : 0.0f;
-        copyUtf8(msg->text, SDK::Message::WIDGET_TEXT_BYTES, text);
+        detail::copyUtf8(msg->text, SDK::Message::WIDGET_TEXT_BYTES, text);
         return msg.send();
     }
+
+    /**
+     * @brief Reject a WidgetShow mask where a percent value is expected.
+     *
+     * WidgetShow is an unscoped enum, so it converts implicitly to float. Without
+     * these deletions update(WIDGET_SHOW_TEXT, "12:00") would silently bind to
+     * update(float, const char*) as percent = 1.0f and show both fields. Deleting
+     * the (mask, text) shapes turns that mistake into a compile error. The uint32_t
+     * form also catches OR-ed masks, which promote to uint32_t.
+     */
+    bool update(SDK::Message::WidgetShow, const char*) = delete;
+    bool update(uint32_t, const char*) = delete;
 
 private:
     template <typename T>
@@ -72,34 +121,6 @@ private:
     {
         auto msg = SDK::make_msg<T>(mKernel);
         return msg && msg.send();
-    }
-
-    /**
-     * @brief Copy a UTF-8 string into a fixed buffer, NUL-terminated.
-     *
-     * Never splits a multi-byte sequence: if @p src does not fit, it is truncated
-     * back to the last whole character so the buffer always holds valid UTF-8.
-     */
-    static void copyUtf8(char* dst, std::size_t cap, const char* src)
-    {
-        if (cap == 0) {
-            return;
-        }
-        std::size_t max = cap - 1;                 // reserve the NUL
-        std::size_t n   = 0;
-        if (src != nullptr) {
-            while (src[n] != '\0' && n < max) {
-                ++n;
-            }
-            // Stopped at the limit mid-sequence? Drop the partial trailing char.
-            if (src[n] != '\0') {
-                while (n > 0 && (static_cast<unsigned char>(src[n]) & 0xC0) == 0x80) {
-                    --n;
-                }
-            }
-            std::memcpy(dst, src, n);
-        }
-        dst[n] = '\0';
     }
 
     const SDK::Kernel& mKernel;

--- a/Libs/Header/SDK/Messages/CommandMessages.hpp
+++ b/Libs/Header/SDK/Messages/CommandMessages.hpp
@@ -636,11 +636,15 @@ inline constexpr uint32_t WIDGET_TEXT_BYTES = 64;
  * shows *now*. Only fields whose bit is set in `shown` are displayed; every other
  * field is hidden (a field is cleared simply by leaving its bit unset).
  *
+ * A bit either gates a field (WIDGET_SHOW_TEXT / WIDGET_SHOW_PERCENT) or modifies
+ * how a shown field renders (WIDGET_PROGRESS_FROM_END).
+ *
  * Cross-version compatible by design. New field kinds (e.g. an icon) are added by
  * APPENDING a field to RequestWidgetUpdate and a new bit here -- never reorder,
  * remove, or reuse existing fields/bits, so the offsets of the old fields stay
  * put. An older sender simply never sets the newer bits, and an older reader
- * ignores bits it does not know (that field is just not shown).
+ * ignores bits it does not know (an unknown field stays hidden; an unknown
+ * modifier is simply not applied, so the field renders its default way).
  *
  * The message is a plain struct over IPC -- it cannot validate what the sender
  * writes -- so the guarantee lives on the READER (the kernel): mask `shown`
@@ -654,8 +658,23 @@ enum WidgetShow : uint32_t {
     WIDGET_SHOW_TEXT    = 1u << 0,   ///< Display `text`.
     WIDGET_SHOW_PERCENT = 1u << 1,   ///< Display `percent` as a progress bar.
 
+    /**
+     * @brief Anchor the progress fill at the bar's end (default: its start).
+     *
+     * Modifier for WIDGET_SHOW_PERCENT (meaningless without it). The bar colours
+     * `percent` of the track; this bit fixes the point that share is measured
+     * from. Start and end are logical positions -- the kernel maps them to the
+     * widget's actual layout and orientation.
+     *
+     * Clear: the fill grows from the start (the 0% end); a rising percent fills
+     * the bar -- e.g. steps toward a goal. Set: the fill is pinned to the end
+     * (the 100% end); a falling percent recedes to that end and empties the bar
+     * from the start -- e.g. a countdown timer sending its remaining share.
+     */
+    WIDGET_PROGRESS_FROM_END = 1u << 2,
+
     /** @brief All bits this SDK version defines -- readers mask `shown` with this. */
-    WIDGET_SHOW_ALL     = WIDGET_SHOW_TEXT | WIDGET_SHOW_PERCENT,
+    WIDGET_SHOW_ALL     = WIDGET_SHOW_TEXT | WIDGET_SHOW_PERCENT | WIDGET_PROGRESS_FROM_END,
 };
 
 /**
@@ -690,7 +709,9 @@ struct RequestWidgetStart : public MessageBase {
  */
 struct RequestWidgetUpdate : public MessageBase {
     uint32_t shown;                    // Bitmask of WidgetShow: fields to display now
-    float    percent;                  // Completion 0..100 (if WIDGET_SHOW_PERCENT); a
+    float    percent;                  // Share of the bar to colour, 0..100 (if
+                                       // WIDGET_SHOW_PERCENT), measured from the bar's
+                                       // start or its end (WIDGET_PROGRESS_FROM_END); a
                                        // reader clamps out-of-range / NaN to that range
     char     text[WIDGET_TEXT_BYTES];  // Label (if WIDGET_SHOW_TEXT); UTF-8, NUL-terminated
 

--- a/Libs/Header/SDK/Messages/CommandMessages.hpp
+++ b/Libs/Header/SDK/Messages/CommandMessages.hpp
@@ -624,6 +624,102 @@ struct EventGlanceStop : public MessageBase {
     EventGlanceStop() : MessageBase(MessageType::EVENT_GLANCE_STOP) {}
 };
 
+// -- Widget (Service -> kernel: live home-screen element) ---------------------
+
+/** @brief Widget label buffer size in bytes (UTF-8, including the NUL). */
+inline constexpr uint32_t WIDGET_TEXT_BYTES = 64;
+
+/**
+ * @brief Which fields of a widget update the kernel should show (bitmask).
+ *
+ * Authoritative / replace semantics: each update fully specifies what the widget
+ * shows *now*. Only fields whose bit is set in `shown` are displayed; every other
+ * field is hidden (a field is cleared simply by leaving its bit unset).
+ *
+ * Cross-version compatible by design. New field kinds (e.g. an icon) are added by
+ * APPENDING a field to RequestWidgetUpdate and a new bit here -- never reorder,
+ * remove, or reuse existing fields/bits, so the offsets of the old fields stay
+ * put. An older sender simply never sets the newer bits, and an older reader
+ * ignores bits it does not know (that field is just not shown).
+ *
+ * The message is a plain struct over IPC -- it cannot validate what the sender
+ * writes -- so the guarantee lives on the READER (the kernel): mask `shown`
+ * against the bits it knows (`shown & WIDGET_SHOW_ALL`) and read a field only
+ * when its known bit is set. That drops any unknown or garbage bit. And because
+ * every field is zero-initialised (see the ctor), even a stray known bit reads a
+ * valid default (empty label, 0 percent) -- never uninitialised memory. So the
+ * worst a bad `shown` can do is blank a field, never crash or over-read.
+ */
+enum WidgetShow : uint32_t {
+    WIDGET_SHOW_TEXT    = 1u << 0,   ///< Display `text`.
+    WIDGET_SHOW_PERCENT = 1u << 1,   ///< Display `percent` as a progress bar.
+
+    /** @brief All bits this SDK version defines -- readers mask `shown` with this. */
+    WIDGET_SHOW_ALL     = WIDGET_SHOW_TEXT | WIDGET_SHOW_PERCENT,
+};
+
+/**
+ * @brief Widget start request.
+ *
+ * A running app claims the single home-screen widget slot for an ongoing
+ * activity; the kernel begins showing an element for it. The app is identified by
+ * the sender's process (its name and icon come from the .uapp), so no payload is
+ * needed. Follow with RequestWidgetUpdate to fill in content, RequestWidgetStop
+ * to end it.
+ *
+ * Ownership is last-start-wins: a START from another app takes the slot over, and
+ * from then on only that new owner's UPDATE/STOP take effect. There is no owner
+ * stack -- when the owner STOPs, the slot is cleared, not handed back to a
+ * previously displaced app (which must START again to show). The kernel also
+ * clears the slot if the owning process dies.
+ */
+struct RequestWidgetStart : public MessageBase {
+    RequestWidgetStart() : MessageBase(MessageType::REQUEST_WIDGET_START) {}
+};
+
+/**
+ * @brief Widget update request.
+ *
+ * Replaces the home-screen element's content: `shown` (a WidgetShow bitmask) is
+ * the authoritative set of fields to display right now -- label, progress bar, or
+ * both -- and fields left out are hidden. Sent whenever the app chooses; there is
+ * no fixed cadence. Fire-and-forget.
+ *
+ * Takes effect only from the slot's current owner: an update before the owner's
+ * START, after its STOP, or from a displaced app is ignored.
+ */
+struct RequestWidgetUpdate : public MessageBase {
+    uint32_t shown;                    // Bitmask of WidgetShow: fields to display now
+    float    percent;                  // Completion 0..100 (if WIDGET_SHOW_PERCENT); a
+                                       // reader clamps out-of-range / NaN to that range
+    char     text[WIDGET_TEXT_BYTES];  // Label (if WIDGET_SHOW_TEXT); UTF-8, NUL-terminated
+
+    // shown MUST default to 0 -- allocateMessage() placement-news every message,
+    // so this guarantees a clean bitmask (no uninitialised bits): an unset field
+    // is never read. That is what makes the cross-version contract above safe;
+    // do not drop this zero-init, and only ever assign shown (never |= it onto an
+    // unconstructed value).
+    RequestWidgetUpdate()
+        : MessageBase(MessageType::REQUEST_WIDGET_UPDATE)
+        , shown(0)
+        , percent(0.0f)
+        , text{}
+    {}
+};
+#if __SIZEOF_POINTER__ == 4
+static_assert(sizeof(RequestWidgetUpdate) == 104, "RequestWidgetUpdate size must be 104 bytes");
+#endif
+
+/**
+ * @brief Widget stop request.
+ *
+ * The activity ended; the kernel clears the slot. Effective only from the current
+ * owner, and it does not restore any previously displaced app (no owner stack).
+ */
+struct RequestWidgetStop : public MessageBase {
+    RequestWidgetStop() : MessageBase(MessageType::REQUEST_WIDGET_STOP) {}
+};
+
 } // namespace SDK::Message
 
 #pragma pack(pop)

--- a/Libs/Header/SDK/Messages/MessageTypes.hpp
+++ b/Libs/Header/SDK/Messages/MessageTypes.hpp
@@ -108,6 +108,14 @@ namespace MessageType {
     constexpr Type REQUEST_ACCESSORY_RELEASE           = 0x03210000;
     constexpr Type EVENT_ACCESSORY_STATUS              = 0x03220000;
 
+    // Widget (Service only): a running app pushes a live element (a text label +
+    // completion percent) that the kernel surfaces on the home screen. Explicit
+    // START/STOP bracket the activity; UPDATE refreshes it whenever the app
+    // chooses (no fixed cadence). The kernel clears it if the app process dies.
+    constexpr Type REQUEST_WIDGET_START                = 0x03300000;
+    constexpr Type REQUEST_WIDGET_UPDATE               = 0x03310000;
+    constexpr Type REQUEST_WIDGET_STOP                 = 0x03320000;
+
     // Application-specific custom messages (Service <-> GUI direct, used by DualAppComm)
     constexpr Type RANGE_APP_SPECIFIC_MIN       = 0x00000000;
     constexpr Type RANGE_APP_SPECIFIC_MAX       = 0x0000FFFF;

--- a/Libs/Header/SDK/Messages/MessageTypes.hpp
+++ b/Libs/Header/SDK/Messages/MessageTypes.hpp
@@ -7,13 +7,24 @@
  * This file defines common message types used in the system.
  * Applications can define custom types without modifying this file.
  *
- * Type ranges:
- * 0x0000_0000-0x0000_0FFF : Events (fire-and-forget, kernel -> app)
- * 0x0000_1000-0x0000_1FFF : Requests (app -> kernel, response expected)
- * 0x0000_2000-0x0000_2FFF : Responses (kernel -> app, response to request)
- * 0x0000_3000-0x0000_3FFF : Commands (kernel -> app, response expected)
- * 0x0000_4000-0x00FF_FFFF : Application-specific custom messages
- * 0x0100_0000-0xFFFF_FFFF : Internal kernel messages (private)
+ * The type lives in the high 16 bits; the low 16 bits are reserved and left
+ * zero for the shared types below.
+ *
+ * 0x0000_0000-0x0000_FFFF : Application-private messages, exchanged Service <->
+ *                           GUI directly over DualAppComm. The kernel never
+ *                           interprets these; each app owns the whole range.
+ * 0x0001_0000-0x7FFF_0000 : Shared kernel <-> application messages defined
+ *                           below, grouped by the high byte:
+ *                             0x01xx : application lifecycle and control
+ *                             0x02xx : system info queries and actuator
+ *                                      requests (backlight, buzzer, vibro)
+ *                             0x03xx : asynchronous events and Service-only
+ *                                      feature channels (glances, sensor
+ *                                      layer, accessories, home widget)
+ * 0x8000_0000-0xFFFF_0000 : Internal kernel messages, never seen by apps.
+ *
+ * Whether a type expects a reply is a property of the message, not of its
+ * range -- there is no separate request/response/command band.
  *
  * Shared between kernel and applications.
  */

--- a/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
+++ b/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
@@ -248,9 +248,18 @@ void KernelMessageDispatcher::appMsgHandler(SDK::MessageBase* msg)
 
         case SDK::MessageType::REQUEST_WIDGET_UPDATE: {
             auto* w = static_cast<SDK::Message::RequestWidgetUpdate*>(msg);
-            LOG_DEBUG("Widget update: shown=0x%X pct=%d text='%s'\n",
-                      w->shown, static_cast<int>(w->percent),
-                      (w->shown & SDK::Message::WIDGET_SHOW_TEXT) ? w->text : "");
+            // Sanitize as the reader contract requires: mask shown, clamp percent
+            // (NaN / out-of-range -> bounds) before the int cast, and bound the
+            // text read so a non-NUL-terminated buffer cannot over-read.
+            const uint32_t shown   = w->shown & SDK::Message::WIDGET_SHOW_ALL;
+            const float    pct     = (w->percent >= 0.0f)
+                                         ? (w->percent > 100.0f ? 100.0f : w->percent)
+                                         : 0.0f;
+            const bool     hasText = (shown & SDK::Message::WIDGET_SHOW_TEXT) != 0;
+            LOG_DEBUG("Widget update: shown=0x%X pct=%d text='%.*s'\n",
+                      shown, static_cast<int>(pct),
+                      hasText ? static_cast<int>(SDK::Message::WIDGET_TEXT_BYTES) : 0,
+                      hasText ? w->text : "");
             mMessageMgr.signalCompletion(msg, SDK::MessageResult::SUCCESS);
         } break;
 

--- a/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
+++ b/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
@@ -247,19 +247,8 @@ void KernelMessageDispatcher::appMsgHandler(SDK::MessageBase* msg)
         } break;
 
         case SDK::MessageType::REQUEST_WIDGET_UPDATE: {
-            auto* w = static_cast<SDK::Message::RequestWidgetUpdate*>(msg);
-            // Sanitize as the reader contract requires: mask shown, clamp percent
-            // (NaN / out-of-range -> bounds) before the int cast, and bound the
-            // text read so a non-NUL-terminated buffer cannot over-read.
-            const uint32_t shown   = w->shown & SDK::Message::WIDGET_SHOW_ALL;
-            const float    pct     = (w->percent >= 0.0f)
-                                         ? (w->percent > 100.0f ? 100.0f : w->percent)
-                                         : 0.0f;
-            const bool     hasText = (shown & SDK::Message::WIDGET_SHOW_TEXT) != 0;
-            LOG_DEBUG("Widget update: shown=0x%X pct=%d text='%.*s'\n",
-                      shown, static_cast<int>(pct),
-                      hasText ? static_cast<int>(SDK::Message::WIDGET_TEXT_BYTES) : 0,
-                      hasText ? w->text : "");
+            LOG_DEBUG("Widget update\n");
+            // No home screen to render in the simulator; just accept it.
             mMessageMgr.signalCompletion(msg, SDK::MessageResult::SUCCESS);
         } break;
 

--- a/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
+++ b/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
@@ -240,6 +240,25 @@ void KernelMessageDispatcher::appMsgHandler(SDK::MessageBase* msg)
             mMessageMgr.signalCompletion(msg, SDK::MessageResult::SUCCESS);
         } break;
 
+        case SDK::MessageType::REQUEST_WIDGET_START: {
+            LOG_DEBUG("Widget start\n");
+            // No home screen to render in the simulator; just accept it.
+            mMessageMgr.signalCompletion(msg, SDK::MessageResult::SUCCESS);
+        } break;
+
+        case SDK::MessageType::REQUEST_WIDGET_UPDATE: {
+            auto* w = static_cast<SDK::Message::RequestWidgetUpdate*>(msg);
+            LOG_DEBUG("Widget update: shown=0x%X pct=%d text='%s'\n",
+                      w->shown, static_cast<int>(w->percent),
+                      (w->shown & SDK::Message::WIDGET_SHOW_TEXT) ? w->text : "");
+            mMessageMgr.signalCompletion(msg, SDK::MessageResult::SUCCESS);
+        } break;
+
+        case SDK::MessageType::REQUEST_WIDGET_STOP: {
+            LOG_DEBUG("Widget stop\n");
+            mMessageMgr.signalCompletion(msg, SDK::MessageResult::SUCCESS);
+        } break;
+
         default:
             break;
     }

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(una-sdk-host-tests
     sensorlayer/SensorConnection_test.cpp
     metrics/MonotonicCounter_test.cpp
     utils/ClockTime_test.cpp
+    utils/CopyUtf8_test.cpp
     support/KernelTestDoubles_test.cpp
     apps/Stopwatch/Stopwatch_test.cpp
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/SettingsSerializer.cpp"

--- a/Tests/Host/utils/CopyUtf8_test.cpp
+++ b/Tests/Host/utils/CopyUtf8_test.cpp
@@ -1,0 +1,112 @@
+/**
+ * Tests for SDK::detail::copyUtf8 -- the UTF-8-safe bounded copy behind
+ * HomeWidget's text field. Boundary and truncation behaviour is the only
+ * nontrivial logic in the widget wrapper, so it is pinned down here.
+ *
+ * Bytes are spelled out explicitly (not source string literals) so the cases
+ * do not depend on this file's encoding. The two-byte sequence D0 94 is the
+ * Cyrillic letter "De"; 94 alone is a bare UTF-8 continuation byte.
+ */
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+#include "SDK/HomeWidget/HomeWidget.hpp"
+
+namespace {
+
+// Fill with a sentinel so "wrote nothing" and over-writes are both visible.
+constexpr char kFill = '#';
+
+// strlen of the result, treating dst as a C string.
+std::size_t copyInto(char* dst, std::size_t cap, const char* src)
+{
+    std::memset(dst, kFill, 16);
+    SDK::detail::copyUtf8(dst, cap, src);
+    return std::strlen(dst);
+}
+
+TEST(CopyUtf8, ZeroCapWritesNothing)
+{
+    char dst[16];
+    std::memset(dst, kFill, sizeof(dst));
+    SDK::detail::copyUtf8(dst, 0, "abc");
+    EXPECT_EQ(dst[0], kFill);  // buffer untouched
+}
+
+TEST(CopyUtf8, CapOneYieldsEmpty)
+{
+    char dst[16];
+    EXPECT_EQ(copyInto(dst, 1, "abc"), 0u);
+    EXPECT_EQ(dst[0], '\0');
+}
+
+TEST(CopyUtf8, NullSrcYieldsEmpty)
+{
+    char dst[16];
+    EXPECT_EQ(copyInto(dst, 8, nullptr), 0u);
+    EXPECT_EQ(dst[0], '\0');
+}
+
+TEST(CopyUtf8, FitsWhole)
+{
+    char dst[16];
+    EXPECT_EQ(copyInto(dst, 8, "abc"), 3u);
+    EXPECT_STREQ(dst, "abc");
+}
+
+TEST(CopyUtf8, ExactFitAscii)
+{
+    char dst[16];
+    // cap 4 holds "abc" + NUL exactly.
+    EXPECT_EQ(copyInto(dst, 4, "abc"), 3u);
+    EXPECT_STREQ(dst, "abc");
+}
+
+TEST(CopyUtf8, AsciiTruncation)
+{
+    char dst[16];
+    // cap 4 -> max 3 payload bytes; 'd' is not a continuation byte, no back-off.
+    EXPECT_EQ(copyInto(dst, 4, "abcdef"), 3u);
+    EXPECT_STREQ(dst, "abc");
+}
+
+TEST(CopyUtf8, TruncationOnCharBoundary)
+{
+    // "A" + De + De = 41 D0 94 D0 94 ; cap 4 -> max 3 lands after the first De.
+    const char src[] = {'\x41', '\xD0', '\x94', '\xD0', '\x94', '\0'};
+    const char want[] = {'\x41', '\xD0', '\x94', '\0'};
+    char dst[16];
+    EXPECT_EQ(copyInto(dst, 4, src), 3u);
+    EXPECT_EQ(std::memcmp(dst, want, sizeof(want)), 0);
+}
+
+TEST(CopyUtf8, TruncationMidSequenceDropsPartialChar)
+{
+    // "A" + De = 41 D0 94 ; cap 3 -> max 2 stops mid-De, which must be dropped.
+    const char src[] = {'\x41', '\xD0', '\x94', '\0'};
+    char dst[16];
+    EXPECT_EQ(copyInto(dst, 3, src), 1u);
+    EXPECT_STREQ(dst, "A");
+}
+
+TEST(CopyUtf8, WholeMultibyteFits)
+{
+    // "A" + De fits in cap 4 (3 payload bytes + NUL).
+    const char src[] = {'\x41', '\xD0', '\x94', '\0'};
+    char dst[16];
+    EXPECT_EQ(copyInto(dst, 4, src), 3u);
+    EXPECT_EQ(std::memcmp(dst, src, 4), 0);
+}
+
+TEST(CopyUtf8, AllContinuationBytesDegradeToEmpty)
+{
+    // Pathological input: only continuation bytes. The n > 0 guard must stop the
+    // back-off at 0 (no underflow) and the result is empty, still terminated.
+    const char src[] = {'\x94', '\x94', '\x94', '\0'};
+    char dst[16];
+    EXPECT_EQ(copyInto(dst, 2, src), 0u);
+    EXPECT_EQ(dst[0], '\0');
+}
+
+}  // namespace

--- a/Tests/Host/utils/CopyUtf8_test.cpp
+++ b/Tests/Host/utils/CopyUtf8_test.cpp
@@ -109,4 +109,15 @@ TEST(CopyUtf8, AllContinuationBytesDegradeToEmpty)
     EXPECT_EQ(dst[0], '\0');
 }
 
+TEST(CopyUtf8, MalformedButFittingInputCopiedAsIs)
+{
+    // Contract: src is assumed valid UTF-8; the copy does not validate it. A
+    // malformed byte that fits (here a lone continuation byte) is passed through
+    // unchanged -- back-off only fires when truncation would split a sequence.
+    const char src[] = {'\x94', '\0'};
+    char dst[16];
+    EXPECT_EQ(copyInto(dst, 8, src), 1u);
+    EXPECT_EQ(std::memcmp(dst, src, 2), 0);
+}
+
 }  // namespace


### PR DESCRIPTION
## Summary
A new Service→kernel IPC channel that lets a running app surface a small live
element — a status label and/or a completion bar — on the kernel's home screen
for the duration of an ongoing activity (e.g. a Timer showing its countdown
while its own GUI is closed). This is **app-push**, distinct from glances (a
separate, kernel-driven app type).

This PR is the **SDK contract only**: the messages, an ergonomic helper, and
simulator acceptance. Kernel-side rendering/placement and the first consumer
(Timer) land separately.

## The contract
Three fire-and-forget requests (`0x0330`–`0x0332`):
- `REQUEST_WIDGET_START` — claim the single home-widget slot. Empty payload; the
  app is identified by its process.
- `REQUEST_WIDGET_UPDATE` — `{ uint32 shown; float percent; char text[64] }`.
  `shown` (a `WidgetShow` bitmask) authoritatively selects which fields to show
  now and carries render modifiers; `percent` is 0..100; `text` is UTF-8,
  NUL-terminated.
- `REQUEST_WIDGET_STOP` — release the slot.

Helper `SDK::HomeWidget` (`start` / `stop` / `update`) wraps the sends.

## Semantics & design
- **Replace, not merge:** each update fully specifies what's shown; fields whose
  `WidgetShow` bit is not set are hidden.
- **Extensible:** new capabilities are added by *appending* a field and/or a new
  `WidgetShow` bit — never reorder/remove/reuse. A bit either gates a field (e.g.
  an icon) or modifies how a shown field renders. Old and new senders and readers
  interoperate by ignoring bits they don't know.
- **Progress direction:** `WIDGET_PROGRESS_FROM_END` — a `WidgetShow` modifier bit
  for `percent` that fixes which point the fill is measured from. Default fills
  from the bar's *start* (a rising percent fills up, e.g. steps toward a goal);
  set pins the fill to the *end* (a falling percent empties from the start, e.g.
  a countdown sending its remaining share). Start/end are logical — the kernel
  maps them to the widget's layout and orientation.
- **Robust against bad input** (a POD over IPC can't validate the sender, so the
  reader is defensive):
  - `shown` is masked to known bits (helper *and* kernel) — unknown/garbage bits
    are dropped.
  - `percent` is clamped to `[0,100]` (NaN/inf → bounds).
  - every field is zero-initialised (placement-new ctor), so the worst a bad
    `shown` can do is blank a field — never a crash or over-read.
  - `text` is copied UTF-8-safe (never splits a multi-byte sequence).
- **Ownership:** a single slot, last-START-wins; only the current owner's
  UPDATE/STOP take effect; no owner stack (STOP clears the slot, it isn't handed
  back to a displaced app); the kernel clears the slot if the owner dies.

## Not in this PR (follow-ups)
- Kernel-side: home rendering, placement, per-app keying, clear-on-death, the
  display policy when multiple apps compete, and whether an active widget keeps
  the owning service scheduled.
- First consumer: the Timer service sending start/update/stop.

## Testing
- `static_assert(sizeof(RequestWidgetUpdate) == 104)` on the 32-bit ABI.
- Compiles under `arm-none-eabi-g++` (headers + helper, incl. a Cyrillic UTF-8
  label) and in the MSVC Win32 simulator (the Stopwatch app builds, exercising
  the new dispatcher cases).
- `copyUtf8` truncation/boundary behaviour covered by host tests (`Tests/Host`,
  10 cases: ASCII + multibyte truncation, mid-sequence back-off,
  all-continuation input, empty/null).

## Compatibility
New message ids only — ABI-safe for existing apps. No capability-flag or
kernel-interface-version change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an SDK API to start, stop, and update a live home-screen widget (progress percent + UTF-8 label), including an option to anchor progress from the end.
* **Documentation**
  * Clarified widget update semantics, including how “shown” fields and progress anchoring work.
* **Bug Fixes**
  * Ensured UTF-8 label updates are bounded, truncation-safe, and always null-terminated.
* **Simulator**
  * Simulator now accepts widget start/update/stop requests and returns success.
* **Tests**
  * Added host unit tests covering UTF-8 bounded-copy and truncation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->