### PR TITLE
feat(abi): bump KERNEL_INTERFACE_VERSION 2 -> 3 for the home-widget IPC

### DIFF
--- a/Libs/Header/SDK/Interfaces/IKernel.hpp
+++ b/Libs/Header/SDK/Interfaces/IKernel.hpp
@@ -34,7 +34,7 @@ namespace SDK::Interface
 {
 
 #define DUMMY_KERNEL_ADDR           (0xA5A5A5A5)
-#define KERNEL_INTERFACE_VERSION    (2)
+#define KERNEL_INTERFACE_VERSION    (3)
 
 class IKernel {
 public:


### PR DESCRIPTION
## What

Bumps `KERNEL_INTERFACE_VERSION` from `2` to `3` in
`Libs/Header/SDK/Interfaces/IKernel.hpp`.

## Why

The home-widget channel (`REQUEST_WIDGET_START` / `REQUEST_WIDGET_UPDATE` /
`REQUEST_WIDGET_STOP`, `HomeWidget`, #231) added new kernel↔app IPC messages.
`KERNEL_INTERFACE_VERSION` is the ABI knob an app uses to declare the minimum
kernel it needs, so it has to advance to reflect the enlarged interface surface.

## How the check works

The gate lives in the app, at startup — `una_init_kernel()` in `system.cpp`:

​```cpp
if (gIKernel->version < KERNEL_INTERFACE_VERSION) { exitA(-4); }
​```

- `gIKernel->version` — what the running kernel advertises (its build-time
  `KERNEL_INTERFACE_VERSION`).
- `KERNEL_INTERFACE_VERSION` — baked into the app at build time as its minimum
  requirement.

The comparison is `<`, i.e. **backward-compatible by design**.

## Behavioural impact

| App built against | Kernel provides | Result |
| --- | --- | --- |
| v2 (all currently shipped apps) | v3 | **runs** — old apps are not broken |
| v3 (widget-using) | v3 | runs |
| v3 (widget-using) | v2 (not-yet-updated firmware) | `exit(-4)`, logs `Kernel not supported. Minimum 3, got 2` |
| v2 | v2 | runs |

- **No flag-day, no forced rebuild** of existing apps — they keep loading and
  running on the v3 kernel, they simply never touch the widget.
- A widget-using app rebuilt against this SDK now fails fast with a clear log on
  old firmware, instead of silently having its widget messages dropped
  (`default: break` in the kernel dispatcher). Declaring that dependency is the
  whole point of the bump.

## Not touched (deliberately)

- **`libcVersion` / `libc_exports_*.ld` are left alone.** That is a separate ABI
  axis (the libc symbol table), checked with strict equality (`!=`) in the kernel
  loader/validator. The widget change adds no new libc symbols, so moving it would
  needlessly reject every existing `.uapp` on load.

## Caveats for reviewers

1. **Coarse knob.** `KERNEL_INTERFACE_VERSION` is a single global constant, so
   *any* app recompiled against this SDK — even one that doesn't use the widget —
   will now require kernel ≥ 3 and won't start on pre-widget firmware. Acceptable
   given firmware is updated with/ahead of apps, but worth noting for
   mixed-firmware fleets.
2. **Lockstep.** The kernel must be rebuilt from this bumped header so
   `IKernel::version` actually advertises `3` (the SDK is a submodule of the
   kernel, so the define moves both sides in one bump).