### PR TITLE
docs(touchgfx): fix the note placement and the non-compiling snippets from #237

### DIFF
--- a/Docs/TouchGFX-Port-Architecture.md
+++ b/Docs/TouchGFX-Port-Architecture.md
@@ -895,14 +895,17 @@ graph TD
 
 #### Message Definition
 ```cpp
-// In shared header file (e.g., AppTypes.hpp)
-enum class CustomMessageType : uint32_t {
-    HEART_RATE_UPDATE = 0x00010001,
-    GPS_LOCATION_UPDATE = 0x00010002,
-    BATTERY_STATUS = 0x00010003,
-    WORKOUT_START = 0x00010004,
-    WORKOUT_STOP = 0x00010005
-};
+// In shared header file (e.g., Commands.hpp)
+namespace CustomMessage {
+
+// `SDK::MessageType::Type` is a `uint32_t` alias, and `MessageBase` takes one directly, so
+// declare the IDs as constants of that type. A scoped `enum class` would not convert
+// implicitly — neither in the constructor below nor in a `switch (msg->getType())`.
+constexpr SDK::MessageType::Type HEART_RATE_UPDATE   = 0x00010001;
+constexpr SDK::MessageType::Type GPS_LOCATION_UPDATE = 0x00010002;
+constexpr SDK::MessageType::Type BATTERY_STATUS      = 0x00010003;
+constexpr SDK::MessageType::Type WORKOUT_START       = 0x00010004;
+constexpr SDK::MessageType::Type WORKOUT_STOP        = 0x00010005;
 
 // Message structures
 struct HeartRateMessage : public SDK::MessageBase {
@@ -910,7 +913,7 @@ struct HeartRateMessage : public SDK::MessageBase {
     uint32_t timestamp;
 
     HeartRateMessage(uint16_t heartRate, uint32_t time)
-        : MessageBase(CustomMessageType::HEART_RATE_UPDATE)
+        : SDK::MessageBase(HEART_RATE_UPDATE)
         , bpm(heartRate), timestamp(time) {}
 };
 
@@ -918,10 +921,12 @@ struct WorkoutCommand : public SDK::MessageBase {
     enum class Action { START, PAUSE, RESUME, STOP };
     Action command;
 
-    WorkoutCommand(Action cmd)
-        : MessageBase(CustomMessageType::WORKOUT_START)
+    explicit WorkoutCommand(Action cmd)
+        : SDK::MessageBase(WORKOUT_START)
         , command(cmd) {}
 };
+
+} // namespace CustomMessage
 ```
 
 #### Service-Side Message Sending
