### PR TITLE
fix(sdk): match the case of KernelProviderGUI.hpp in the CustomGUI entry point

### DIFF
--- a/Libs/Source/AppSystem/EntryPoint/CustomGUI/main.cpp
+++ b/Libs/Source/AppSystem/EntryPoint/CustomGUI/main.cpp
@@ -17,7 +17,7 @@
 
 #include "SDK/Kernel/Kernel.hpp"
 #include "SDK/Kernel/KernelBuilder.hpp"
-#include "SDK/Kernel/KernelProviderGui.hpp"
+#include "SDK/Kernel/KernelProviderGUI.hpp"
 #include "SDK/UnaLogger/Logger.h"
 
 // Include path must be defined globally


### PR DESCRIPTION
The header is `KernelProviderGUI.hpp`; the include asked for `KernelProviderGui.hpp`. Case-insensitive filesystems resolve it anyway, so this only breaks on Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GUI provider reference to align with the renamed header, ensuring the application builds correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->