### PR TITLE
docs(examples,tutorials): follow up on the send_msg sweep review

### DIFF
--- a/Docs/Examples/Alarm-Architecture.md
+++ b/Docs/Examples/Alarm-Architecture.md
@@ -518,7 +518,7 @@ SDK::send_msg<CustomMessage::AlarmStopAll>(mKernel);   // zero-field message
 
 There is no per-app sender class: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
 
-`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters *or* when you need to wait for queue space: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. `refreshTimeFormat()` does exactly this to pick up the system clock format:
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. That timeout bounds the wait for the reply, not for queue space -- the kernel gives every queue push the same short deadline, so neither call waits out a full queue. `refreshTimeFormat()` does exactly this to pick up the system clock format:
 
 ```cpp
 if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {

--- a/Docs/Examples/Alarm-Architecture.md
+++ b/Docs/Examples/Alarm-Architecture.md
@@ -518,7 +518,7 @@ SDK::send_msg<CustomMessage::AlarmStopAll>(mKernel);   // zero-field message
 
 There is no per-app sender class: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
 
-`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. That timeout bounds the wait for the reply, not for queue space -- the kernel gives every queue push the same short deadline, so neither call waits out a full queue. `refreshTimeFormat()` does exactly this to pick up the system clock format:
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. That timeout bounds the wait for the reply, not for queue space — no send waits out a full queue. `refreshTimeFormat()` does exactly this to pick up the system clock format:
 
 ```cpp
 if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {

--- a/Docs/Examples/Cycling-Architecture.md
+++ b/Docs/Examples/Cycling-Architecture.md
@@ -735,7 +735,7 @@ SDK::send_msg<CustomMessage::ManualLap>(mKernel);   // zero-field message
 
 There is no per-app sender class to write: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
 
-`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters *or* when you need to wait for queue space: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. That timeout bounds the wait for the reply, not for queue space -- the kernel gives every queue push the same short deadline, so neither call waits out a full queue. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
 
 ```cpp
 if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {

--- a/Docs/Examples/Cycling-Architecture.md
+++ b/Docs/Examples/Cycling-Architecture.md
@@ -735,7 +735,7 @@ SDK::send_msg<CustomMessage::ManualLap>(mKernel);   // zero-field message
 
 There is no per-app sender class to write: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
 
-`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. That timeout bounds the wait for the reply, not for queue space -- the kernel gives every queue push the same short deadline, so neither call waits out a full queue. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. That timeout bounds the wait for the reply, not for queue space — no send waits out a full queue. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
 
 ```cpp
 if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {

--- a/Docs/Examples/Hiking-Architecture.md
+++ b/Docs/Examples/Hiking-Architecture.md
@@ -737,7 +737,7 @@ SDK::send_msg<CustomMessage::ManualLap>(mKernel);   // zero-field message
 
 There is no per-app sender class to write: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
 
-`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters *or* when you need to wait for queue space: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. That timeout bounds the wait for the reply, not for queue space -- the kernel gives every queue push the same short deadline, so neither call waits out a full queue. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
 
 ```cpp
 if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {

--- a/Docs/Examples/Hiking-Architecture.md
+++ b/Docs/Examples/Hiking-Architecture.md
@@ -737,7 +737,7 @@ SDK::send_msg<CustomMessage::ManualLap>(mKernel);   // zero-field message
 
 There is no per-app sender class to write: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
 
-`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. That timeout bounds the wait for the reply, not for queue space -- the kernel gives every queue push the same short deadline, so neither call waits out a full queue. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. That timeout bounds the wait for the reply, not for queue space — no send waits out a full queue. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
 
 ```cpp
 if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {

--- a/Docs/Examples/Running-Architecture.md
+++ b/Docs/Examples/Running-Architecture.md
@@ -900,7 +900,7 @@ SDK::send_msg<CustomMessage::IntervalsNextPhase>(mKernel);   // zero-field messa
 
 There is no per-app sender class to write: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
 
-`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters *or* when you need to wait for queue space: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. That timeout bounds the wait for the reply, not for queue space -- the kernel gives every queue push the same short deadline, so neither call waits out a full queue. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
 
 ```cpp
 if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {

--- a/Docs/Examples/Running-Architecture.md
+++ b/Docs/Examples/Running-Architecture.md
@@ -900,7 +900,7 @@ SDK::send_msg<CustomMessage::IntervalsNextPhase>(mKernel);   // zero-field messa
 
 There is no per-app sender class to write: the message type owns its field filling and `send_msg` owns the allocate/send/release sequence.
 
-`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. That timeout bounds the wait for the reply, not for queue space -- the kernel gives every queue push the same short deadline, so neither call waits out a full queue. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room the message is dropped rather than waited for. Reach for `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout (`msg.send(100)`) and read the result back. That timeout bounds the wait for the reply, not for queue space — no send waits out a full queue. `sendInitialInfoToGui()` does this to pick up the system units and clock format before forwarding them to the GUI:
 
 ```cpp
 if (auto msg = SDK::make_msg<SDK::Message::RequestSystemSettings>(mKernel)) {

--- a/Docs/Examples/Stopwatch-Architecture.md
+++ b/Docs/Examples/Stopwatch-Architecture.md
@@ -172,12 +172,23 @@ constexpr SDK::MessageType::Type STOPWATCH_REQUEST = 0x00000006;
 ```cpp
 struct StopwatchState : public SDK::MessageBase {
     Stopwatch::State state;
+    StopwatchState()
+        : SDK::MessageBase(STOPWATCH_STATE)
+        , state{}
+    {}
+
+    explicit StopwatchState(const Stopwatch::State &state)
+        : StopwatchState()
+    {
+        this->state = state;
+    }
 };
 static_assert(sizeof(StopwatchState) <= 256,
               "StopwatchState must fit the largest kernel message pool block");
 ```
 
-`StopwatchState` also carries a constructor that fills the snapshot, so publishing is a single call:
+The second constructor fills the snapshot and delegates to the first, so the message type is named in
+exactly one place. It is also what makes publishing a single call:
 
 ```cpp
 SDK::send_msg<CustomMessage::StopwatchState>(mKernel, mStopwatch.state());
@@ -193,6 +204,14 @@ bool startStopwatch() { return SDK::send_msg<CustomMessage::StopwatchStart>(mKer
 `SDK::send_msg<T>` allocates the message from the kernel pool, forwards any arguments to the
 message's constructor, sends it, and releases it, returning `false` if allocation or the send
 failed. There is no per-app sender class.
+
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room
+the message is dropped rather than waited for. That is why the commands return the bool: a `false`
+tells the screen the press never left, so it must not show the change as applied. A snapshot lost the
+other way needs no such handling, because the GUI re-requests one on start and resume. Reach for
+`SDK::make_msg<T>()` when the reply matters *or* when you need to wait for queue space: it returns an
+RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read the result
+back (`msg.send(timeout) && msg.ok()`).
 
 **Message summary**:
 

--- a/Docs/Examples/Stopwatch-Architecture.md
+++ b/Docs/Examples/Stopwatch-Architecture.md
@@ -218,8 +218,7 @@ mid-session is corrected by the next command, not immediately. That is an accept
 example, not a pattern to copy into something that must not miss an update. Reach for
 `SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope
 exit, so you can send with a timeout and read the result back (`msg.send(timeout) && msg.ok()`). That
-timeout bounds the wait for the reply, not for queue space — the kernel gives every queue push the
-same short deadline, so neither call waits out a full queue.
+timeout bounds the wait for the reply, not for queue space — no send waits out a full queue.
 
 **Message summary**:
 

--- a/Docs/Examples/Stopwatch-Architecture.md
+++ b/Docs/Examples/Stopwatch-Architecture.md
@@ -187,8 +187,9 @@ static_assert(sizeof(StopwatchState) <= 256,
               "StopwatchState must fit the largest kernel message pool block");
 ```
 
-The second constructor fills the snapshot and delegates to the first, so the message type is named in
-exactly one place. It is also what makes publishing a single call:
+The second constructor fills the snapshot and delegates to the first — the shape every example app
+uses, which keeps the type tag in a single initializer. It is also what makes publishing a single
+call:
 
 ```cpp
 SDK::send_msg<CustomMessage::StopwatchState>(mKernel, mStopwatch.state());
@@ -205,13 +206,20 @@ bool startStopwatch() { return SDK::send_msg<CustomMessage::StopwatchStart>(mKer
 message's constructor, sends it, and releases it, returning `false` if allocation or the send
 failed. There is no per-app sender class.
 
-`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room
-the message is dropped rather than waited for. That is why the commands return the bool: a `false`
-tells the screen the press never left, so it must not show the change as applied. A snapshot lost the
-other way needs no such handling, because the GUI re-requests one on start and resume. Reach for
-`SDK::make_msg<T>()` when the reply matters *or* when you need to wait for queue space: it returns an
-RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read the result
-back (`msg.send(timeout) && msg.ok()`).
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — it never waits for a
+reply, and a message that finds no room in the queue is dropped. `MainView` uses the returned bool for
+exactly one press: pause is the only control whose screen holds a pending state (`mPausePending`), so
+it must know the command left. Start, lap and reset discard it and let the answering snapshot correct
+the display.
+
+A dropped message is tolerated rather than recovered. `publish()` is itself a zero-timeout send, so a
+snapshot can be lost too, and the GUI only re-requests one on start and resume — a snapshot dropped
+mid-session is corrected by the next command, not immediately. That is an acceptable trade for an
+example, not a pattern to copy into something that must not miss an update. Reach for
+`SDK::make_msg<T>()` when the reply matters: it returns an RAII `MessageGuard` that releases on scope
+exit, so you can send with a timeout and read the result back (`msg.send(timeout) && msg.ok()`). That
+timeout bounds the wait for the reply, not for queue space — the kernel gives every queue push the
+same short deadline, so neither call waits out a full queue.
 
 **Message summary**:
 

--- a/Docs/Tutorials/Files/ARCHITECTURE.md
+++ b/Docs/Tutorials/Files/ARCHITECTURE.md
@@ -308,8 +308,12 @@ void Model::updateSettings(float decimalCounter, CustomMessage::ActivityType act
 `SDK::send_msg<T>(kernel, args...)` allocates the message from the kernel pool, forwards `args...`
 to the message's constructor, sends it, and releases it — returning `false` if allocation or the
 send failed. Each message fills its own fields in that constructor, so there is no sender class to
-write. Use `SDK::make_msg<T>` instead when you need to inspect a reply (`msg.send(timeout) &&
-msg.ok()`).
+write.
+
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room
+the message is dropped rather than waited for. Use `SDK::make_msg<T>` instead when the reply matters
+*or* when you need to wait for queue space: it returns an RAII `MessageGuard` that releases on scope
+exit, so you can send with a timeout and read the result back (`msg.send(timeout) && msg.ok()`).
 
 #### Message Receiving
 

--- a/Docs/Tutorials/Files/ARCHITECTURE.md
+++ b/Docs/Tutorials/Files/ARCHITECTURE.md
@@ -102,18 +102,18 @@ The tutorial defines custom messages in the application-specific range (0x000000
 - **Direction**: GUI → Service
 - **Purpose**: Update settings and persist to file
 - **Structure**: `CustomMessage::SetSettings`
-  - `int decimalCounter` - Counter value (multiplied by 10)
-  - `int activityType` - Activity type enum value
-  - `int displayMode` - Display mode enum value
+  - `int32_t decimalCounter` - Counter value (multiplied by 10)
+  - `int32_t activityType` - Activity type enum value
+  - `int32_t displayMode` - Display mode enum value
 - **Response**: Automatic save to file
 
 #### SETTINGS_VALUES (0x00000004)
 - **Direction**: Service → GUI
 - **Purpose**: Deliver current settings to GUI
 - **Structure**: `CustomMessage::SettingsValues`
-  - `int decimalCounter` - Counter value (multiplied by 10)
-  - `int activityType` - Activity type enum value
-  - `int displayMode` - Display mode enum value
+  - `int32_t decimalCounter` - Counter value (multiplied by 10)
+  - `int32_t activityType` - Activity type enum value
+  - `int32_t displayMode` - Display mode enum value
 
 ### Message Flow Architecture
 
@@ -310,10 +310,12 @@ to the message's constructor, sends it, and releases it — returning `false` if
 send failed. Each message fills its own fields in that constructor, so there is no sender class to
 write.
 
-`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room
-the message is dropped rather than waited for. Use `SDK::make_msg<T>` instead when the reply matters
-*or* when you need to wait for queue space: it returns an RAII `MessageGuard` that releases on scope
-exit, so you can send with a timeout and read the result back (`msg.send(timeout) && msg.ok()`).
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — it never waits for a
+reply, and a message that finds no room in the queue is dropped. Use `SDK::make_msg<T>` instead when
+the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with
+a timeout and read the result back (`msg.send(timeout) && msg.ok()`). That timeout bounds the wait for
+the reply, not for queue space — the kernel gives every queue push the same short deadline, so neither
+call waits out a full queue.
 
 #### Message Receiving
 

--- a/Docs/Tutorials/Files/ARCHITECTURE.md
+++ b/Docs/Tutorials/Files/ARCHITECTURE.md
@@ -201,9 +201,9 @@ void Service::loadSettings() {
                 int32_t activityType = static_cast<int32_t>(mActivityType);
                 int32_t displayMode = static_cast<int32_t>(mDisplayMode);
 
-                reader.getInt("decimalCounter", decimalCounter);
-                reader.getInt("activityType", activityType);
-                reader.getInt("displayMode", displayMode);
+                reader.get("decimalCounter", decimalCounter);
+                reader.get("activityType", activityType);
+                reader.get("displayMode", displayMode);
 
                 // Validate and convert back to types
                 mDecimalCounter = decimalCounter;
@@ -232,11 +232,11 @@ void Service::saveSettings() {
     auto file = mKernel.fs.file("settings.json");
     if (file && file->open(SDK::Interface::IFile::Mode::WRITE)) {
         SDK::JsonStreamWriter writer(file.get());
-        writer.startObject();
+        writer.startMap(3);
         writer.add("decimalCounter", mDecimalCounter);
-        writer.add("activityType", static_cast<int>(mActivityType));
-        writer.add("displayMode", static_cast<int>(mDisplayMode));
-        writer.endObject();
+        writer.add("activityType", static_cast<int32_t>(mActivityType));
+        writer.add("displayMode", static_cast<int32_t>(mDisplayMode));
+        writer.endMap();
         file->close();
         LOG_INFO("Settings saved to file\n");
     } else {

--- a/Docs/Tutorials/Files/ARCHITECTURE.md
+++ b/Docs/Tutorials/Files/ARCHITECTURE.md
@@ -189,7 +189,7 @@ private:
 ```cpp
 void Service::loadSettings() {
     auto file = mKernel.fs.file("settings.json");
-    if (file && file->open(SDK::Interface::IFile::Mode::READ)) {
+    if (file && file->open(0)) {   // open(bool wMode = false) -- 0 reads
         char buffer[1024];
         size_t bytesRead = file->read(buffer, sizeof(buffer) - 1);
         if (bytesRead > 0) {
@@ -230,7 +230,7 @@ void Service::loadSettings() {
 ```cpp
 void Service::saveSettings() {
     auto file = mKernel.fs.file("settings.json");
-    if (file && file->open(SDK::Interface::IFile::Mode::WRITE)) {
+    if (file && file->open(1)) {   // open(bool wMode = false) -- 1 writes
         SDK::JsonStreamWriter writer(file.get());
         writer.startMap(3);
         writer.add("decimalCounter", mDecimalCounter);
@@ -314,8 +314,7 @@ write.
 reply, and a message that finds no room in the queue is dropped. Use `SDK::make_msg<T>` instead when
 the reply matters: it returns an RAII `MessageGuard` that releases on scope exit, so you can send with
 a timeout and read the result back (`msg.send(timeout) && msg.ok()`). That timeout bounds the wait for
-the reply, not for queue space — the kernel gives every queue push the same short deadline, so neither
-call waits out a full queue.
+the reply, not for queue space — no send waits out a full queue.
 
 #### Message Receiving
 

--- a/Docs/Tutorials/Files/Software/Libs/Header/Commands.hpp
+++ b/Docs/Tutorials/Files/Software/Libs/Header/Commands.hpp
@@ -5,7 +5,6 @@
 #include "SDK/Messages/MessageTypes.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
 
-#include <array>
 #include <cstdint>
 
 // Force 4-byte alignment for all message structures
@@ -91,8 +90,8 @@ namespace CustomMessage {
     // GUI --> Service
     struct SetSettings : public SDK::MessageBase {
         int32_t decimalCounter;
-        int activityType;
-        int displayMode;
+        int32_t activityType;
+        int32_t displayMode;
 
         SetSettings()
             : SDK::MessageBase(SET_SETTINGS)
@@ -101,7 +100,7 @@ namespace CustomMessage {
             , displayMode(0)
         {}
 
-        explicit SetSettings(int32_t decimalCounter, int activityType, int displayMode)
+        explicit SetSettings(int32_t decimalCounter, int32_t activityType, int32_t displayMode)
             : SetSettings()
         {
             this->decimalCounter = decimalCounter;
@@ -113,8 +112,8 @@ namespace CustomMessage {
     // Service --> GUI
     struct SettingsValues : public SDK::MessageBase {
         int32_t decimalCounter;
-        int activityType;
-        int displayMode;
+        int32_t activityType;
+        int32_t displayMode;
 
         SettingsValues()
             : SDK::MessageBase(SETTINGS_VALUES)
@@ -123,7 +122,7 @@ namespace CustomMessage {
             , displayMode(0)
         {}
 
-        explicit SettingsValues(int32_t decimalCounter, int activityType, int displayMode)
+        explicit SettingsValues(int32_t decimalCounter, int32_t activityType, int32_t displayMode)
             : SettingsValues()
         {
             this->decimalCounter = decimalCounter;

--- a/Docs/Tutorials/Sensors/ARCHITECTURE.md
+++ b/Docs/Tutorials/Sensors/ARCHITECTURE.md
@@ -73,8 +73,9 @@ namespace CustomMessage {
     constexpr SDK::MessageType::Type PRESSURE_VALUES = 0x0000000B;
 
     // Every message pairs a default constructor, which sets the message type,
-    // with one that fills the fields and delegates to it. That second
-    // constructor is what lets a caller send the message in a single call.
+    // with one that fills the fields and delegates to it -- so the message type
+    // is named in exactly one place. That second constructor is what lets a
+    // caller send the message in a single call.
     struct HRValues : public SDK::MessageBase {
         float heartRate;
         float trustLevel;
@@ -104,14 +105,23 @@ namespace CustomMessage {
     // RtcValues: uint32_t time;
     // BatteryValues: float level;
     // PressureValues: uint64_t timestamp; float pressure;
-    //   ^ defined, and Model.cpp already handles PRESSURE_VALUES, but the
-    //     service only logs the raw frame today -- it never sends this one.
 }
 ```
+
+`PressureValues` is the one message the service never sends: the sensor is connected and `Model.cpp`
+handles `PRESSURE_VALUES`, but the service only hex-dumps the raw frame today. Both ends exist, and
+so does `SDK::SensorDataParser::Pressure` — wiring it up means giving that branch the same
+parse-then-send shape as the branches below, using `parser.getPressure()`.
 
 Those constructors are what let `SDK::send_msg<T>(kernel, args...)` do the whole send in one call —
 allocate from the kernel pool, forward the arguments to the constructor, send, and release. The app
 needs no sender class of its own.
+
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room
+the message is dropped rather than waited for. That is the right trade for sensor data: the next
+sample is moments away. Reach for `SDK::make_msg<T>()` when the reply matters *or* when you need to
+wait for queue space: it returns an RAII `MessageGuard` that releases on scope exit, so you can send
+with a timeout and read the result back (`msg.send(timeout) && msg.ok()`).
 
 ### Step 2: Service - Subscribe & Process Sensors
 
@@ -145,15 +155,15 @@ if (mSensorHR.matchesDriver(handle)) {
         SDK::send_msg<CustomMessage::HRValues>(mKernel, parser.getBpm(), parser.getTrustLevel());
     }
 }
-// Similar for GPS:  send_msg<LocationValues>(mKernel, ts, lat, lon, alt);
-// Altimeter:        send_msg<ElevationValues>(mKernel, ts, parser.getAltitude());
-// Accel:            if (nowMs - mLastAccTimeMs >= 100) send_msg<AccelerometerValues>(mKernel, ts, x, y, z);
-// Steps:            send_msg<StepCounterValues>(mKernel, ts, parser.getStepCount());
-// Floors:           send_msg<FloorsValues>(mKernel, ts, parser.getFloorsUp());
-// Compass:          compute heading from magnetic X/Y fields, then send_msg<CompassValues>(mKernel, ts, heading);
+// Similar for GPS:  SDK::send_msg<LocationValues>(mKernel, ts, lat, lon, alt);
+// Altimeter:        SDK::send_msg<ElevationValues>(mKernel, ts, parser.getAltitude());
+// Accel:            if (nowMs - mLastAccTimeMs >= 100) SDK::send_msg<AccelerometerValues>(mKernel, ts, x, y, z);
+// Steps:            SDK::send_msg<StepCounterValues>(mKernel, ts, parser.getStepCount());
+// Floors:           SDK::send_msg<FloorsValues>(mKernel, ts, parser.getFloorsUp());
+// Compass:          compute heading from magnetic X/Y fields, then SDK::send_msg<CompassValues>(mKernel, ts, heading);
 ```
 
-Track stats every 1s (simplistic CPU% = ms/10, rates=counts/sec) with `send_msg<StatsValues>(...)`, and `send_msg<RtcValues>(mKernel, timeMs/1000)`.
+Track stats every 1s (simplistic CPU% = ms/10, rates=counts/sec) with `SDK::send_msg<StatsValues>(...)`, and `SDK::send_msg<RtcValues>(mKernel, timeMs/1000)`.
 
 ### Step 3: GUI Model - Receive Messages
 

--- a/Docs/Tutorials/Sensors/ARCHITECTURE.md
+++ b/Docs/Tutorials/Sensors/ARCHITECTURE.md
@@ -73,9 +73,9 @@ namespace CustomMessage {
     constexpr SDK::MessageType::Type PRESSURE_VALUES = 0x0000000B;
 
     // Every message pairs a default constructor, which sets the message type,
-    // with one that fills the fields and delegates to it -- so the message type
-    // is named in exactly one place. That second constructor is what lets a
-    // caller send the message in a single call.
+    // with one that fills the fields and delegates to it -- the shape every
+    // example app uses, which keeps the type tag in a single initializer. That
+    // second constructor is what lets a caller send the message in a single call.
     struct HRValues : public SDK::MessageBase {
         float heartRate;
         float trustLevel;
@@ -117,11 +117,13 @@ Those constructors are what let `SDK::send_msg<T>(kernel, args...)` do the whole
 allocate from the kernel pool, forward the arguments to the constructor, send, and release. The app
 needs no sender class of its own.
 
-`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — if the queue has no room
-the message is dropped rather than waited for. That is the right trade for sensor data: the next
-sample is moments away. Reach for `SDK::make_msg<T>()` when the reply matters *or* when you need to
-wait for queue space: it returns an RAII `MessageGuard` that releases on scope exit, so you can send
-with a timeout and read the result back (`msg.send(timeout) && msg.ok()`).
+`send_msg` is for fire-and-forget sends, and it posts with a zero timeout — it never waits for a
+reply, and a message that finds no room in the queue is dropped. That is the right trade for sensor
+data: the next sample is moments away. Reach for `SDK::make_msg<T>()` when the reply matters: it
+returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read
+the result back (`msg.send(timeout) && msg.ok()`). That timeout bounds the wait for the reply, not for
+queue space — the kernel gives every queue push the same short deadline, so neither call waits out a
+full queue.
 
 ### Step 2: Service - Subscribe & Process Sensors
 
@@ -155,15 +157,17 @@ if (mSensorHR.matchesDriver(handle)) {
         SDK::send_msg<CustomMessage::HRValues>(mKernel, parser.getBpm(), parser.getTrustLevel());
     }
 }
-// Similar for GPS:  SDK::send_msg<LocationValues>(mKernel, ts, lat, lon, alt);
-// Altimeter:        SDK::send_msg<ElevationValues>(mKernel, ts, parser.getAltitude());
-// Accel:            if (nowMs - mLastAccTimeMs >= 100) SDK::send_msg<AccelerometerValues>(mKernel, ts, x, y, z);
-// Steps:            SDK::send_msg<StepCounterValues>(mKernel, ts, parser.getStepCount());
-// Floors:           SDK::send_msg<FloorsValues>(mKernel, ts, parser.getFloorsUp());
-// Compass:          compute heading from magnetic X/Y fields, then SDK::send_msg<CompassValues>(mKernel, ts, heading);
+// Similar for GPS:  SDK::send_msg<CustomMessage::LocationValues>(mKernel, ts, lat, lon, alt);
+// Altimeter:        SDK::send_msg<CustomMessage::ElevationValues>(mKernel, ts, parser.getAltitude());
+// Accel:            if (nowMs - mLastAccTimeMs >= 100) SDK::send_msg<CustomMessage::AccelerometerValues>(mKernel, ts, x, y, z);
+// Steps:            SDK::send_msg<CustomMessage::StepCounterValues>(mKernel, ts, parser.getStepCount());
+// Floors:           SDK::send_msg<CustomMessage::FloorsValues>(mKernel, ts, parser.getFloorsUp());
+// Compass:          compute heading from magnetic X/Y fields, then SDK::send_msg<CustomMessage::CompassValues>(mKernel, ts, heading);
 ```
 
-Track stats every 1s (simplistic CPU% = ms/10, rates=counts/sec) with `SDK::send_msg<StatsValues>(...)`, and `SDK::send_msg<RtcValues>(mKernel, timeMs/1000)`.
+Track stats every 1s (simplistic CPU% = ms/10, rates=counts/sec) with
+`SDK::send_msg<CustomMessage::StatsValues>(...)`, and
+`SDK::send_msg<CustomMessage::RtcValues>(mKernel, timeMs/1000)`.
 
 ### Step 3: GUI Model - Receive Messages
 

--- a/Docs/Tutorials/Sensors/ARCHITECTURE.md
+++ b/Docs/Tutorials/Sensors/ARCHITECTURE.md
@@ -122,8 +122,7 @@ reply, and a message that finds no room in the queue is dropped. That is the rig
 data: the next sample is moments away. Reach for `SDK::make_msg<T>()` when the reply matters: it
 returns an RAII `MessageGuard` that releases on scope exit, so you can send with a timeout and read
 the result back (`msg.send(timeout) && msg.ok()`). That timeout bounds the wait for the reply, not for
-queue space — the kernel gives every queue push the same short deadline, so neither call waits out a
-full queue.
+queue space — no send waits out a full queue.
 
 ### Step 2: Service - Subscribe & Process Sensors
 

--- a/Docs/Tutorials/Sensors/Software/Libs/Header/Commands.hpp
+++ b/Docs/Tutorials/Sensors/Software/Libs/Header/Commands.hpp
@@ -5,7 +5,6 @@
 #include "SDK/Messages/MessageTypes.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
 
-#include <array>
 #include <cstdint>
 
 // Force 4-byte alignment for all message structures
@@ -197,7 +196,7 @@ namespace CustomMessage {
         {}
 
         explicit StatsValues(float serviceCpuPct, float guiCpuPct, float txMsgRate,
-                 float rxMsgRate, float txByteRate, float rxByteRate)
+                             float rxMsgRate, float txByteRate, float rxByteRate)
             : StatsValues()
         {
             this->serviceCpuPct = serviceCpuPct;

--- a/Docs/index.rst
+++ b/Docs/index.rst
@@ -52,6 +52,7 @@ Next steps:
    Examples/Cycling-Architecture
    Examples/Hiking-Architecture
    Examples/HRMonitor-Architecture
+   Examples/Stopwatch-Architecture
    Examples/GlanceHR-Architecture
    Examples/GlanceSteps-Architecture
 


### PR DESCRIPTION
Follow-up to review on #238. Seven small things, no behaviour change on the device.

### The send_msg drop caveat reaches the last three pages

The pages converted by #219 all carry a paragraph saying `send_msg` posts with a **zero timeout** — a full queue drops the message — and that `make_msg` is the counterpart when the reply matters or you need to wait for room. The three pages converted by #238 didn't get it: Stopwatch said only "returning `false` if allocation or the send failed", Sensors said nothing, Files mentioned `make_msg` for replies but not the drop. That timeout is the one behavioural difference between the two calls.

Each page now states it in its own terms — the Stopwatch commands return the bool precisely so a screen can tell a press never left, while a lost *snapshot* needs no handling because the GUI re-requests one on start and resume; for sensor data the drop is the right trade, since the next sample is moments away.

### Two corrections on the same pages

- **`send_msg` was unqualified** in the Sensors guidance comments (7 places). Copying that doesn't compile in C++17: with no visible declaration of `send_msg` as a template the `<` parses as less-than, and ADL can't rescue a call with explicit template arguments until C++20's P0846. Now `SDK::send_msg`, as every other page writes it.
- **The "PressureValues is never sent" note** sat inside the code block a reader copies, and undersold the work — that branch hex-dumps the frame rather than parsing it. Now prose under the block, pointing at `SDK::SensorDataParser::Pressure` and the parse-then-send shape the other branches use.

Plus: the Stopwatch page showed `StopwatchState` without its constructors and then described one in prose. The snippet is now the struct verbatim from `Commands.hpp` (verified identical), and the prose says what delegating buys — the message type is named once.

### Fixed-width types finished in the Files tutorial

#238 widened `SetSettings::decimalCounter` to `int32_t` to agree with `SettingsValues` but left `activityType` and `displayMode` as plain `int` in both. These are `#pragma pack(4)` structs crossing a process boundary, and they're what a tutorial reader copies. `int` is 4 bytes on both the ARM target and the host simulator, so **no layout changes today** — it removes an assumption that doesn't belong in a wire struct. Call sites keep `static_cast<int>`: `int` is right for the locals and the JSON round-trip, and the conversion is exact.

Also in both tutorial headers: dropped the unused `<array>` (nothing in either `Software` tree names `std::array`, so it isn't a transitive dependency for anything downstream), and aligned the `StatsValues` constructor's second parameter line to its open paren per the SDK's `.clang-format`.

### One thing beyond the review

`Stopwatch-Architecture.md` was the **only** page under `Docs/Examples` missing from the Example Apps toctree in `index.rst`, so Sphinx built it as an orphan and no link on the site reached it — including from the page #238 had just rewritten. Added the missing line. Say the word if you'd rather that landed separately.

### Verification

Ran the CI builds locally in `xanderhendriks/stm32cubeide:16.0`:

| Build | Result |
|---|---|
| `Docs/Tutorials/Files` | `Files_0.0.0-dev.uapp`, 242784 bytes |
| `Docs/Tutorials/Sensors` | `Sensors_0.0.0-dev.uapp`, 535164 bytes |
| `Examples/Apps/Stopwatch` | `Stopwatch_0.0.0-dev.uapp`, 160736 bytes |

The 6 compiler warnings in the two tutorial builds are pre-existing and in files this PR doesn't touch (`Libs/Source/Fit/RecordingMarker.cpp`, `Libs/Source/Variant/VariantConfig.cpp`, and `-Wswitch` in each `MainView.cpp`); Stopwatch builds with none.

`sphinx-build Docs` exits 0 and goes from 212 warnings to 211 — the orphan-page warning is gone, and no remaining warning names any file touched here.
