### PR TITLE
docs(examples): stop teaching the retired per-app Sender

### DIFF
--- a/Docs/Examples/Alarm-Architecture.md
+++ b/Docs/Examples/Alarm-Architecture.md
@@ -144,7 +144,10 @@ public:
 ```cpp
 uint32_t AlarmManager::execute(const std::tm& tmNow)
 {
-    checkAlarms(tmNow.tm_hour, tmNow.tm_min, tmNow.tm_wday, tmNow);
+    checkAlarms(static_cast<uint8_t>(tmNow.tm_hour),
+                static_cast<uint8_t>(tmNow.tm_min),
+                static_cast<uint8_t>(tmNow.tm_wday),
+                tmNow);
     uint32_t nextCheckMs = (60 - tmNow.tm_sec) * 1000;
     return nextCheckMs;
 }

--- a/Docs/Examples/Alarm-Architecture.md
+++ b/Docs/Examples/Alarm-Architecture.md
@@ -306,6 +306,7 @@ bool Model::customMessageHandler(SDK::MessageBase* msg)
         case CustomMessage::ALARM_LIST: {
             auto* m = static_cast<CustomMessage::AlarmList*>(msg);
             mAlarmList.assign(m->alarms, m->alarms + m->count);
+            mTimeFormat12h = m->timeFormat12h;
             modelListener->onAlarmListUpdated(mAlarmList);
         } break;
 

--- a/Docs/Examples/Alarm-Architecture.md
+++ b/Docs/Examples/Alarm-Architecture.md
@@ -480,6 +480,26 @@ struct ActivatedAlarm : public SDK::MessageBase {
 };
 ```
 
+`AlarmList` is the one worth reading closely, because the awkward part of the conversion lives in
+its constructor rather than at any call site. It takes a `std::vector<Alarm>` but stores a fixed
+array, so it clamps the count and copies element-wise — the caller just hands over the vector:
+
+```cpp
+explicit AlarmList(const std::vector<Alarm> &list, bool timeFormat12h = false)
+    : AlarmList()
+{
+    this->count = static_cast<uint8_t>(
+        list.size() < kMaxAlarms ? list.size() : kMaxAlarms);
+    for (uint8_t i = 0; i < this->count; ++i) {
+        this->alarms[i] = list[i];
+    }
+    this->timeFormat12h = timeFormat12h;
+}
+```
+
+`timeFormat12h` defaults to `false` because it is only meaningful Service → GUI; the GUI → Service
+direction leaves it alone and the service ignores it there.
+
 Sending is then one call in either direction. `SDK::send_msg<T>(kernel, args...)` allocates the message from the kernel pool, forwards `args...` to the constructor, sends it, and releases it, returning `false` if allocation or the send failed:
 
 ```cpp
@@ -494,7 +514,7 @@ SDK::send_msg<CustomMessage::AlarmStopAll>(mKernel);   // zero-field message
 
 There is no per-app sender class: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
 
-`send_msg` is for fire-and-forget sends. When the reply matters, use `SDK::make_msg<T>()` instead — it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read the result back. `refreshTimeFormat()` does exactly this to pick up the system clock format:
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters *or* when you need to wait for queue space: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. `refreshTimeFormat()` does exactly this to pick up the system clock format:
 
 ```cpp
 if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {

--- a/Docs/Examples/Alarm-Architecture.md
+++ b/Docs/Examples/Alarm-Architecture.md
@@ -54,11 +54,10 @@ public:
     void run();
 
 private:
-    SDK::Kernel&          mKernel;
-    bool                  mGuiStarted;
-    CustomMessage::Sender mGuiSender;
-    AlarmManager          mAlarmManager;
-    Alarm                 mActiveAlarm;
+    SDK::Kernel& mKernel;
+    bool         mGuiStarted;
+    AlarmManager mAlarmManager;
+    Alarm        mActiveAlarm;
     // ...
 };
 ```
@@ -404,8 +403,8 @@ The app implements automatic timeout to conserve battery:
 
 ```cpp
 Model::Model()
