### PR TITLE
fix(cmake): make builds independent of where the SDK is checked out

### DIFF
--- a/.github/workflows/apps-ci.yml
+++ b/.github/workflows/apps-ci.yml
@@ -120,6 +120,78 @@ jobs:
           path: variants-out/${{ matrix.variant }}/*.uapp
           if-no-files-found: error
 
+  # The -fmacro-prefix-map prefixes in cmake/una-app.cmake fail *silently*: give an
+  # app a source root none of them cover, or respell LIBS_PATH, and the build still
+  # succeeds -- it just quietly goes back to baking the checkout path into .rodata.
+  # Nothing else in CI notices, because the matrix above builds every app from the
+  # one path where the SDK prefix happens to cover the app too. So build one app
+  # from two directories outside the SDK and require the bytes to match.
+  reproducible-build:
+    runs-on: ubuntu-latest
+    container: xanderhendriks/stm32cubeide:16.0
+    env:
+      # Workout asserts in its own Libs sources and has a GUI, so one build
+      # exercises the SDK, LIBS_PATH and TOUCHGFX_PATH prefixes together.
+      APP: Workout
+    steps:
+      - name: Setup GIT
+        run: |
+          # See the note in cmake-build: security.ubuntu.com hangs `apt update`.
+          find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) \
+            -exec sed -i 's#security\.ubuntu\.com/ubuntu#archive.ubuntu.com/ubuntu#g' {} +
+          apt-get update && apt-get install -y git python3-full python3-pip python-is-python3 cmake
+
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+
+      - name: Install scripts requirements
+        run: python3 -m pip install --break-system-packages -r Utilities/Scripts/app_packer/requirements.txt
+
+      - name: Build ${{ env.APP }} from two different directories
+        run: |
+          export PATH=/tmp/bin:`find /opt/st/stm32cubeide_* -type f -name arm-none-eabi-objcopy | head -n 1 | xargs dirname`:$PATH
+          export PATH=/tmp/bin:`find /opt/st/stm32cubeide_* -type f -name make | head -n 1 | xargs dirname`:$PATH
+          chmod +x $(find /opt/st/stm32cubeide_* -type f -name make | head -n 1)
+          chmod +x $(find /opt/st/stm32cubeide_* -type f -name arm-none-eabi-gcc | head -n 1)
+          chmod +x $(find /opt/st/stm32cubeide_* -type f -name arm-none-eabi-g++ | head -n 1)
+          export UNA_SDK=$GITHUB_WORKSPACE
+          # The two roots differ in depth and in length, so a path that survives
+          # into the binary changes its bytes rather than just its contents.
+          for root in /tmp/one /tmp/a/rather/deeper/two; do
+            mkdir -p "$root"
+            cp -a "$GITHUB_WORKSPACE/Examples/Apps/$APP" "$root/"
+            cd "$root/$APP/Software/Apps/$APP-CMake"
+            mkdir -p build
+            cd build
+            cmake ..
+            make -j$(nproc)
+          done
+
+      # Steps in this container run under `sh -e`, not bash, so keep this POSIX.
+      - name: Require identical bytes and no build path in the app
+        run: |
+          one=/tmp/one/$APP/Software/Apps/$APP-CMake/build
+          two=/tmp/a/rather/deeper/two/$APP/Software/Apps/$APP-CMake/build
+          found=$(find "$one" "$two" -maxdepth 1 -name '*.uapp' | wc -l)
+          if [ "$found" -ne 2 ]; then
+            echo "::error::expected one .uapp from each build, found $found -- the checks below would have passed vacuously"
+            exit 1
+          fi
+          a=$(find "$one" -maxdepth 1 -name '*.uapp')
+          b=$(find "$two" -maxdepth 1 -name '*.uapp')
+          if ! cmp "$a" "$b"; then
+            echo "::error::$APP built at two paths produced different bytes"
+            exit 1
+          fi
+          for path in /tmp/one /tmp/a/rather/deeper/two "$GITHUB_WORKSPACE"; do
+            if grep -qaF -e "$path" "$a"; then
+              echo "::error::'$path' is baked into $APP -- a -fmacro-prefix-map prefix stopped matching"
+              exit 1
+            fi
+          done
+
   release:
     runs-on: ubuntu-latest
     needs: [cmake-build, pack-variants]

--- a/cmake/una-app.cmake
+++ b/cmake/una-app.cmake
@@ -42,6 +42,9 @@ set(CMAKE_CXX_STANDARD 17)
 # -fmacro-prefix-map rewrites __FILE__ only: logged basenames are unchanged and
 # debug info keeps real paths, which -ffile-prefix-map would have broken.
 #
+# Unprobed, unlike -fcyclomatic-complexity below: that one exists only in ST's
+# fork, while -fmacro-prefix-map has been mainline GCC since 8.
+#
 # ABSOLUTE, not REALPATH: the compiler sees the path as CMake spells it
 # ("$ENV{UNA_SDK}/Libs/...", see cmake/una-sdk.cmake) and CMake does not resolve
 # symlinks, so a REALPATH prefix silently stops matching whenever UNA_SDK is
@@ -52,16 +55,20 @@ add_compile_options(
 )
 
 # App sources live in sibling directories above the project dir, so CMake compiles
-# them absolutely too -- and 7 of the 8 example apps assert in their own sources.
+# them absolutely too, and several of the example apps assert in their own sources.
 # Broadest first: where two prefixes both match, GCC applies the one given *last*.
+#
+# Truthy, not DEFINED: get_filename_component("" ABSOLUTE) returns the app's own
+# source dir, so a defined-but-empty LIBS_PATH would emit that as a map *after*
+# the one above and, by that same last-wins rule, relabel the app's own sources.
 set(_una_app_prefix_maps "")
 get_filename_component(_una_abs "${CMAKE_SOURCE_DIR}" ABSOLUTE)
 list(APPEND _una_app_prefix_maps "${_una_abs}=/una-app")
-if(DEFINED LIBS_PATH)
+if(LIBS_PATH)
     get_filename_component(_una_abs "${LIBS_PATH}" ABSOLUTE)
     list(APPEND _una_app_prefix_maps "${_una_abs}=/una-app-libs")
 endif()
-if(DEFINED TOUCHGFX_PATH)
+if(TOUCHGFX_PATH)
     get_filename_component(_una_abs "${TOUCHGFX_PATH}" ABSOLUTE)
     list(APPEND _una_app_prefix_maps "${_una_abs}=/una-app-gui")
 endif()

--- a/cmake/una-app.cmake
+++ b/cmake/una-app.cmake
@@ -32,6 +32,48 @@ set(CMAKE_CXX_STANDARD 17)
 # Add this to your CMakeLists.txt is you want verbose compiler log
 # set(CMAKE_VERBOSE_MAKEFILE ON)
 
+# Make the build independent of where the SDK and the app are checked out.
+#
+# __FILE__ reaches .rodata two ways: assert() (no NDEBUG anywhere, so newlib's
+# __assert_func keeps it) and UnaLogger's __FILENAME__, which trims to a basename
+# only at *runtime*. SDK and app sources both compile through absolute paths, so
+# the same source built elsewhere produces different bytes.
+#
+# -fmacro-prefix-map rewrites __FILE__ only: logged basenames are unchanged and
+# debug info keeps real paths, which -ffile-prefix-map would have broken.
+#
+# ABSOLUTE, not REALPATH: the compiler sees the path as CMake spells it
+# ("$ENV{UNA_SDK}/Libs/...", see cmake/una-sdk.cmake) and CMake does not resolve
+# symlinks, so a REALPATH prefix silently stops matching whenever UNA_SDK is
+# reached through one (a symlinked checkout, or macOS /tmp -> /private/tmp).
+get_filename_component(UNA_SDK_ABSPATH "$ENV{UNA_SDK}" ABSOLUTE)
+add_compile_options(
+    $<$<COMPILE_LANGUAGE:C,CXX>:-fmacro-prefix-map=${UNA_SDK_ABSPATH}=/una-sdk>
+)
+
+# App sources live in sibling directories above the project dir, so CMake compiles
+# them absolutely too -- and 7 of the 8 example apps assert in their own sources.
+# Broadest first: where two prefixes both match, GCC applies the one given *last*.
+set(_una_app_prefix_maps "")
+get_filename_component(_una_abs "${CMAKE_SOURCE_DIR}" ABSOLUTE)
+list(APPEND _una_app_prefix_maps "${_una_abs}=/una-app")
+if(DEFINED LIBS_PATH)
+    get_filename_component(_una_abs "${LIBS_PATH}" ABSOLUTE)
+    list(APPEND _una_app_prefix_maps "${_una_abs}=/una-app-libs")
+endif()
+if(DEFINED TOUCHGFX_PATH)
+    get_filename_component(_una_abs "${TOUCHGFX_PATH}" ABSOLUTE)
+    list(APPEND _una_app_prefix_maps "${_una_abs}=/una-app-gui")
+endif()
+foreach(_una_map IN LISTS _una_app_prefix_maps)
+    add_compile_options(
+        $<$<COMPILE_LANGUAGE:C,CXX>:-fmacro-prefix-map=${_una_map}>
+    )
+endforeach()
+unset(_una_abs)
+unset(_una_map)
+unset(_una_app_prefix_maps)
+
 # Common compile options (match CubeIDE exactly)
 add_compile_options(
     -mcpu=cortex-m33


### PR DESCRIPTION
The same source currently produces different binaries depending on where the SDK and the app are checked out, so a published `.uapp` cannot be rebuilt and checked against its source.

Two things expand `__FILE__` into `.rodata`. `assert()` is the bulk of it, UnaLogger's `__FILENAME__` adds the rest. 

- `ABSOLUTE`, not `REALPATH`: the compiler sees the path as CMake spells it out, and CMake does not resolve symlinks so `REALPATH` prefix silently fails to match whenever `UNA_SDK` is reached through a symlink.
- The app maps are emitted last, as when two prefixes both match GCC applies the one given last, not he first. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reproducibility by ensuring identical app binaries are produced regardless of the source directory location.
  * Removed source and build paths from generated app artifacts.
* **Tests**
  * Added automated verification for reproducible Workout app builds across different directory structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->