### PR TITLE
fix(simulator): sync MSVS source lists with the gcc Makefiles

### DIFF
--- a/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Docs/Tutorials/Files/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -34,6 +34,8 @@
     <ClCompile Include="$(SdkPath)\ThirdParty\coreJSON\source\core_json.c"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\JSON\JsonStreamReader.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\JSON\JsonStreamWriter.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitCrc.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Fit\FitWriter.cpp"/>
     <ClCompile Include="..\..\generated\gui_generated\src\common\FrontendApplicationBase.cpp"/>
     <ClCompile Include="..\..\gui\src\model\Model.cpp"/>
     <ClCompile Include="..\..\generated\simulator\src\video\SoftwareMJPEGDecoder.cpp"/>

--- a/Docs/Tutorials/Images/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Docs/Tutorials/Images/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -22,7 +22,6 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Wrappers\StdLibWrappers.c"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Kernel\KernelBuilder.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Port\TouchGFX\TouchGFXCommandProcessor.cpp"/>
-    <ClCompile Include="$(SdkPath)\Libs\Source\SensorLayer\SensorConnection.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\App\DualAppComm.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\App\AppCore.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\App\AppMessageCore.cpp"/>

--- a/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Docs/Tutorials/Sensors/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -20,6 +20,11 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Kernel\Mock\FileSystem.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\UnaLogger\Logger.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Wrappers\StdLibWrappers.c"/>
+    <ClCompile Include="$(SdkPath)\ThirdParty\coreJSON\source\core_json.c"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\JSON\JsonStreamReader.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\JSON\JsonStreamWriter.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\TrackMap\TrackMapBuilder.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Timer\Timer.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Kernel\KernelBuilder.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Port\TouchGFX\TouchGFXCommandProcessor.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\SensorLayer\SensorConnection.cpp"/>
@@ -51,6 +56,7 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\SensorPressure.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuWristMotion.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuStepCounter.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Sensors\Imu\ImuRunningCadence.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\ComponentSimulator.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\Simulator\GpsStepCounterSimulator.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Simulator\Components\SensorListener.cpp"/>

--- a/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
+++ b/Examples/Apps/HRMonitor/Software/Apps/TouchGFX-GUI/simulator/msvs/Application.vcxproj
@@ -29,6 +29,10 @@
     <ClCompile Include="$(SdkPath)\Libs\Source\Timer\Timer.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\UnaLogger\Logger.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Wrappers\StdLibWrappers.c"/>
+    <ClCompile Include="$(SdkPath)\ThirdParty\coreJSON\source\core_json.c"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\JSON\JsonStreamReader.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\JSON\JsonStreamWriter.cpp"/>
+    <ClCompile Include="$(SdkPath)\Libs\Source\TrackMap\TrackMapBuilder.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Kernel\KernelBuilder.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\Port\TouchGFX\TouchGFXCommandProcessor.cpp"/>
     <ClCompile Include="$(SdkPath)\Libs\Source\SensorLayer\SensorConnection.cpp"/>


### PR DESCRIPTION
Fixes the four pre-existing source-list drifts that #223's new checker surfaces, so that check can land green rather than red.

#223 adds a CI job diffing each simulator project's two hand-maintained source lists — the gcc Makefile's `ADDITIONAL_SOURCES(_UNA)` and the MSVS `Application.vcxproj`'s `ClCompile` items. On its own branch that job currently exits 1 with 4 drifting projects, so merging it as-is leaves `main` failing. This PR clears the backlog; **merge this first**, then #223 is green on arrival.

Nothing in CI builds the MSVC side, so each of these was a link error waiting for whoever next opened Visual Studio.

## Changes

| Project | Change | Why |
|---|---|---|
| `Docs/Tutorials/Files` | **+** `Fit/FitCrc.cpp`, `Fit/FitWriter.cpp` | Its `ActivityWriter.cpp` constructs a `fit::FitWriter` — both are genuinely required |
| `Docs/Tutorials/Sensors` | **+** `core_json.c`, JSON pair, `TrackMapBuilder.cpp`, `Timer/Timer.cpp`, `ImuRunningCadence.cpp` | Present in the Makefile; the standard SDK simulator set that every passing project carries in both lists |
| `Examples/Apps/HRMonitor` | **+** `core_json.c`, JSON pair, `TrackMapBuilder.cpp` | Same; it already carried `Timer.cpp` and `ImuRunningCadence.cpp` |
| `Docs/Tutorials/Images` | **−** `SensorLayer/SensorConnection.cpp` | Cruft — see below |

The `Images` case is the one going the other way. Its only sensor references are an `#include` of a messages header and a **commented-out** `// mSensorHR.disconnect();`. The structurally identical `Buttons`, `HelloWorld` and `ScrollMenu` tutorials list `SensorConnection.cpp` in neither file; only `Sensors`, which actually uses sensors, has it in both. So the entry is a leftover and the Makefile was right.

New entries follow the block ordering already used by the passing projects (`core_json`, JSON pair, `TrackMapBuilder`, `Timer`, then `KernelBuilder`), matching `Workout`.

## Verification

- `check_msvs_sources.py` from #223: **all 14 projects OK**, was 4 in drift.
- All four files parse as well-formed XML via `ElementTree`, no duplicate `ClCompile` includes.
- Every added `$(SdkPath)` source confirmed to exist on disk.
- **No Makefile is touched**, so the Linux simulator build is unaffected by construction.

## Out of scope

`Application.vcxproj.filters` is left alone. It's cosmetic (Solution Explorer grouping only, no effect on compilation) and already only partially populated on these projects — e.g. the `Files` tutorial's filters file lists `Logger.cpp` but none of the JSON sources. Worth a separate tidy-up if anyone cares about the VS tree. #223's checker only compares `ClCompile`, so this doesn't affect the gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated several TouchGFX simulator projects to compile the required fitness, sensor, JSON, timer, and track-mapping components.
  * Removed an obsolete sensor connection source from the Images tutorial simulator.
  * Improved simulator build completeness for the HR Monitor, Sensors, Files, and Images tutorials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->