-    : mKernel(SDK::KernelProviderGUI::GetInstance().getKernel())
-    , mSrvSender(mKernel)
+    : modelListener(nullptr)
+    , mKernel(SDK::KernelProviderGUI::GetInstance().getKernel())
 {
     SDK::TouchGFXCommandProcessor::GetInstance().setAppLifeCycleCallback(this);
     SDK::TouchGFXCommandProcessor::GetInstance().setCustomMessageHandler(this);
@@ -444,7 +443,8 @@ constexpr SDK::MessageType::Type ALARM_SNOOZE_ALL = 0x00000007;
 struct AlarmList : public SDK::MessageBase {
     Alarm   alarms[kMaxAlarms];
     uint8_t count;
-    // sizeof = 32 (MessageBase) + 20*sizeof(Alarm) + 1 = 133 bytes → Pool 3 (256 bytes)
+    bool    timeFormat12h;  // Service -> GUI only; the GUI leaves it at the default
+    // sizeof = 32 (MessageBase) + 20*sizeof(Alarm) + 2 = 134 bytes → Pool 3 (256 bytes)
 };
 ```
 
@@ -459,28 +459,49 @@ struct AlarmList : public SDK::MessageBase {
 | `ALARM_STOP` / `ALARM_STOP_ALL` | GUI → Service | User taps Stop on `RingingView` |
 | `ALARM_SNOOZE` / `ALARM_SNOOZE_ALL` | GUI → Service | User taps Snooze on `RingingView` |
 
-### Message Sender
+### Sending Messages
 
-`CustomMessage::Sender` provides type-safe message sending for both directions. Each method allocates a typed message, fills fields, sends, and releases:
+Each message struct keeps a default constructor (which sets its message type) plus, where it has fields, a field-filling constructor that delegates to it:
 
 ```cpp
-class Sender {
-public:
-    Sender(const SDK::Kernel& kernel);
+struct ActivatedAlarm : public SDK::MessageBase {
+    Alarm alarm;
 
-    // Service <-> GUI
-    bool listUpd(const std::vector<Alarm>& list);
+    ActivatedAlarm()
+        : SDK::MessageBase(ACTIVATED_ALARM)
+        , alarm{}
+    {}
 
-    // Service --> GUI
-    bool alarmActivated(const Alarm& alarm);
-
-    // GUI --> Service
-    bool activateEffect(const Alarm& alarm);
-    bool stop(const Alarm& alarm);
-    bool stopAll();
-    bool snooze(const Alarm& alarm);
-    bool snoozeAll();
+    explicit ActivatedAlarm(const Alarm &alarm)
+        : ActivatedAlarm()
+    {
+        this->alarm = alarm;
+    }
 };
+```
+
+Sending is then one call in either direction. `SDK::send_msg<T>(kernel, args...)` allocates the message from the kernel pool, forwards `args...` to the constructor, sends it, and releases it, returning `false` if allocation or the send failed:
+
+```cpp
+// Service --> GUI
+SDK::send_msg<CustomMessage::ActivatedAlarm>(mKernel, alarm);
+SDK::send_msg<CustomMessage::AlarmList>(mKernel, list, mTimeFormat12h);
+
+// GUI --> Service
+SDK::send_msg<CustomMessage::AlarmActivateEffect>(mKernel, mActiveAlarm);
+SDK::send_msg<CustomMessage::AlarmStopAll>(mKernel);   // zero-field message
+```
+
+There is no per-app sender class: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
+
+`send_msg` is for fire-and-forget sends. When the reply matters, use `SDK::make_msg<T>()` instead — it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read the result back. `refreshTimeFormat()` does exactly this to pick up the system clock format:
+
+```cpp
+if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
+    if (msg.send(100) && msg.ok()) {
+        mTimeFormat12h = msg->timeFormat;
+    }
+}
 ```
 
 ## Build and Setup

--- a/Docs/Examples/Cycling-Architecture.md
+++ b/Docs/Examples/Cycling-Architecture.md
@@ -59,9 +59,8 @@ public:
     void run();
 
 private:
-    SDK::Kernel&          mKernel;
-    bool                  mGuiStarted;
-    CustomMessage::Sender mGuiSender;
+    SDK::Kernel& mKernel;
+    bool         mGuiStarted;
     // ... additional members
 };
 ```
@@ -177,7 +176,7 @@ void Service::processTrack() {
     mTrackData.pace = getPace(mTrackData.speed, mSpeedCounter.getMinValid());
 
     // Update GUI
-    mGuiSender.trackData(mTrackData);
+    SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
 
     // FIT file recording
     if (mTrackState == Track::State::ACTIVE) {
@@ -197,7 +196,7 @@ Each record is assembled from the current counter values and GPS state. Fields a
 
 **GPS Fix State Management**:
 
-Fix state changes are tracked via `mPreviousGpsFixState`. On every change the GUI is notified via `mGuiSender.fix()`. The very first acquired fix also triggers `notifyFirstFix()` — backlight on, buzzer pattern (150 ms × 3), and a strong vibro click:
+Fix state changes are tracked via `mPreviousGpsFixState`. On every change the GUI is notified with a `GpsFix` message. The very first acquired fix also triggers `notifyFirstFix()` — backlight on, buzzer pattern (150 ms × 3), and a strong vibro click:
 
 ```cpp
 if (mPreviousGpsFixState != mGps.fix) {
@@ -206,7 +205,7 @@ if (mPreviousGpsFixState != mGps.fix) {
         notifyFirstFix();
         firstFix = true;
     }
-    mGuiSender.fix(mGps.fix);
+    SDK::send_msg<CustomMessage::GpsFix>(mKernel, mGps.fix);
 }
 ```
 
@@ -680,6 +679,7 @@ constexpr SDK::MessageType::Type MANUAL_LAP     = 0x0000000F;
 struct SettingsUpd : public SDK::MessageBase {
     Settings settings;
     bool     unitsImperial;
+    bool     timeFormat12h;                     // true = 12-hour clock
     uint8_t  hrThresholds[kHrThresholdsCount];  // C-array of 6
     uint8_t  hrThresholdsCount;
 };
@@ -693,35 +693,58 @@ struct TrackDataUpd : public SDK::MessageBase {
 } // namespace CustomMessage
 ```
 
-#### Message Sender
+#### Sending Messages
 
-**`CustomMessage::Sender`** provides type-safe message sending from the service to the GUI. Each method allocates a typed message via `mKernel.comm.allocateMessage<>()`, fills its fields, sends it, and releases it, returning `bool`:
+Every message struct keeps a default constructor (which sets its message type) plus, where it has fields, a field-filling constructor that delegates to it. Anything unusual — a `memcpy`, a clamp, a bounded string copy — lives in that constructor rather than at the call site. For `SettingsUpd`, whose fields are listed above:
 
 ```cpp
-class Sender {
-public:
-    Sender(const SDK::Kernel& kernel);
+    SettingsUpd()
+        : SDK::MessageBase(SETTINGS_UPDATE)
+        , unitsImperial(false)
+        , timeFormat12h(false)
+        , hrThresholds {}
+        , hrThresholdsCount(0)
+    {}
 
-    // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
-                     const uint8_t (&thresholds)[kHrThresholdsCount],
-                     uint8_t thresholdCount);
-    bool time(std::tm localTime);
-    bool battery(uint8_t level);
-    bool fix(bool state);
-    bool trackState(Track::State state);
-    bool trackData(const Track::Data& data);
-    bool lapEnd(uint32_t lapNum);
-    bool summary(const ActivitySummary* summaryPtr);
+    explicit SettingsUpd(Settings settings, bool units, bool timeFormat12h,
+                         const uint8_t (&thresholds)[kHrThresholdsCount],
+                         uint8_t thresholdCount)
+        : SettingsUpd()
+    {
+        this->settings          = settings;
+        this->unitsImperial     = units;
+        this->timeFormat12h     = timeFormat12h;
+        memcpy(this->hrThresholds, thresholds, sizeof(this->hrThresholds));
+        this->hrThresholdsCount = thresholdCount;
+    }
+```
 
-    // GUI --> Service
-    bool settingsSave(Settings settings);
-    bool trackStart();
-    bool trackStop(bool discard);
-    bool trackPause();
-    bool trackResume();
-    bool manualLap();
-};
+Sending is then one call in either direction. `SDK::send_msg<T>(kernel, args...)` allocates the message from the kernel pool, forwards `args...` to the constructor, sends it, and releases it, returning `false` if allocation or the send failed:
+
+```cpp
+// Service --> GUI
+SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
+SDK::send_msg<CustomMessage::LapEnded>(mKernel, mTrackData.lapNum);
+SDK::send_msg<CustomMessage::SettingsUpd>(mKernel, mSettings, mIsImperial,
+                                          mTimeFormat12h, hrThresholds, hrThresholdsCount);
+
+// GUI --> Service
+SDK::send_msg<CustomMessage::TrackStop>(mKernel, /* discard */ true);
+SDK::send_msg<CustomMessage::ManualLap>(mKernel);   // zero-field message
+```
+
+There is no per-app sender class to write: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
+
+`send_msg` is for fire-and-forget sends. When the reply matters, use `SDK::make_msg<T>()` instead — it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read the result back. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
+
+```cpp
+if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
+    if (msg.send(100) && msg.ok()) {
+        mIsImperial    = msg->imperialUnits;
+        mTimeFormat12h = msg->timeFormat;
+        // ... copy the HR zone thresholds ...
+    }
+}
 ```
 
 ### Asset Management

--- a/Docs/Examples/Cycling-Architecture.md
+++ b/Docs/Examples/Cycling-Architecture.md
@@ -735,7 +735,7 @@ SDK::send_msg<CustomMessage::ManualLap>(mKernel);   // zero-field message
 
 There is no per-app sender class to write: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
 
-`send_msg` is for fire-and-forget sends. When the reply matters, use `SDK::make_msg<T>()` instead — it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read the result back. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters *or* when you need to wait for queue space: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
 
 ```cpp
 if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {

--- a/Docs/Examples/HRMonitor-Architecture.md
+++ b/Docs/Examples/HRMonitor-Architecture.md
@@ -57,9 +57,8 @@ private:
     static constexpr uint32_t skSampleLatency = 2000;
 
     // -- Infrastructure ---
-    SDK::Kernel&          mKernel;
-    bool                  mGuiStarted;
-    CustomMessage::Sender mGuiSender;
+    SDK::Kernel& mKernel;
+    bool         mGuiStarted;
 
     // -- Sensors ---
     SDK::Sensor::Connection mSensorHr;
@@ -98,7 +97,7 @@ void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)
             if (parser.isDataValid()) {
                 mHr   = parser.getBpm();
                 mHrTl = parser.getTrustLevel();
-                mGuiSender.heartRate(mHr, mHrTl);
+                SDK::send_msg<CustomMessage::HRValues>(mKernel, mHr, mHrTl);
             }
         }
     }
