### PR TITLE
refactor(examples): retire the remaining per-app senders

### DIFF
--- a/Docs/Examples/Stopwatch-Architecture.md
+++ b/Docs/Examples/Stopwatch-Architecture.md
@@ -56,10 +56,9 @@ public:
     void run();
 
 private:
-    SDK::Kernel           &mKernel;
-    CustomMessage::Sender  mSender;
-    Stopwatch::Core        mStopwatch;
-    bool                   mGuiStarted;
+    SDK::Kernel     &mKernel;
+    Stopwatch::Core  mStopwatch;
+    bool             mGuiStarted;
 
     void handleCommand(SDK::MessageBase *msg);
     void publish();
@@ -178,7 +177,22 @@ static_assert(sizeof(StopwatchState) <= 256,
               "StopwatchState must fit the largest kernel message pool block");
 ```
 
-The remaining messages are empty commands. A `Sender` helper allocates, fills, sends, and releases each message for both directions.
+`StopwatchState` also carries a constructor that fills the snapshot, so publishing is a single call:
+
+```cpp
+SDK::send_msg<CustomMessage::StopwatchState>(mKernel, mStopwatch.state());
+```
+
+The remaining messages are empty commands, which need no arguments at all — the
+GUI sends them the same way:
+
+```cpp
+bool startStopwatch() { return SDK::send_msg<CustomMessage::StopwatchStart>(mKernel); }
+```
+
+`SDK::send_msg<T>` allocates the message from the kernel pool, forwards any arguments to the
+message's constructor, sends it, and releases it, returning `false` if allocation or the send
+failed. There is no per-app sender class.
 
 **Message summary**:
 
@@ -330,7 +344,7 @@ una_app_build_app()
 
 **App Libraries** (`Libs/`):
 - `Stopwatch.hpp` — state struct, timekeeping arithmetic, and the `Core` transition logic (header-only, host-testable)
-- `Commands.hpp` — the service↔GUI message contract and `Sender`
+- `Commands.hpp` — the service↔GUI message contract
 - `Service` — the service entry point and message loop
 
 ### Host Tests

--- a/Docs/Tutorials/Files/ARCHITECTURE.md
+++ b/Docs/Tutorials/Files/ARCHITECTURE.md
@@ -174,9 +174,6 @@ private:
     CustomMessage::ActivityType mActivityType;
     CustomMessage::DisplayMode mDisplayMode;
 
-    // Communication
-    CustomMessage::GUISender mSender;
-
     // Methods
     void loadSettings();
     void saveSettings();
@@ -260,9 +257,10 @@ The Service's main loop processes custom messages:
 ```cpp
 case CustomMessage::GET_SETTINGS: {
     LOG_INFO("Received GET_SETTINGS request\n");
-    mSender.updateSettings(mDecimalCounter,
-                          static_cast<int>(mActivityType),
-                          static_cast<int>(mDisplayMode));
+    SDK::send_msg<CustomMessage::SettingsValues>(
+        mKernel, mDecimalCounter,
+        static_cast<int>(mActivityType),
+        static_cast<int>(mDisplayMode));
 } break;
 
 case CustomMessage::SET_SETTINGS: {
@@ -296,20 +294,22 @@ The GUI follows TouchGFX's MVP pattern:
 
 ```cpp
 void Model::requestSettings() {
-    if (auto req = SDK::make_msg<CustomMessage::GetSettings>(mKernel)) {
-        req.send();
-    }
+    SDK::send_msg<CustomMessage::GetSettings>(mKernel);
 }
 
 void Model::updateSettings(float decimalCounter, CustomMessage::ActivityType activityType, CustomMessage::DisplayMode displayMode) {
-    if (auto req = SDK::make_msg<CustomMessage::SetSettings>(mKernel)) {
-        req->decimalCounter = static_cast<int>(decimalCounter * 10);  // Convert to int
-        req->activityType = static_cast<int>(activityType);
-        req->displayMode = static_cast<int>(displayMode);
-        req.send();
-    }
+    SDK::send_msg<CustomMessage::SetSettings>(mKernel,
+                                             static_cast<int>(decimalCounter * 10),  // Convert to int
+                                             static_cast<int>(activityType),
+                                             static_cast<int>(displayMode));
 }
 ```
+
+`SDK::send_msg<T>(kernel, args...)` allocates the message from the kernel pool, forwards `args...`
+to the message's constructor, sends it, and releases it — returning `false` if allocation or the
+send failed. Each message fills its own fields in that constructor, so there is no sender class to
+write. Use `SDK::make_msg<T>` instead when you need to inspect a reply (`msg.send(timeout) &&
+msg.ok()`).
 
 #### Message Receiving
 

--- a/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -3,6 +3,7 @@
 #include <gui/common/FrontendApplication.hpp>
 
 #include "SDK/Kernel/KernelProviderGUI.hpp"
+#include "SDK/Messages/MessageGuard.hpp"
 #include "SDK/Port/TouchGFX/TouchGFXCommandProcessor.hpp"
 
 #define LOG_MODULE_PRX      "Model"
@@ -79,19 +80,15 @@ void Model::exitApp()
 
 void Model::requestSettings()
 {
-    if (auto req = SDK::make_msg<CustomMessage::GetSettings>(mKernel)) {
-        req.send();
-    }
+    SDK::send_msg<CustomMessage::GetSettings>(mKernel);
 }
 
 void Model::updateSettings(float decimalCounter, CustomMessage::ActivityType activityType, CustomMessage::DisplayMode displayMode)
 {
-    if (auto req = SDK::make_msg<CustomMessage::SetSettings>(mKernel)) {
-        req->decimalCounter = static_cast<int>(decimalCounter * 10);
-        req->activityType = static_cast<int>(activityType);
-        req->displayMode = static_cast<int>(displayMode);
-        req.send();
-    }
+    SDK::send_msg<CustomMessage::SetSettings>(mKernel,
+                                             static_cast<int>(decimalCounter * 10),
+                                             static_cast<int>(activityType),
+                                             static_cast<int>(displayMode));
 }
 
 // IUserApp implementation

--- a/Docs/Tutorials/Files/Software/Libs/Header/Commands.hpp
+++ b/Docs/Tutorials/Files/Software/Libs/Header/Commands.hpp
@@ -4,8 +4,6 @@
 #include "SDK/Messages/MessageBase.hpp"
 #include "SDK/Messages/MessageTypes.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
-#include "SDK/Messages/MessageGuard.hpp"
-#include "SDK/Kernel/Kernel.hpp"
 
 #include <array>
 
@@ -59,7 +57,9 @@ namespace CustomMessage {
     /*
      * HRValues Message Struct:
      * - Inherits from SDK::MessageBase for SDK messaging
-     * - Constructor initializes message type to HR_VALUES
+     * - The default constructor sets the message type to HR_VALUES
+     * - A second constructor fills the fields and delegates to the first, which
+     *   is what lets a caller send it in one line with SDK::send_msg
      * - Contains HR data: heartRate (BPM) and trustLevel (0.0-1.0)
      */
     // struct HRValues : public SDK::MessageBase {
@@ -71,6 +71,13 @@ namespace CustomMessage {
     //         , heartRate()
     //         , trustLevel()
     //     {}
+
+    //     explicit HRValues(float heartRate, float trustLevel)
+    //         : HRValues()
+    //     {
+    //         this->heartRate  = heartRate;
+    //         this->trustLevel = trustLevel;
+    //     }
     // };
 
     // GUI --> Service
@@ -92,6 +99,14 @@ namespace CustomMessage {
             , activityType(0)
             , displayMode(0)
         {}
+
+        explicit SetSettings(int decimalCounter, int activityType, int displayMode)
+            : SetSettings()
+        {
+            this->decimalCounter = decimalCounter;
+            this->activityType   = activityType;
+            this->displayMode    = displayMode;
+        }
     };
 
     // Service --> GUI
@@ -106,57 +121,16 @@ namespace CustomMessage {
             , activityType(0)
             , displayMode(0)
         {}
-    };
 
-
-    ///////////////////////////////////////
-    //// Wrappers
-    ///////////////////////////////////////
-
-    class GUISender {
-    public:
-        GUISender(const SDK::Kernel& kernel) : mKernel(kernel)
-        {}
-
-        virtual ~GUISender() = default;
-
-        // Service --> GUI
-        /*
-         * updateHeartRate Method:
-         * - Creates and sends HR update message to GUI
-         * - Uses SDK::make_msg to allocate message from kernel pool
-         * - Returns true if message sent successfully
-         * - Automatically cleaned up by SDK after delivery
-         */
-        // bool updateHeartRate(float value, float trustLevel)
-        // {
-        //     if (auto req = SDK::make_msg<CustomMessage::HRValues>(mKernel)) {
-        //         req->heartRate  = value;
-        //         req->trustLevel = trustLevel;
-
-        //         return req.send();  // Send to GUI via SDK messaging
-        //     }
-
-        //     return false;
-        // }
-
-        // Service --> GUI
-        bool updateSettings(int decimalCounter, int activityType, int displayMode)
+        explicit SettingsValues(int32_t decimalCounter, int activityType, int displayMode)
+            : SettingsValues()
         {
-            if (auto req = SDK::make_msg<CustomMessage::SettingsValues>(mKernel)) {
-                req->decimalCounter = decimalCounter;
-                req->activityType = activityType;
-                req->displayMode = displayMode;
-
-                return req.send();
-            }
-
-            return false;
+            this->decimalCounter = decimalCounter;
+            this->activityType   = activityType;
+            this->displayMode    = displayMode;
         }
-
-    private:
-        const SDK::Kernel& mKernel;
     };
+
 
 } // namespace CustomMessage
 

--- a/Docs/Tutorials/Files/Software/Libs/Header/Commands.hpp
+++ b/Docs/Tutorials/Files/Software/Libs/Header/Commands.hpp
@@ -6,6 +6,7 @@
 #include "SDK/Messages/CommandMessages.hpp"
 
 #include <array>
+#include <cstdint>
 
 // Force 4-byte alignment for all message structures
 #pragma pack(push, 4)
@@ -89,7 +90,7 @@ namespace CustomMessage {
 
     // GUI --> Service
     struct SetSettings : public SDK::MessageBase {
-        int decimalCounter;
+        int32_t decimalCounter;
         int activityType;
         int displayMode;
 
@@ -100,7 +101,7 @@ namespace CustomMessage {
             , displayMode(0)
         {}
 
-        explicit SetSettings(int decimalCounter, int activityType, int displayMode)
+        explicit SetSettings(int32_t decimalCounter, int activityType, int displayMode)
             : SetSettings()
         {
             this->decimalCounter = decimalCounter;
@@ -130,7 +131,6 @@ namespace CustomMessage {
             this->displayMode    = displayMode;
         }
     };
-
 
 } // namespace CustomMessage
 

--- a/Docs/Tutorials/Files/Software/Libs/Header/Service.hpp
+++ b/Docs/Tutorials/Files/Software/Libs/Header/Service.hpp
@@ -22,7 +22,6 @@ public:
 
 private:
     SDK::Kernel&             mKernel;
-    CustomMessage::GUISender mSender;
     bool                     mGUIStarted;
     // Settings
     int32_t                  mDecimalCounter;

--- a/Docs/Tutorials/Files/Software/Libs/Sources/Service.cpp
+++ b/Docs/Tutorials/Files/Software/Libs/Sources/Service.cpp
@@ -1,5 +1,6 @@
 // #include "SDK/SensorLayer/DataParsers/SensorDataParserHeartRate.hpp"  // Commented out: HR parser include
 #include "SDK/Messages/SensorLayerMessages.hpp"
+#include "SDK/Messages/MessageGuard.hpp"
 #include "SDK/JSON/JsonStreamReader.hpp"
 #include "SDK/JSON/JsonStreamWriter.hpp"
 
@@ -11,7 +12,6 @@
 
 Service::Service(SDK::Kernel& kernel)
     : mKernel(SDK::KernelProviderService::GetInstance().getKernel())
-    , mSender(mKernel)
     , mGUIStarted(false)
     , mDecimalCounter(10)  // 1.0f * 10
     , mActivityType(CustomMessage::ActivityType::RUNNING)
@@ -75,9 +75,10 @@ void Service::run()
                 // Settings messages
                 case CustomMessage::GET_SETTINGS: {
                     LOG_INFO("Received GET_SETTINGS request\n");
-                    mSender.updateSettings(mDecimalCounter,
-                                           static_cast<int>(mActivityType),
-                                           static_cast<int>(mDisplayMode));
+                    SDK::send_msg<CustomMessage::SettingsValues>(
+                        mKernel, mDecimalCounter,
+                        static_cast<int>(mActivityType),
+                        static_cast<int>(mDisplayMode));
                 } break;
 
                 case CustomMessage::SET_SETTINGS: {
@@ -192,7 +193,7 @@ void Service::onStartGUI()
      * To enable: Uncomment below and ensure HR message types are defined in Commands.hpp
      * This initializes the GUI display with default values before real sensor data arrives.
      */
-    // mSender.updateHeartRate(0.0f, 0.0f);  // Send initial HR (0.0) and trust level (0.0) to GUI
+    // SDK::send_msg<CustomMessage::HRValues>(mKernel, 0.0f, 0.0f);  // Send initial HR (0.0) and trust level (0.0) to GUI
 }
 
 void Service::onStopGUI()
@@ -217,7 +218,7 @@ void Service::onSdlNewData(uint16_t handle, SDK::Sensor::DataBatch& data)
     //             mHR   = parser.getBpm();  // Extract BPM
     //             mHRTL = parser.getTrustLevel();  // Extract trust level
 
-    //             mSender.updateHeartRate(mHR, mHRTL);  // Send to GUI
+    //             SDK::send_msg<CustomMessage::HRValues>(mKernel, mHR, mHRTL);  // Send to GUI
     //         }
     //     }
     // }

--- a/Docs/Tutorials/Sensors/ARCHITECTURE.md
+++ b/Docs/Tutorials/Sensors/ARCHITECTURE.md
@@ -69,13 +69,31 @@ namespace CustomMessage {
     constexpr SDK::MessageType::Type COMPASS_VALUES = 0x00000007;
     constexpr SDK::MessageType::Type STATS_VALUES = 0x00000008;
     constexpr SDK::MessageType::Type RTC_VALUES = 0x00000009;
+    constexpr SDK::MessageType::Type BATTERY_VALUES = 0x0000000A;
+    constexpr SDK::MessageType::Type PRESSURE_VALUES = 0x0000000B;
 
+    // Every message pairs a default constructor, which sets the message type,
+    // with one that fills the fields and delegates to it. That second
+    // constructor is what lets a caller send the message in a single call.
     struct HRValues : public SDK::MessageBase {
         float heartRate;
         float trustLevel;
-        HRValues() : SDK::MessageBase(HR_VALUES), heartRate(0), trustLevel(0) {}
+
+        HRValues()
+            : SDK::MessageBase(HR_VALUES)
+            , heartRate()
+            , trustLevel()
+        {}
+
+        explicit HRValues(float heartRate, float trustLevel)
+            : HRValues()
+        {
+            this->heartRate  = heartRate;
+            this->trustLevel = trustLevel;
+        }
     };
-    // Similar for others:
+
+    // The rest follow the same shape, over these fields:
     // LocationValues: uint64_t timestamp; double latitude, longitude, altitude;
     // ElevationValues: uint64_t timestamp; float elevation;
     // AccelerometerValues: uint64_t timestamp; float x,y,z;
@@ -84,35 +102,14 @@ namespace CustomMessage {
     // CompassValues: uint64_t timestamp; float heading;
     // StatsValues: float serviceCpuPct, guiCpuPct, txMsgRate, rxMsgRate, txByteRate, rxByteRate;
     // RtcValues: uint32_t time;
+    // BatteryValues: float level;
+    // PressureValues: uint64_t timestamp; float pressure;
+    //   ^ defined, and Model.cpp already handles PRESSURE_VALUES, but the
+    //     service only logs the raw frame today -- it never sends this one.
 }
-
 ```
 
-Each struct pairs its default constructor (which sets the message type) with one that fills the
-fields and delegates to it:
-
-```cpp
-struct HRValues : public SDK::MessageBase {
-    float heartRate;
-    float trustLevel;
-
-    HRValues()
-        : SDK::MessageBase(HR_VALUES)
-        , heartRate()
-        , trustLevel()
-    {}
-
-    explicit HRValues(float heartRate, float trustLevel)
-        : HRValues()
-    {
-        this->heartRate  = heartRate;
-        this->trustLevel = trustLevel;
-    }
-};
-// The other ten messages follow the same shape.
-```
-
-That constructor is what lets `SDK::send_msg<T>(kernel, args...)` do the whole send in one call —
+Those constructors are what let `SDK::send_msg<T>(kernel, args...)` do the whole send in one call —
 allocate from the kernel pool, forward the arguments to the constructor, send, and release. The app
 needs no sender class of its own.
 

--- a/Docs/Tutorials/Sensors/ARCHITECTURE.md
+++ b/Docs/Tutorials/Sensors/ARCHITECTURE.md
@@ -86,20 +86,35 @@ namespace CustomMessage {
     // RtcValues: uint32_t time;
 }
 
-class GUISender {
-public:
-    GUISender(const SDK::Kernel& kernel) : mKernel(kernel) {}
-    bool updateHeartRate(float bpm, float tl) {
-        if (auto req = SDK::make_msg<CustomMessage::HRValues>(mKernel)) {
-            req->heartRate = bpm;
-            req->trustLevel = tl;
-            return req.send();
-        }
-        return false;
-    }
-    // Similar updateLocation(uint64_t ts, double lat, double lon, double alt), etc.
-};
 ```
+
+Each struct pairs its default constructor (which sets the message type) with one that fills the
+fields and delegates to it:
+
+```cpp
+struct HRValues : public SDK::MessageBase {
+    float heartRate;
+    float trustLevel;
+
+    HRValues()
+        : SDK::MessageBase(HR_VALUES)
+        , heartRate()
+        , trustLevel()
+    {}
+
+    explicit HRValues(float heartRate, float trustLevel)
+        : HRValues()
+    {
+        this->heartRate  = heartRate;
+        this->trustLevel = trustLevel;
+    }
+};
+// The other ten messages follow the same shape.
+```
+
+That constructor is what lets `SDK::send_msg<T>(kernel, args...)` do the whole send in one call —
+allocate from the kernel pool, forward the arguments to the constructor, send, and release. The app
+needs no sender class of its own.
 
 ### Step 2: Service - Subscribe & Process Sensors
 
@@ -112,7 +127,6 @@ SDK::Sensor::Connection mSensorAltimeter{SDK::Sensor::Type::ALTIMETER, 0, 0};
 SDK::Sensor::Connection mSensorAccelerometer{SDK::Sensor::Type::ACCELEROMETER, 0, 0};
 SDK::Sensor::Connection mSensorStepCounter{SDK::Sensor::Type::STEP_COUNTER, 0, 0};
 SDK::Sensor::Connection mSensorFloorCounter{SDK::Sensor::Type::FLOOR_COUNTER, 0, 0};
-// CustomMessage::GUISender mSender;
 ```
 
 In `run()` [`Service.cpp`](Software/Libs/Sources/Service.cpp): connect all (acc.connect(0.1f, 0)), loop getMessage:
@@ -131,18 +145,18 @@ In `onSdlNewData`:
 if (mSensorHR.matchesDriver(handle)) {
     SDK::SensorDataParser::HeartRate parser(data[0]);
     if (parser.isDataValid()) {
-        mSender.updateHeartRate(parser.getBpm(), parser.getTrustLevel());
+        SDK::send_msg<CustomMessage::HRValues>(mKernel, parser.getBpm(), parser.getTrustLevel());
     }
 }
-// Similar for GPS: parser.getLatitude() etc (double), updateLocation(ts, lat,lon,alt);
-// Altimeter: updateElevation(ts, parser.getAltitude());
-// Accel: if (nowMs - mLastAccTimeMs >= 100) updateAccelerometer(ts, x,y,z);
-// Steps: updateStepCounter(ts, parser.getStepCount());
-// Floors: updateFloors(ts, parser.getFloorsUp());
-// Compass: compute heading from magnetic X/Y fields, updateCompass(ts, heading);
+// Similar for GPS:  send_msg<LocationValues>(mKernel, ts, lat, lon, alt);
+// Altimeter:        send_msg<ElevationValues>(mKernel, ts, parser.getAltitude());
+// Accel:            if (nowMs - mLastAccTimeMs >= 100) send_msg<AccelerometerValues>(mKernel, ts, x, y, z);
+// Steps:            send_msg<StepCounterValues>(mKernel, ts, parser.getStepCount());
+// Floors:           send_msg<FloorsValues>(mKernel, ts, parser.getFloorsUp());
+// Compass:          compute heading from magnetic X/Y fields, then send_msg<CompassValues>(mKernel, ts, heading);
 ```
 
-Track stats every 1s (simplistic CPU% = ms/10, rates=counts/sec), `mSender.updateStats(...)`, `updateRtc(timeMs/1000)`.
+Track stats every 1s (simplistic CPU% = ms/10, rates=counts/sec) with `send_msg<StatsValues>(...)`, and `send_msg<RtcValues>(mKernel, timeMs/1000)`.
 
 ### Step 3: GUI Model - Receive Messages
 

--- a/Docs/Tutorials/Sensors/Software/Libs/Header/Commands.hpp
+++ b/Docs/Tutorials/Sensors/Software/Libs/Header/Commands.hpp
@@ -261,7 +261,6 @@ namespace CustomMessage {
         }
     };
 
-
 } // namespace CustomMessage
 
 #pragma pack(pop)

--- a/Docs/Tutorials/Sensors/Software/Libs/Header/Commands.hpp
+++ b/Docs/Tutorials/Sensors/Software/Libs/Header/Commands.hpp
@@ -4,8 +4,6 @@
 #include "SDK/Messages/MessageBase.hpp"
 #include "SDK/Messages/MessageTypes.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
-#include "SDK/Messages/MessageGuard.hpp"
-#include "SDK/Kernel/Kernel.hpp"
 
 #include <array>
 #include <cstdint>
@@ -45,6 +43,13 @@ namespace CustomMessage {
             , heartRate()
             , trustLevel()
         {}
+
+        explicit HRValues(float heartRate, float trustLevel)
+            : HRValues()
+        {
+            this->heartRate  = heartRate;
+            this->trustLevel = trustLevel;
+        }
     };
 
     // Service --> GUI
@@ -61,6 +66,15 @@ namespace CustomMessage {
             , longitude()
             , altitude()
         {}
+
+        explicit LocationValues(uint64_t timestamp, double latitude, double longitude, double altitude)
+            : LocationValues()
+        {
+            this->timestamp = timestamp;
+            this->latitude  = latitude;
+            this->longitude = longitude;
+            this->altitude  = altitude;
+        }
     };
 
     // Service --> GUI
@@ -73,6 +87,13 @@ namespace CustomMessage {
             , timestamp()
             , elevation()
         {}
+
+        explicit ElevationValues(uint64_t timestamp, float elevation)
+            : ElevationValues()
+        {
+            this->timestamp = timestamp;
+            this->elevation = elevation;
+        }
     };
 
     // Service --> GUI
@@ -89,6 +110,15 @@ namespace CustomMessage {
             , y()
             , z()
         {}
+
+        explicit AccelerometerValues(uint64_t timestamp, float x, float y, float z)
+            : AccelerometerValues()
+        {
+            this->timestamp = timestamp;
+            this->x         = x;
+            this->y         = y;
+            this->z         = z;
+        }
     };
 
     // Service --> GUI
@@ -101,6 +131,13 @@ namespace CustomMessage {
             , timestamp()
             , steps()
         {}
+
+        explicit StepCounterValues(uint64_t timestamp, uint32_t steps)
+            : StepCounterValues()
+        {
+            this->timestamp = timestamp;
+            this->steps     = steps;
+        }
     };
 
     // Service --> GUI
@@ -113,6 +150,13 @@ namespace CustomMessage {
             , timestamp()
             , floors()
         {}
+
+        explicit FloorsValues(uint64_t timestamp, uint32_t floors)
+            : FloorsValues()
+        {
+            this->timestamp = timestamp;
+            this->floors    = floors;
+        }
     };
 
     // Service --> GUI
@@ -125,6 +169,13 @@ namespace CustomMessage {
             , timestamp()
             , heading()
         {}
+
+        explicit CompassValues(uint64_t timestamp, float heading)
+            : CompassValues()
+        {
+            this->timestamp = timestamp;
+            this->heading   = heading;
+        }
     };
 
     struct StatsValues : public SDK::MessageBase {
@@ -144,6 +195,18 @@ namespace CustomMessage {
             , txByteRate(0)
             , rxByteRate(0)
         {}
+
+        explicit StatsValues(float serviceCpuPct, float guiCpuPct, float txMsgRate,
+                 float rxMsgRate, float txByteRate, float rxByteRate)
+            : StatsValues()
+        {
+            this->serviceCpuPct = serviceCpuPct;
+            this->guiCpuPct     = guiCpuPct;
+            this->txMsgRate     = txMsgRate;
+            this->rxMsgRate     = rxMsgRate;
+            this->txByteRate    = txByteRate;
+            this->rxByteRate    = rxByteRate;
+        }
     };
 
     constexpr SDK::MessageType::Type RTC_VALUES = 0x00000009;
@@ -155,6 +218,12 @@ namespace CustomMessage {
             : SDK::MessageBase(RTC_VALUES)
             , time(0)
         {}
+
+        explicit RtcValues(uint32_t time)
+            : RtcValues()
+        {
+            this->time = time;
+        }
     };
 
     // Service --> GUI
@@ -165,6 +234,12 @@ namespace CustomMessage {
             : SDK::MessageBase(BATTERY_VALUES)
             , level(0.0f)
         {}
+
+        explicit BatteryValues(float level)
+            : BatteryValues()
+        {
+            this->level = level;
+        }
     };
 
     // Service --> GUI
@@ -177,170 +252,15 @@ namespace CustomMessage {
             , timestamp(0)
             , pressure(0.0f)
         {}
+
+        explicit PressureValues(uint64_t timestamp, float pressure)
+            : PressureValues()
+        {
+            this->timestamp = timestamp;
+            this->pressure  = pressure;
+        }
     };
 
-
-    ///////////////////////////////////////
-    //// Wrappers
-    ///////////////////////////////////////
-
-    class GUISender {
-    public:
-        GUISender(const SDK::Kernel& kernel) : mKernel(kernel)
-        {}
-
-        virtual ~GUISender() = default;
-
-        // Service --> GUI
-        bool updateHeartRate(float value, float trustLevel)
-        {
-            if (auto req = SDK::make_msg<CustomMessage::HRValues>(mKernel)) {
-                req->heartRate  = value;
-                req->trustLevel = trustLevel;
-
-                return req.send();
-            }
-
-            return false;
-        }
-
-        // Service --> GUI
-        bool updateLocation(uint64_t timestamp, double latitude, double longitude, double altitude)
-        {
-            if (auto req = SDK::make_msg<CustomMessage::LocationValues>(mKernel)) {
-                req->timestamp = timestamp;
-                req->latitude  = latitude;
-                req->longitude = longitude;
-                req->altitude  = altitude;
-
-                return req.send();
-            }
-
-            return false;
-        }
-
-        // Service --> GUI
-        bool updateElevation(uint64_t timestamp, float elevation)
-        {
-            if (auto req = SDK::make_msg<CustomMessage::ElevationValues>(mKernel)) {
-                req->timestamp = timestamp;
-                req->elevation = elevation;
-
-                return req.send();
-            }
-
-            return false;
-        }
-
-        // Service --> GUI
-        bool updateAccelerometer(uint64_t timestamp, float x, float y, float z)
-        {
-            if (auto req = SDK::make_msg<CustomMessage::AccelerometerValues>(mKernel)) {
-                req->timestamp = timestamp;
-                req->x = x;
-                req->y = y;
-                req->z = z;
-
-                return req.send();
-            }
-
-            return false;
-        }
-
-        // Service --> GUI
-        bool updateStepCounter(uint64_t timestamp, uint32_t steps)
-        {
-            if (auto req = SDK::make_msg<CustomMessage::StepCounterValues>(mKernel)) {
-                req->timestamp = timestamp;
-                req->steps = steps;
-
-                return req.send();
-            }
-
-            return false;
-        }
-
-        // Service --> GUI
-        bool updateFloors(uint64_t timestamp, uint32_t floors)
-        {
-            if (auto req = SDK::make_msg<CustomMessage::FloorsValues>(mKernel)) {
-                req->timestamp = timestamp;
-                req->floors = floors;
-
-                return req.send();
-            }
-
-            return false;
-        }
-
-        // Service --> GUI
-    bool updateCompass(uint64_t timestamp, float heading)
-    {
-        if (auto req = SDK::make_msg<CustomMessage::CompassValues>(mKernel)) {
-            req->timestamp = timestamp;
-            req->heading = heading;
-
-            return req.send();
-        }
-
-        return false;
-    }
-
-    bool updateStats(float serviceCpuPct, float guiCpuPct, float txMsgRate, float rxMsgRate, float txByteRate, float rxByteRate)
-    {
-        if (auto req = SDK::make_msg<CustomMessage::StatsValues>(mKernel)) {
-            req->serviceCpuPct = serviceCpuPct;
-            req->guiCpuPct = guiCpuPct;
-            req->txMsgRate = txMsgRate;
-            req->rxMsgRate = rxMsgRate;
-            req->txByteRate = txByteRate;
-            req->rxByteRate = rxByteRate;
-
-            return req.send();
-        }
-
-        return false;
-    }
-
-    bool updateRtc(uint32_t time)
-    {
-        if (auto req = SDK::make_msg<CustomMessage::RtcValues>(mKernel)) {
-            req->time = time;
-
-            return req.send();
-        }
-
-        return false;
-    }
-
-    // Service --> GUI
-    bool updateBattery(float level)
-    {
-        if (auto req = SDK::make_msg<CustomMessage::BatteryValues>(mKernel)) {
-            req->level = level;
-
-            return req.send();
-        }
-
-        return false;
-    }
-
-    // Service --> GUI
-    bool updatePressure(uint64_t timestamp, float pressure)
-    {
-        if (auto req = SDK::make_msg<CustomMessage::PressureValues>(mKernel)) {
-            req->timestamp = timestamp;
-            req->pressure = pressure;
-
-            return req.send();
-        }
-
-        return false;
-    }
-
-private:
-    const SDK::Kernel& mKernel;
-    };
 
 } // namespace CustomMessage
 

--- a/Docs/Tutorials/Sensors/Software/Libs/Header/Service.hpp
+++ b/Docs/Tutorials/Sensors/Software/Libs/Header/Service.hpp
@@ -18,7 +18,6 @@ public:
 
 private:
     SDK::Kernel&             mKernel;
-    CustomMessage::GUISender mSender;
     bool                     mGUIStarted;
     SDK::Sensor::Connection  mSensorHR;
     SDK::Sensor::Connection  mSensorGPS;

--- a/Docs/Tutorials/Sensors/Software/Libs/Sources/Service.cpp
+++ b/Docs/Tutorials/Sensors/Software/Libs/Sources/Service.cpp
@@ -7,6 +7,7 @@
 #include "SDK/SensorLayer/DataParsers/SensorDataParserBatteryLevel.hpp"
 #include "SDK/SensorLayer/SensorDataView.hpp"
 #include "SDK/Messages/SensorLayerMessages.hpp"
+#include "SDK/Messages/MessageGuard.hpp"
 #include <cmath>
 #include <sstream>
 #include <iomanip>
@@ -23,7 +24,6 @@
 
 Service::Service(SDK::Kernel& kernel)
     : mKernel(SDK::KernelProviderService::GetInstance().getKernel())
-    , mSender(mKernel)
     , mGUIStarted(false)
     , mSensorHR(SDK::Sensor::Type::HEART_RATE, 0, 0)
     , mSensorGPS(SDK::Sensor::Type::GPS_LOCATION, 0, 0)
@@ -198,11 +198,11 @@ void Service::run()
                 // Calculate simplistic CPU % (ms per sec /10)
                 float serviceCpuPct = static_cast<float>(mServiceCpuTimeMs) / 10.0f;
                 float guiCpuPct = static_cast<float>(mGuiCpuTimeMs) / 10.0f;
-                mSender.updateStats(serviceCpuPct, guiCpuPct,
-                                    static_cast<float>(mTxMessages),
-                                    static_cast<float>(mRxMessages),
-                                    static_cast<float>(mTxBytes),
-                                    static_cast<float>(mRxBytes));
+                SDK::send_msg<CustomMessage::StatsValues>(mKernel, serviceCpuPct, guiCpuPct,
+                                                         static_cast<float>(mTxMessages),
+                                                         static_cast<float>(mRxMessages),
+                                                         static_cast<float>(mTxBytes),
+                                                         static_cast<float>(mRxBytes));
                 LOG_INFO("Stats sent: SCPU%.1f%% GCPU%.1f%% TX:%.0f msg/s (%.0f B/s) RX:%.0f msg/s (%.0f B/s)\n",
                          serviceCpuPct, guiCpuPct,
                          static_cast<float>(mTxMessages), static_cast<float>(mTxBytes),
@@ -210,7 +210,7 @@ void Service::run()
 
                 // Send RTC time (seconds since boot)
                 uint32_t rtcTime = static_cast<uint32_t>(mKernel.sys.getTimeMs() / 1000ULL);
-                mSender.updateRtc(rtcTime);
+                SDK::send_msg<CustomMessage::RtcValues>(mKernel, rtcTime);
 
                 // Reset counters
                 mTxMessages = 0;
@@ -268,7 +268,7 @@ void Service::onStartGUI()
 {
     LOG_INFO("GUI started\n");
     mGUIStarted = true;
-    mSender.updateHeartRate(0.0f, 0.0f);
+    SDK::send_msg<CustomMessage::HRValues>(mKernel, 0.0f, 0.0f);
 }
 
 void Service::onStopGUI()
@@ -287,7 +287,7 @@ void Service::onSdlNewData(uint16_t handle, SDK::Sensor::DataBatch& data)
                 mHRTL = parser.getTrustLevel();
                 // LOG_DEBUG("HR: %.0f BPM\n", mHR);
                 mTxMessages++;
-                mSender.updateHeartRate(mHR, mHRTL);
+                SDK::send_msg<CustomMessage::HRValues>(mKernel, mHR, mHRTL);
                 mTxBytes += sizeof(CustomMessage::HRValues);
             }
         } else if (mSensorGPS.matchesDriver(handle)) {
@@ -299,7 +299,7 @@ void Service::onSdlNewData(uint16_t handle, SDK::Sensor::DataBatch& data)
                 float altitude = parser.getAltitude();
                 // LOG_DEBUG("GPS: %.6f, %.6f, %.1f\n", latitude, longitude, altitude);
                 mTxMessages++;
-                mSender.updateLocation(timestamp, latitude, longitude, altitude);
+                SDK::send_msg<CustomMessage::LocationValues>(mKernel, timestamp, latitude, longitude, altitude);
                 mTxBytes += sizeof(CustomMessage::LocationValues);
             }
         } else if (mSensorAltimeter.matchesDriver(handle)) {
@@ -309,7 +309,7 @@ void Service::onSdlNewData(uint16_t handle, SDK::Sensor::DataBatch& data)
                 float elevation = parser.getAltitude();
                 // LOG_DEBUG("Elevation: %.1f m\n", elevation);
                 mTxMessages++;
-                mSender.updateElevation(timestamp, elevation);
+                SDK::send_msg<CustomMessage::ElevationValues>(mKernel, timestamp, elevation);
                 mTxBytes += sizeof(CustomMessage::ElevationValues);
             }
         } else if (mSensorAccelerometer.matchesDriver(handle)) {
@@ -324,7 +324,7 @@ void Service::onSdlNewData(uint16_t handle, SDK::Sensor::DataBatch& data)
                     // LOG_DEBUG("Acc: %.2f, %.2f, %.2f, now: %u, last: %u, timestamp: %llu\n", x, y, z, nowMs, mLastAccTimeMs, timestamp);
                     mLastAccTimeMs = nowMs;
                     mTxMessages++;
-                    mSender.updateAccelerometer(timestamp, x, y, z);
+                    SDK::send_msg<CustomMessage::AccelerometerValues>(mKernel, timestamp, x, y, z);
                     mTxBytes += sizeof(CustomMessage::AccelerometerValues);
                 }
             }
