### PR TITLE
fix(cmake): make -fcyclomatic-complexity opt-in

### DIFF
--- a/cmake/una-app.cmake
+++ b/cmake/una-app.cmake
@@ -49,8 +49,6 @@ add_compile_options(
     -nostdlib
     -mthumb
     -ffunction-sections
-    -fcyclomatic-complexity
-
 )
 
 # C++ specific flags
@@ -112,6 +110,29 @@ function(una_app_setup_version BUILD_VERSION_OUT WORKING_DIR)
     message("Fallback BUILD_VERSION: ${BUILD_VERSION}")
 endfunction()
 
+# -fcyclomatic-complexity exists only in ST's GNU Tools for STM32 fork; mainline
+# arm-none-eabi-gcc rejects it outright. Probed rather than assumed so both
+# toolchains work unchanged. This runs from the build functions below, not at
+# include time, because the languages are not enabled until the app calls
+# project(). C and CXX are probed separately so each language is gated by its
+# own compiler's answer rather than the other's.
+function(una_app_add_metrics_flags TARGET_NAME)
+    include(CheckCCompilerFlag)
+    include(CheckCXXCompilerFlag)
+    check_c_compiler_flag(-fcyclomatic-complexity UNA_HAVE_FCYCLOMATIC_COMPLEXITY_C)
+    check_cxx_compiler_flag(-fcyclomatic-complexity UNA_HAVE_FCYCLOMATIC_COMPLEXITY_CXX)
+    if(UNA_HAVE_FCYCLOMATIC_COMPLEXITY_C)
+        target_compile_options(${TARGET_NAME} PRIVATE
+            $<$<COMPILE_LANGUAGE:C>:-fcyclomatic-complexity>
+        )
+    endif()
+    if(UNA_HAVE_FCYCLOMATIC_COMPLEXITY_CXX)
+        target_compile_options(${TARGET_NAME} PRIVATE
+            $<$<COMPILE_LANGUAGE:CXX>:-fcyclomatic-complexity>
+        )
+    endif()
+endfunction()
+
 # Function to build service executable
 # Needs:
 # - TARGET_NAME - arg
@@ -147,6 +168,8 @@ function(una_app_build_service TARGET_NAME)
     message("DEV_ID: ${DEV_ID}")
 
     add_executable(${TARGET_NAME} ${SERVICE_SOURCES})
+
+    una_app_add_metrics_flags(${TARGET_NAME})
 
     target_include_directories(${TARGET_NAME} PRIVATE ${SERVICE_INCLUDE_DIRS})
 
@@ -213,6 +236,8 @@ function(una_app_build_gui TARGET_NAME)
     list(REMOVE_DUPLICATES TOUCHGFX_LIBS_DIRS)
 
     add_executable(${TARGET_NAME} ${GUI_SOURCES})
+
+    una_app_add_metrics_flags(${TARGET_NAME})
 
     target_include_directories(${TARGET_NAME} PRIVATE ${GUI_INCLUDE_DIRS})
 


### PR DESCRIPTION
## Problem

`cmake/una-app.cmake` unconditionally passes `-fcyclomatic-complexity`. That flag exists only in ST's GNU Tools for STM32 fork — mainline `arm-none-eabi-gcc` (including the official Arm GNU Toolchain) rejects it at the first compile:

```
arm-none-eabi-g++: error: unrecognized command-line option '-fcyclomatic-complexity'
```

This makes the CMake workflow unusable with any non-ST toolchain, which is a shame — as far as I can tell it is the *only* thing that requires the ST fork on that path. `una-app.cmake` links with `-nostdlib -nodefaultlibs -nostartfiles` against the vendored `Libs/Source/AppSystem/Libc++/libstdc++.a`, so newlib's syscall stubs (the reason `Docs/sdk-setup.md` calls the ST toolchain critical) are never linked and never needed.

## Change

Guard the flag behind an `option()` defaulting to `OFF`.

```cmake
option(UNA_ENABLE_CYCLOMATIC_COMPLEXITY
    "Emit cyclomatic complexity metrics (ST GNU Tools for STM32 only)" OFF)
```

**Why `option()` rather than `check_cxx_compiler_flag`:** `una-app.cmake` is included *before* `project()` in every app's `CMakeLists.txt`, so CXX is not enabled at that point and the probe cannot run reliably there. An `option()` needs no compiler and works where the file actually sits.

ST users keep the metrics with `-DUNA_ENABLE_CYCLOMATIC_COMPLEXITY=ON`.

## Testing

Both directions verified against `Examples/Apps/Alarm` with the Arm GNU Toolchain 15.2.Rel1 on macOS (aarch64):

**Default (`OFF`)** — builds a complete, valid package:
```
INFO:root:Name           : Alarm
INFO:root:ID             : A19C2A7E4F8B6D31
INFO:root:Image          : Alarm_1.0.0-verify.uapp (210952 bytes)
```

**`-DUNA_ENABLE_CYCLOMATIC_COMPLEXITY=ON`** — the flag is genuinely re-added, confirmed by mainline GCC rejecting it exactly as before this change. I do not have the ST toolchain to hand, so that arm is verified as "the flag reaches the compiler", not as "ST still emits metrics" — worth a second pair of eyes if that matters to you.

Happy to adjust the option name or default if you would rather keep it `ON` and detect the fork some other way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build configuration compatibility across supported compiler toolchains.
  * Cyclomatic complexity checks are enabled automatically when supported by the selected compiler.
  * Builds continue successfully with compilers that do not provide this capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->