@@ -972,14 +977,14 @@ class FitnessModel : public ICustomMessageHandler {
 public:
     bool customMessageHandler(MessageBase* msg) override {
         switch (msg->getType()) {
-            case CustomMessageType::HEART_RATE_UPDATE: {
+            case CustomMessage::HEART_RATE_UPDATE: {
                 auto* hrMsg = static_cast<HeartRateMessage*>(msg);
                 mCurrentHeartRate = hrMsg->bpm;
                 mLastUpdateTime = hrMsg->timestamp;
                 notifyHeartRateChanged();
                 return true;
             }
-            case CustomMessageType::BATTERY_STATUS: {
+            case CustomMessage::BATTERY_STATUS: {
                 auto* battMsg = static_cast<BatteryMessage*>(msg);
                 mBatteryLevel = battMsg->percentage;
                 notifyBatteryChanged();
@@ -1003,22 +1008,25 @@ private:
 
 #### Request-Response Pattern
 ```cpp
+constexpr SDK::MessageType::Type CONFIG_REQUEST  = 0x00010006;
+constexpr SDK::MessageType::Type CONFIG_RESPONSE = 0x00010007;
+
 // Request message
-struct ConfigurationRequest : public MessageBase {
+struct ConfigurationRequest : public SDK::MessageBase {
     enum class ConfigType { UNITS, THEME, ALERTS };
     ConfigType type;
 
-    ConfigurationRequest(ConfigType t)
-        : MessageBase(CONFIG_REQUEST_TYPE), type(t) {}
+    explicit ConfigurationRequest(ConfigType t)
+        : SDK::MessageBase(CONFIG_REQUEST), type(t) {}
 };
 
 // Response message
-struct ConfigurationResponse : public MessageBase {
+struct ConfigurationResponse : public SDK::MessageBase {
     ConfigurationRequest::ConfigType type;
     std::string value;
 
-    ConfigurationResponse(ConfigType t, const std::string& val)
-        : MessageBase(CONFIG_RESPONSE_TYPE), type(t), value(val) {}
+    ConfigurationResponse(ConfigurationRequest::ConfigType t, const std::string& val)
+        : SDK::MessageBase(CONFIG_RESPONSE), type(t), value(val) {}
 };
 
 // Service implementation

--- a/Docs/TouchGFX-Port-Architecture.md
+++ b/Docs/TouchGFX-Port-Architecture.md
@@ -936,16 +936,6 @@ caller usually ignores it — a dropped heart-rate sample is superseded a second
 example apps do exactly that. A dropped reply to a request is not self-correcting, so those sends
 are worth checking (see the request-response pattern below).
 
-Note that `send_msg` posts with a **zero timeout**: if the message queue is full it gives up
-immediately rather than waiting for room. That suits telemetry, but when you need to wait for queue
-space — or to read a reply — use `SDK::make_msg<T>` and send it yourself with an explicit timeout:
-
-```cpp
-if (auto msg = SDK::make_msg<HeartRateMessage>(mKernel, bpm, getCurrentTime())) {
-    msg.send(100);  // wait up to 100 ms for queue space
-}
-```
-
 ```cpp
 class FitnessService {
 public:
@@ -964,6 +954,16 @@ public:
         }
     }
 };
+```
+
+Note that `send_msg` posts with a **zero timeout**: if the message queue is full it gives up
+immediately rather than waiting for room. That suits telemetry, but when you need to wait for queue
+space — or to read a reply — use `SDK::make_msg<T>` and send it yourself with an explicit timeout:
+
+```cpp
+if (auto msg = SDK::make_msg<HeartRateMessage>(mKernel, bpm, getCurrentTime())) {
+    msg.send(100);  // wait up to 100 ms for queue space
+}
 ```
 
 #### GUI-Side Message Handling


### PR DESCRIPTION
The two follow-ups from my review of #237, now that it's merged. Docs-only, one file, two commits.

### 1. Move the zero-timeout note below the example it interrupted

#237 added the "`send_msg` posts with a zero timeout" note to `Docs/TouchGFX-Port-Architecture.md`, but it landed between the prose introducing the `FitnessService` snippet ("*Return the `bool` rather than swallowing it… the example apps do exactly that*") and the snippet itself. That left two adjacent fences with the second one missing its lead-in. Same text, moved after the block it was splitting.

### 2. Make the custom-message snippets compile

The examples under **Custom Message Communication** never compiled, which is how the `sendHeartRateUpdate` divergence #237 fixed survived in three different forms in the first place.

`MessageBase` takes a `SDK::MessageType::Type` — a `uint32_t` alias (`Libs/Header/SDK/Messages/MessageTypes.hpp:48`) — but the IDs were declared as a scoped `enum class CustomMessageType : uint32_t`. That doesn't convert implicitly, so it fails in the mem-initialisers of both `HeartRateMessage` and `WorkoutCommand`, *and* in the `switch (msg->getType())` cases of the GUI-side handler.

Fixed by declaring the IDs as `constexpr SDK::MessageType::Type` constants in a `CustomMessage` namespace — which is what the shipping apps (`Examples/Apps/*/Software/Libs/Header/Commands.hpp`) and the per-app architecture docs already do — with a comment saying why, so the `enum class` doesn't come back.

Two more in the request-response example:

- `ConfigurationResponse`'s constructor took an unqualified `ConfigType`; that name only exists inside `ConfigurationRequest`. Now `ConfigurationRequest::ConfigType`, matching the member declaration right above it.
- `CONFIG_REQUEST_TYPE` / `CONFIG_RESPONSE_TYPE` were never declared anywhere. Added as two constants alongside the others.

Also added `explicit` to the two single-argument constructors, for consistency with the field-filling constructors #237 documented.

### Deliberately not fixed

Two things in the same section are still wrong, but fixing them means inventing API surface rather than correcting it, so I'd rather they were a conscious decision than a drive-by:

- `BatteryMessage` (L988) and its `percentage` member are used but never defined. Same for `HEART_RATE_MESSAGE_TYPE` (L816), `BULK_DATA_TYPE` (L1053) and `CUSTOM_MESSAGE_TYPE` (L1101).
- `ConfigurationResponse` holds a `std::string` in a message that gets pool-allocated. Every real app and every per-app doc uses a fixed-size buffer for exactly this reason — `AlarmList`'s comment spells it out: "*Fixed-size array avoids heap allocation in the message pool path*". As written this snippet teaches the opposite of the rest of the SDK.

Happy to take either or both in this PR if you'd prefer them dealt with now.