@@ -335,7 +335,7 @@ void Service::onSdlNewData(uint16_t handle, SDK::Sensor::DataBatch& data)
                 uint32_t steps = parser.getStepCount();
                 // LOG_DEBUG("Steps: %u\n", steps);
                 mTxMessages++;
-                mSender.updateStepCounter(timestamp, steps);
+                SDK::send_msg<CustomMessage::StepCounterValues>(mKernel, timestamp, steps);
                 mTxBytes += sizeof(CustomMessage::StepCounterValues);
             }
         } else if (mSensorFloorCounter.matchesDriver(handle)) {
@@ -345,7 +345,7 @@ void Service::onSdlNewData(uint16_t handle, SDK::Sensor::DataBatch& data)
                 uint32_t floors = static_cast<uint32_t>(parser.getFloorsUp());
                 // LOG_DEBUG("Floors: %u\n", floors);
                 mTxMessages++;
-                mSender.updateFloors(timestamp, floors);
+                SDK::send_msg<CustomMessage::FloorsValues>(mKernel, timestamp, floors);
                 mTxBytes += sizeof(CustomMessage::FloorsValues);
             }
         } else if (mSensorMagneticField.matchesDriver(handle)) {
@@ -358,7 +358,7 @@ void Service::onSdlNewData(uint16_t handle, SDK::Sensor::DataBatch& data)
             if (nowMs - mLastMagTimeMs >= 100) {
                 // LOG_DEBUG("Compass: %.1f deg (X:%.2f Y:%.2f)\n", heading, x, y);
                 mTxMessages++;
-                mSender.updateCompass(nowMs, heading);
+                SDK::send_msg<CustomMessage::CompassValues>(mKernel, nowMs, heading);
                 mTxBytes += sizeof(CustomMessage::CompassValues);
                 mLastMagTimeMs = nowMs;
             }
@@ -368,7 +368,7 @@ void Service::onSdlNewData(uint16_t handle, SDK::Sensor::DataBatch& data)
                 float level = parser.getCharge();
                 // LOG_DEBUG("Battery: %.1f%%\n", level);
                 mTxMessages++;
-                mSender.updateBattery(level);
+                SDK::send_msg<CustomMessage::BatteryValues>(mKernel, level);
                 mTxBytes += sizeof(CustomMessage::BatteryValues);
             }
         } else if (mSensorAccelerometerRaw.matchesDriver(handle)) {

--- a/Examples/Apps/Stopwatch/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Stopwatch/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -6,6 +6,7 @@
 #include "SDK/Kernel/Kernel.hpp"
 #include "SDK/Interfaces/IGuiLifeCycleCallback.hpp"
 #include "SDK/Interfaces/ICustomMessageHandler.hpp"
+#include "SDK/Messages/MessageGuard.hpp"
 #include <SDK/GUI/Config.hpp>
 
 #include "Commands.hpp"
@@ -66,10 +67,10 @@ public:
      * that was sent is always answered with a snapshot, which is what lets the
      * screen trust that a pending change will resolve.
      *  @{ */
-    bool startStopwatch() { return mSender.start(); }
-    bool pauseStopwatch() { return mSender.pause(); }
-    bool lapStopwatch()   { return mSender.lap(); }
-    bool resetStopwatch() { return mSender.reset(); }
+    bool startStopwatch() { return SDK::send_msg<CustomMessage::StopwatchStart>(mKernel); }
+    bool pauseStopwatch() { return SDK::send_msg<CustomMessage::StopwatchPause>(mKernel); }
+    bool lapStopwatch()   { return SDK::send_msg<CustomMessage::StopwatchLap>(mKernel); }
+    bool resetStopwatch() { return SDK::send_msg<CustomMessage::StopwatchReset>(mKernel); }
     /** @} */
 
     /**
@@ -98,8 +99,7 @@ protected:
 
     bool mInvalidate = false;               ///< Request to redraw current screen
 
-    CustomMessage::Sender mSender;          ///< Outbound commands to the service
-    Stopwatch::State      mState;           ///< Last snapshot from the service
+    Stopwatch::State mState;                ///< Last snapshot from the service
 
     // IGuiLifeCycleCallback
     void onStart()   override;

--- a/Examples/Apps/Stopwatch/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Stopwatch/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -12,7 +12,6 @@
 Model::Model()
     : modelListener(nullptr)
     , mKernel(SDK::KernelProviderGUI::GetInstance().getKernel())
-    , mSender(mKernel)
     , mState{}
 {
     SDK::TouchGFXCommandProcessor::GetInstance().setAppLifeCycleCallback(this);
@@ -77,7 +76,7 @@ void Model::onStart()
     // The service publishes a snapshot when it is told the GUI is up, so this
     // is only a safety net for the case where that message beat our handler
     // being registered.
-    mSender.requestState();
+    SDK::send_msg<CustomMessage::StopwatchRequest>(mKernel);
 }
 
 void Model::onResume()
@@ -85,7 +84,7 @@ void Model::onResume()
     mInvalidate = true;
 
     // The stopwatch may have moved on while the GUI was suspended.
-    mSender.requestState();
+    SDK::send_msg<CustomMessage::StopwatchRequest>(mKernel);
 }
 
 void Model::onSuspend()

--- a/Examples/Apps/Stopwatch/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Stopwatch/Software/Libs/Header/Commands.hpp
@@ -18,7 +18,6 @@
 
 #include "SDK/Messages/MessageBase.hpp"
 #include "SDK/Messages/MessageTypes.hpp"
-#include "SDK/Kernel/Kernel.hpp"
 
 #include "Stopwatch.hpp"
 
@@ -47,6 +46,12 @@ struct StopwatchState : public SDK::MessageBase {
         : SDK::MessageBase(STOPWATCH_STATE)
         , state{}
     {}
+
+    explicit StopwatchState(const Stopwatch::State &state)
+        : StopwatchState()
+    {
+        this->state = state;
+    }
 };
 
 // The fixed lap array keeps the message inside the 256-byte pool block, which
@@ -75,56 +80,6 @@ struct StopwatchReset : public SDK::MessageBase {
  */
 struct StopwatchRequest : public SDK::MessageBase {
     StopwatchRequest() : SDK::MessageBase(STOPWATCH_REQUEST) {}
-};
-
-/**
- * @class Sender
- * @brief Allocates, sends and releases the custom messages.
- */
-class Sender
-{
-public:
-    Sender(const SDK::Kernel &kernel)
-        : mKernel(kernel)
-    {}
-
-    virtual ~Sender() = default;
-
-    /**
-     * @brief Service --> GUI: publish the current state.
-     */
-    bool state(const Stopwatch::State &state)
-    {
-        auto *msg = mKernel.comm.allocateMessage<StopwatchState>();
-        if (!msg) {
-            return false;
-        }
-        msg->state = state;
-        const bool status = mKernel.comm.sendMessage(msg);
-        mKernel.comm.releaseMessage(msg);
-        return status;
-    }
-
-    bool start()        { return send<StopwatchStart>(); }
-    bool pause()        { return send<StopwatchPause>(); }
-    bool lap()          { return send<StopwatchLap>(); }
-    bool reset()        { return send<StopwatchReset>(); }
-    bool requestState() { return send<StopwatchRequest>(); }
-
-private:
-    template<typename T>
-    bool send()
-    {
-        auto *msg = mKernel.comm.allocateMessage<T>();
-        if (!msg) {
-            return false;
-        }
-        const bool status = mKernel.comm.sendMessage(msg);
-        mKernel.comm.releaseMessage(msg);
-        return status;
-    }
-
-    const SDK::Kernel &mKernel;
 };
 
 } // namespace CustomMessage

--- a/Examples/Apps/Stopwatch/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Stopwatch/Software/Libs/Header/Service.hpp
@@ -35,10 +35,9 @@ public:
     void run();
 
 private:
-    SDK::Kernel           &mKernel;
-    CustomMessage::Sender  mSender;
-    Stopwatch::Core        mStopwatch;
-    bool                   mGuiStarted;
+    SDK::Kernel     &mKernel;
+    Stopwatch::Core  mStopwatch;
+    bool             mGuiStarted;
 
     /**
      * @brief Apply one app-specific command to the stopwatch and publish it.

--- a/Examples/Apps/Stopwatch/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Stopwatch/Software/Libs/Sources/Service.cpp
@@ -1,4 +1,5 @@
 #include "Service.hpp"
+#include "SDK/Messages/MessageGuard.hpp"
 
 #define LOG_MODULE_PRX      "Service"
 #define LOG_MODULE_LEVEL    LOG_LEVEL_INFO
@@ -12,7 +13,6 @@ static constexpr uint32_t kWaitForever = 0xFFFFFFFF;
 
 Service::Service(SDK::Kernel &kernel)
     : mKernel(kernel)
-    , mSender(kernel)
     , mStopwatch()
     , mGuiStarted(false)
 {
@@ -102,5 +102,5 @@ void Service::publish()
     if (!mGuiStarted) {
         return;
     }
-    mSender.state(mStopwatch.state());
+    SDK::send_msg<CustomMessage::StopwatchState>(mKernel, mStopwatch.state());
 }


### PR DESCRIPTION
Continuing to chip away at #235...

#219 removed the per-app sender from the seven activity apps but three were left behind: Stopwatch merged after it, and the Sensors and Files tutorials call their class GUISender, so the sweep never matched them.

Messages go back to being plain data: each gains a field-filling ctor delegating to its default one, and Commands.hpp drops its Kernel.hpp include because a message no longer needs to know the kernel exists. The Files tutorial's commented-out "add your own message" scaffolding is converted too, since half-finished examples are still read as the recommended shape.

No behaviour change: every converted call site already discarded send_msg's bool, and Stopwatch's Model still returns it to its callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and tutorial guidance to demonstrate direct SDK message sending.
  * Clarified message construction, state snapshots, command dispatch, replies, and failure handling.

* **Examples**
  * Updated stopwatch, sensor, and settings examples to use typed messages and direct SDK communication.
  * Added battery and pressure message examples and value-based message construction.
  * Removed obsolete sender helper examples and related wrapper APIs.
  * Improved settings value handling and consistency across tutorial code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->