### PR TITLE
fix(sdk): include <new> in the app entry points that use placement new

### DIFF
--- a/Libs/Source/AppSystem/EntryPoint/CustomGUI/main.cpp
+++ b/Libs/Source/AppSystem/EntryPoint/CustomGUI/main.cpp
@@ -15,6 +15,8 @@
  ******************************************************************************
  */
 
+#include <new>
+
 #include "SDK/Kernel/Kernel.hpp"
 #include "SDK/Kernel/KernelBuilder.hpp"
 #include "SDK/Kernel/KernelProviderGUI.hpp"

--- a/Libs/Source/AppSystem/EntryPoint/Service/main.cpp
+++ b/Libs/Source/AppSystem/EntryPoint/Service/main.cpp
@@ -15,6 +15,8 @@
  ******************************************************************************
  */
 
+#include <new>
+
 #include "SDK/Kernel/Kernel.hpp"
 #include "SDK/Kernel/KernelBuilder.hpp"
 #include "SDK/Kernel/KernelProviderService.hpp"


### PR DESCRIPTION
Both app entry points construct their application object with placement new into statically allocated storage:

- `EntryPoint/Service/main.cpp` — `sService = new (sServiceStorage) Service(kernel);`
- `EntryPoint/CustomGUI/main.cpp` — `sGui = new (sGuiStorage) Gui(kernel);`

The standard declares that `operator new` overload in `<new>`, but neither file includes it. `Kernel.hpp` pulls in only `<cassert>`, so the declaration is arriving transitively through the kernel include chain.

This adds the explicit include to both.

### Not a build fix

`Service/main.cpp` is in `UNA_SDK_SOURCES_APPSYSTEM` (`cmake/una-sdk.cmake`) and therefore compiles in every app build today, without error. So this is include-what-you-use hygiene against a transitive include that could disappear under a future header change or a different toolchain — not a repair of anything currently broken.

`CustomGUI/main.cpp` is referenced by no build in the repo (it needs an app-supplied `Gui.hpp`), so it has never been compiled at all; the same include is added there for consistency.

### Availability

`<new>` is already included by `Libs/Source/Calibration/{StrideLut,CadenceStrideModel,OutdoorStrideCalibrator}.cpp`, which link into the same ARM builds, so the header is proven available in this toolchain. Placement is a separate std-header group ahead of the project includes, matching those files.

### Verification

Inspection only — I have not run a firmware build for this. The change is a single additive standard include in each file with no other edits.

### Note on #243

#243 touches the include block of `CustomGUI/main.cpp` (line 20). This PR inserts above that line rather than modifying it, so the two should merge cleanly, but whichever lands second may want a quick rebase.