@@ -324,10 +323,19 @@ struct HRValues : public SDK::MessageBase {
         , heartRate(0.0f)
         , trustLevel(0.0f)
     {}
+
+    explicit HRValues(float heartRate, float trustLevel)
+        : HRValues()
+    {
+        this->heartRate  = heartRate;
+        this->trustLevel = trustLevel;
+    }
 };
 
 } // namespace CustomMessage
 ```
+
+Each message keeps a default constructor (which sets its message type) and a field-filling constructor that delegates to it. The field-filling constructor is what makes the one-line send below possible.
 
 **Message summary**:
 
@@ -335,22 +343,17 @@ struct HRValues : public SDK::MessageBase {
 |---------|-----------|---------|
 | `HR_VALUES` | Service -> GUI | Every valid sensor reading while `mGuiStarted` is true; also once on GUI start with (0.0, 0.0) |
 
-### Message Sender
+### Sending Messages
 
-`CustomMessage::Sender` provides type-safe message sending from the service to the GUI. It uses the `allocateMessage` / `sendMessage` / `releaseMessage` pattern:
+Fire-and-forget sends go through `SDK::send_msg<T>()`, which allocates the message from the kernel pool, forwards its arguments to the message's constructor, sends it, and releases it — returning `false` if allocation or the send failed:
 
 ```cpp
-class Sender {
-public:
-    Sender(const SDK::Kernel& kernel);
-
-    // Service --> GUI
-    bool heartRate(float value, float trustLevel);
-
-private:
-    const SDK::Kernel& mKernel;
-};
+SDK::send_msg<CustomMessage::HRValues>(mKernel, mHr, mHrTl);
 ```
+
+There is no per-app sender class to write: the message type carries the field-filling constructor and `send_msg` supplies the rest. That is the only send this app needs — every HRMonitor message is fire-and-forget.
+
+When the reply matters, `SDK::make_msg<T>()` is the counterpart: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read the result back (`msg.send(timeout) && msg.ok()`). The Cycling, Hiking, Running, and Alarm services use it that way to query `SDK::Message::RequestSystemSettings` — see [Cycling](Cycling-Architecture.md#sending-messages) for a worked example.
 
 ## Build and Setup
 
@@ -407,7 +410,7 @@ una_app_build_app()
 **App Libraries** (`Libs/`):
 - `Service` — service entry point, sensor handling, FIT recording coordination
 - `ActivityWriter` — FIT file lifecycle management
-- `Commands.hpp` — shared message types and `Sender` class
+- `Commands.hpp` — shared message types for the service↔GUI contract
 
 ### Development Setup
 

--- a/Docs/Examples/HRMonitor-Architecture.md
+++ b/Docs/Examples/HRMonitor-Architecture.md
@@ -351,7 +351,7 @@ Fire-and-forget sends go through `SDK::send_msg<T>()`, which allocates the messa
 SDK::send_msg<CustomMessage::HRValues>(mKernel, mHr, mHrTl);
 ```
 
-There is no per-app sender class to write: the message type carries the field-filling constructor and `send_msg` supplies the rest. That is the only send this app needs — every HRMonitor message is fire-and-forget.
+There is no per-app sender class to write: the message type carries the field-filling constructor and `send_msg` supplies the rest. That is the only send this app needs — every HRMonitor message is fire-and-forget, and `send_msg` posts with a zero timeout, so a full queue drops the sample rather than waiting for room. That is the right trade here: the next reading is a second away.
 
 When the reply matters, `SDK::make_msg<T>()` is the counterpart: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read the result back (`msg.send(timeout) && msg.ok()`). The Cycling, Hiking, Running, and Alarm services use it that way to query `SDK::Message::RequestSystemSettings` — see [Cycling](Cycling-Architecture.md#sending-messages) for a worked example.
 

--- a/Docs/Examples/Hiking-Architecture.md
+++ b/Docs/Examples/Hiking-Architecture.md
@@ -737,7 +737,7 @@ SDK::send_msg<CustomMessage::ManualLap>(mKernel);   // zero-field message
 
 There is no per-app sender class to write: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
 
-`send_msg` is for fire-and-forget sends. When the reply matters, use `SDK::make_msg<T>()` instead — it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read the result back. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters *or* when you need to wait for queue space: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
 
 ```cpp
 if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {

--- a/Docs/Examples/Hiking-Architecture.md
+++ b/Docs/Examples/Hiking-Architecture.md
@@ -60,9 +60,8 @@ public:
     void run();
 
 private:
-    SDK::Kernel&          mKernel;
-    bool                  mGUIStarted;
-    CustomMessage::Sender mGuiSender;
+    SDK::Kernel& mKernel;
+    bool         mGUIStarted;
     // ... additional members
 };
 ```
@@ -180,7 +179,7 @@ void Service::processTrack() {
     mTrackData.pace = getPace(mTrackData.speed, mSpeedCounter.getMinValid());
 
     // Update GUI
-    mGuiSender.trackData(mTrackData);
+    SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
 
     // FIT file recording
     if (mTrackState == Track::State::ACTIVE) {
@@ -200,7 +199,7 @@ Each record is assembled from the current counter values and GPS state. Fields a
 
 **GPS Fix State Management**:
 
-Fix state changes are tracked via `mPreviousGpsFixState`. On every change the GUI is notified via `mGuiSender.fix()`. The very first acquired fix also triggers `notifyFirstFix()` — backlight on, buzzer pattern (150 ms × 3), and a strong vibro click:
+Fix state changes are tracked via `mPreviousGpsFixState`. On every change the GUI is notified with a `GpsFix` message. The very first acquired fix also triggers `notifyFirstFix()` — backlight on, buzzer pattern (150 ms × 3), and a strong vibro click:
 
 ```cpp
 if (mPreviousGpsFixState != mGps.fix) {
@@ -209,7 +208,7 @@ if (mPreviousGpsFixState != mGps.fix) {
         notifyFirstFix();
         firstFix = true;
     }
-    mGuiSender.fix(mGps.fix);
+    SDK::send_msg<CustomMessage::GpsFix>(mKernel, mGps.fix);
 }
 ```
 
@@ -682,6 +681,7 @@ constexpr SDK::MessageType::Type MANUAL_LAP     = 0x0000000F;
 struct SettingsUpd : public SDK::MessageBase {
     Settings settings;
     bool     unitsImperial;
+    bool     timeFormat12h;                     // true = 12-hour clock
     uint8_t  hrThresholds[kHrThresholdsCount];  // C-array of 6
     uint8_t  hrThresholdsCount;
 };
@@ -695,35 +695,58 @@ struct TrackDataUpd : public SDK::MessageBase {
 } // namespace CustomMessage
 ```
 
-#### Message Sender
+#### Sending Messages
 
-**`CustomMessage::Sender`** provides type-safe message sending from the service to the GUI. Each method allocates a typed message via `mKernel.comm.allocateMessage<>()`, fills its fields, sends it, and releases it, returning `bool`:
+Every message struct keeps a default constructor (which sets its message type) plus, where it has fields, a field-filling constructor that delegates to it. Anything unusual — a `memcpy`, a clamp, a bounded string copy — lives in that constructor rather than at the call site. For `SettingsUpd`, whose fields are listed above:
 
 ```cpp
-class Sender {
-public:
-    Sender(const SDK::Kernel& kernel);
+    SettingsUpd()
+        : SDK::MessageBase(SETTINGS_UPDATE)
+        , unitsImperial(false)
+        , timeFormat12h(false)
+        , hrThresholds {}
+        , hrThresholdsCount(0)
+    {}
 
-    // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
-                     const uint8_t (&thresholds)[kHrThresholdsCount],
-                     uint8_t thresholdCount);
-    bool time(std::tm localTime);
-    bool battery(uint8_t level);
-    bool fix(bool state);
-    bool trackState(Track::State state);
-    bool trackData(const Track::Data& data);
-    bool lapEnd(uint32_t lapNum);
-    bool summary(const ActivitySummary* summaryPtr);
+    explicit SettingsUpd(Settings settings, bool units, bool timeFormat12h,
+                         const uint8_t (&thresholds)[kHrThresholdsCount],
+                         uint8_t thresholdCount)
+        : SettingsUpd()
+    {
+        this->settings          = settings;
+        this->unitsImperial     = units;
+        this->timeFormat12h     = timeFormat12h;
+        memcpy(this->hrThresholds, thresholds, sizeof(this->hrThresholds));
+        this->hrThresholdsCount = thresholdCount;
+    }
+```
 
-    // GUI --> Service
-    bool settingsSave(Settings settings);
-    bool trackStart();
-    bool trackStop(bool discard);
-    bool trackPause();
-    bool trackResume();
-    bool manualLap();
-};
+Sending is then one call in either direction. `SDK::send_msg<T>(kernel, args...)` allocates the message from the kernel pool, forwards `args...` to the constructor, sends it, and releases it, returning `false` if allocation or the send failed:
+
+```cpp
+// Service --> GUI
+SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
+SDK::send_msg<CustomMessage::LapEnded>(mKernel, mTrackData.lapNum);
+SDK::send_msg<CustomMessage::SettingsUpd>(mKernel, mSettings, mIsImperial,
+                                          mTimeFormat12h, hrThresholds, hrThresholdsCount);
+
+// GUI --> Service
+SDK::send_msg<CustomMessage::TrackStop>(mKernel, /* discard */ true);
+SDK::send_msg<CustomMessage::ManualLap>(mKernel);   // zero-field message
+```
+
+There is no per-app sender class to write: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
+
+`send_msg` is for fire-and-forget sends. When the reply matters, use `SDK::make_msg<T>()` instead — it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read the result back. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
+
+```cpp
+if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
+    if (msg.send(100) && msg.ok()) {
+        mIsImperial    = msg->imperialUnits;
+        mTimeFormat12h = msg->timeFormat;
+        // ... copy the HR zone thresholds ...
+    }
+}
 ```
 
 ### Asset Management

--- a/Docs/Examples/Hiking-Architecture.md
+++ b/Docs/Examples/Hiking-Architecture.md
@@ -61,7 +61,7 @@ public:
 
 private:
     SDK::Kernel& mKernel;
-    bool         mGUIStarted;
+    bool         mGuiStarted;
     // ... additional members
 };
 ```

--- a/Docs/Examples/Running-Architecture.md
+++ b/Docs/Examples/Running-Architecture.md
@@ -62,9 +62,8 @@ public:
     void run();
 
 private:
-    SDK::Kernel&          mKernel;
-    bool                  mGuiStarted;
-    CustomMessage::Sender mGuiSender;
+    SDK::Kernel& mKernel;
+    bool         mGuiStarted;
     // ... additional members
 };
 ```
@@ -202,7 +201,7 @@ void Service::processTrack() {
     mTrackData.pace = getPace(mTrackData.speed, mSpeedCounter.getMinValid());
 
     // Update GUI
-    mGuiSender.trackData(mTrackData);
+    SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
 
     // FIT file recording
     if (mTrackState == Track::State::ACTIVE) {
@@ -227,7 +226,7 @@ Each record is assembled from the current counter values and GPS state. Fields a
 
 **GPS Fix State Management**:
 
-Fix state changes are tracked via `mPreviousGpsFixState`. On every change the GUI is notified via `mGuiSender.fix()`. The very first acquired fix also triggers `notifyFirstFix()` — backlight on, buzzer pattern (150 ms × 3), and a strong vibro click:
+Fix state changes are tracked via `mPreviousGpsFixState`. On every change the GUI is notified with a `GpsFix` message. The very first acquired fix also triggers `notifyFirstFix()` — backlight on, buzzer pattern (150 ms × 3), and a strong vibro click:
 
 ```cpp
 if (mPreviousGpsFixState != mGps.fix) {
@@ -236,7 +235,7 @@ if (mPreviousGpsFixState != mGps.fix) {
         notifyFirstFix();
         firstFix = true;
     }
-    mGuiSender.fix(mGps.fix);
+    SDK::send_msg<CustomMessage::GpsFix>(mKernel, mGps.fix);
 }
 ```
 
@@ -326,8 +325,8 @@ mPhaseStartActiveDist = mDistanceCounter.getValueActive();
 #### Interval Phase Notifications
 
 On every phase change, `onIntervalsPhaseChange(bool alert, bool manual)` is called:
-- If `alert` is true, `mGuiSender.intervalsPhaseAlert(mTrackData.intervals)` sends an `INTERVALS_PHASE_ALERT` message to the GUI, which navigates to `TrackIntervalsAlertView` and shows a countdown timer before returning to the track screen.
-- When the entire workout is complete (all repeats done and `COOL_DOWN` phase ended or skipped), `mGuiSender.intervalsWorkoutCompleted()` sends `INTERVALS_WORKOUT_COMPLETED` and sets `mIntervalsCompleted = true` to block further phase processing.
+- If `alert` is true, `SDK::send_msg<CustomMessage::IntervalsPhaseAlert>(mKernel, mTrackData.intervals)` sends an `INTERVALS_PHASE_ALERT` message to the GUI, which navigates to `TrackIntervalsAlertView` and shows a countdown timer before returning to the track screen.
+- When the entire workout is complete (all repeats done and `COOL_DOWN` phase ended or skipped), `SDK::send_msg<CustomMessage::IntervalsWorkoutCompleted>(mKernel)` sends `INTERVALS_WORKOUT_COMPLETED` and sets `mIntervalsCompleted = true` to block further phase processing.
 
 ### WristTiltDetector
 
@@ -833,6 +832,7 @@ constexpr SDK::MessageType::Type INTERVALS_NEXT_PHASE = 0x00000011;
 struct SettingsUpd : public SDK::MessageBase {
     Settings settings;
     bool     unitsImperial;
+    bool     timeFormat12h;                     // true = 12-hour clock
     uint8_t  hrThresholds[kHrThresholdsCount];  // C-array of 6
     uint8_t  hrThresholdsCount;
 };
@@ -858,38 +858,58 @@ struct IntervalsNextPhase : public SDK::MessageBase {};
 } // namespace CustomMessage
 ```
 
-#### Message Sender
+#### Sending Messages
 
-**`CustomMessage::Sender`** provides type-safe message sending from the service to the GUI. Each method allocates a typed message via `mKernel.comm.allocateMessage<>()`, fills its fields, sends it, and releases it, returning `bool`:
+Every message struct keeps a default constructor (which sets its message type) plus, where it has fields, a field-filling constructor that delegates to it. Anything unusual — a `memcpy`, a clamp, a bounded string copy — lives in that constructor rather than at the call site:
 
 ```cpp
-class Sender {
-public:
-    Sender(const SDK::Kernel& kernel);
+struct AccessoryStatusUpd : public SDK::MessageBase {
+    uint8_t state;     ///< SDK::Accessory::State
+    char    name[24];  ///< device name (may be empty)
 
-    // Service --> GUI
-    bool settingsUpd(Settings settings, bool units,
-                     const uint8_t (&thresholds)[kHrThresholdsCount],
-                     uint8_t thresholdCount);
-    bool time(std::tm localTime);
-    bool battery(uint8_t level);
-    bool fix(bool state);
-    bool trackState(Track::State state);
-    bool trackData(const Track::Data& data);
-    bool lapEnd(uint32_t lapNum);
-    bool summary(const ActivitySummary* summaryPtr);
-    bool intervalsPhaseAlert(const Track::IntervalsData& intervals);
-    bool intervalsWorkoutCompleted();
+    AccessoryStatusUpd()
+        : SDK::MessageBase(ACCESSORY_STATUS)
+        , state(0)
+        , name{}
+    {}
 
-    // GUI --> Service
-    bool settingsSave(Settings settings);
-    bool trackStart(bool intervalsMode);
-    bool trackStop(bool discard);
-    bool trackPause();
-    bool trackResume();
-    bool manualLap();
-    bool intervalsNextPhase();
+    explicit AccessoryStatusUpd(uint8_t state, const char* name)
+        : AccessoryStatusUpd()
+    {
+        this->state = state;
+        if (name) {
+            strncpy(this->name, name, sizeof(this->name) - 1);
+        }
+    }
 };
+```
+
+Sending is then one call in either direction. `SDK::send_msg<T>(kernel, args...)` allocates the message from the kernel pool, forwards `args...` to the constructor, sends it, and releases it, returning `false` if allocation or the send failed:
+
+```cpp
+// Service --> GUI
+SDK::send_msg<CustomMessage::TrackDataUpd>(mKernel, mTrackData);
+SDK::send_msg<CustomMessage::IntervalsPhaseAlert>(mKernel, mTrackData.intervals);
+SDK::send_msg<CustomMessage::SettingsUpd>(mKernel, mSettings, mIsImperial, mTimeFormat12h,
+                                          hrThresholds, CustomMessage::kHrThresholdsCount);
+
+// GUI --> Service
+SDK::send_msg<CustomMessage::TrackStart>(mKernel, intervalsMode);
+SDK::send_msg<CustomMessage::IntervalsNextPhase>(mKernel);   // zero-field message
+```
+
+There is no per-app sender class to write: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
+
+`send_msg` is for fire-and-forget sends. When the reply matters, use `SDK::make_msg<T>()` instead — it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read the result back. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
+
+```cpp
+if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {
+    if (msg.send(100) && msg.ok()) {
+        mIsImperial    = msg->imperialUnits;
+        mTimeFormat12h = msg->timeFormat;
+        // ... copy the HR zone thresholds ...
+    }
+}
 ```
 
 ### Asset Management

--- a/Docs/Examples/Running-Architecture.md
+++ b/Docs/Examples/Running-Architecture.md
@@ -900,7 +900,7 @@ SDK::send_msg<CustomMessage::IntervalsNextPhase>(mKernel);   // zero-field messa
 
 There is no per-app sender class to write: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
 
-`send_msg` is for fire-and-forget sends. When the reply matters, use `SDK::make_msg<T>()` instead — it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read the result back. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters *or* when you need to wait for queue space: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
 
 ```cpp
 if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {

--- a/Docs/TouchGFX-Port-Architecture.md
+++ b/Docs/TouchGFX-Port-Architecture.md
@@ -808,7 +808,7 @@ public:
 ```cpp
 // In Service (Backend)
 void Service::sendHeartRateUpdate(uint16_t bpm) {
-    SDK::send_msg<HeartRateMessage>(*kernel, bpm);
+    SDK::send_msg<HeartRateMessage>(*kernel, bpm, getCurrentTime());
 }
 
 // In Model (GUI)

--- a/Docs/TouchGFX-Port-Architecture.md
+++ b/Docs/TouchGFX-Port-Architecture.md
@@ -926,15 +926,22 @@ struct WorkoutCommand : public SDK::MessageBase {
 ```
 
 #### Service-Side Message Sending
+
+Because each message fills its own fields in its constructor, sending one is a single call:
+`SDK::send_msg<T>(kernel, args...)` allocates the message, forwards `args...` to the constructor,
+sends it, and releases it — returning `false` if allocation or the send failed. Apps do not need a
+sender class of their own.
+
+Return the `bool` rather than swallowing it, so the caller can decide. For periodic telemetry the
+caller usually ignores it — a dropped heart-rate sample is superseded a second later, and the
+example apps do exactly that. A dropped reply to a request is not self-correcting, so those sends
+are worth checking (see the request-response pattern below).
+
 ```cpp
 class FitnessService {
 public:
-    void sendHeartRateUpdate(uint16_t bpm) {
-        auto msg = mKernel.comm.allocateMessage<HeartRateMessage>(bpm, getCurrentTime());
-        if (msg) {
-            mKernel.comm.sendMessage(msg, 100); // 100ms timeout
-            mKernel.comm.releaseMessage(msg);
-        }
+    bool sendHeartRateUpdate(uint16_t bpm) {
+        return SDK::send_msg<HeartRateMessage>(mKernel, bpm, getCurrentTime());
     }
 
     void handleWorkoutCommand(WorkoutCommand::Action action) {
@@ -1008,9 +1015,10 @@ struct ConfigurationResponse : public MessageBase {
 // Service implementation
 void Service::handleConfigRequest(ConfigurationRequest* req) {
     std::string value = getConfigurationValue(req->type);
-    auto response = allocateMessage<ConfigurationResponse>(req->type, value);
-    comm.sendMessage(response);
-    releaseMessage(response);
+    if (!SDK::send_msg<ConfigurationResponse>(mKernel, req->type, value)) {
+        // Nothing retries this for us: the requester will block until it times out.
+        Logger::error("Config response for type %d dropped", static_cast<int>(req->type));
+    }
 }
 ```
 

--- a/Docs/TouchGFX-Port-Architecture.md
+++ b/Docs/TouchGFX-Port-Architecture.md
@@ -808,8 +808,7 @@ public:
 ```cpp
 // In Service (Backend)
 void Service::sendHeartRateUpdate(uint16_t bpm) {
-    auto msg = make_msg<HeartRateMessage>(bpm);
-    kernel->comm.sendMessage(msg);
+    SDK::send_msg<HeartRateMessage>(*kernel, bpm);
 }
 
 // In Model (GUI)
@@ -936,6 +935,16 @@ Return the `bool` rather than swallowing it, so the caller can decide. For perio
 caller usually ignores it — a dropped heart-rate sample is superseded a second later, and the
 example apps do exactly that. A dropped reply to a request is not self-correcting, so those sends
 are worth checking (see the request-response pattern below).
+
+Note that `send_msg` posts with a **zero timeout**: if the message queue is full it gives up
+immediately rather than waiting for room. That suits telemetry, but when you need to wait for queue
+space — or to read a reply — use `SDK::make_msg<T>` and send it yourself with an explicit timeout:
+
+```cpp
+if (auto msg = SDK::make_msg<HeartRateMessage>(mKernel, bpm, getCurrentTime())) {
+    msg.send(100);  // wait up to 100 ms for queue space
+}
+```
 
 ```cpp
 class FitnessService {

--- a/Docs/TouchGFX-Port-Architecture.md
+++ b/Docs/TouchGFX-Port-Architecture.md
@@ -807,8 +807,8 @@ public:
 #### Service Layer Communication
 ```cpp
 // In Service (Backend)
-void Service::sendHeartRateUpdate(uint16_t bpm) {
-    SDK::send_msg<HeartRateMessage>(*kernel, bpm, getCurrentTime());
+bool Service::sendHeartRateUpdate(uint16_t bpm) {
+    return SDK::send_msg<HeartRateMessage>(*kernel, bpm, getCurrentTime());
 }
 
 // In Model (GUI)


### PR DESCRIPTION
Addresses docs half of the issue in #235 without fully resolving.

#219 retired `CustomMessage::Sender` in favor of the `make_msg` implementation so that a new app would have less to
copy/paste. Each doc now draws its struct and its call sites from its own app instead of sketching a generic sender, so the examples break visibly if the app changes. `make_msg` is called out for the request/response case because `send_msg` discards the reply, and reaching for the wrong one fails silently.

Also adds `bool timeFormat12h` to the `SettingsUpd` listings, which never had it (everything is moving so fast!)

Stopwatch and the Sensors/Files tutorials still have live senders - the latter named `GUISender`, which is why #219's sweep missed them. Leaving that for a separate PR so as to not couple docs change with code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated architecture examples for alarm, cycling, heart-rate, hiking, running, and TouchGFX integrations.
  - Clarified typed messaging patterns for notifications and request/response interactions, including delivery status, timeouts, failures, and cleanup.
  - Added guidance for 12-hour time-format settings.
  - Updated examples covering alarm, heart-rate, GPS, track, interval, and settings messages.
  - Improved documentation of message construction, field initialization, and handling of configuration responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->