### PR TITLE
fix(simulator): clean up the include and format nits left by #222

### DIFF
--- a/Libs/Header/SDK/Simulator/Kernel/Mock/AppMemory.hpp
+++ b/Libs/Header/SDK/Simulator/Kernel/Mock/AppMemory.hpp
@@ -27,7 +27,7 @@ public:
     virtual void *malloc(size_t size) override
     { 
         void *p = std::malloc(size);
-        printf("malloc %p %d bytes\n", p, size);
+        printf("malloc %p %zu bytes\n", p, size);
         return p;
     }
 
@@ -39,7 +39,7 @@ public:
 
     void* realloc(void* ptr, size_t size) override
     {
-        printf("realloc  %p:%d\n", ptr, size);
+        printf("realloc  %p:%zu\n", ptr, size);
         return std::realloc(ptr, size);
     }
 

--- a/Libs/Header/SDK/Simulator/Kernel/Mock/Logger.hpp
+++ b/Libs/Header/SDK/Simulator/Kernel/Mock/Logger.hpp
@@ -17,6 +17,8 @@
 #include "SDK/Simulator/OS/OS.hpp"
 #include "touchgfx/Utils.hpp"
 
+#include <cstdio>
+
 // GetTickCount64() is Windows-only. Provide a portable wrapper.
 #ifndef _WIN32
 #include <cstdint>

--- a/Libs/Source/Simulator/Components/Sensors/SensorBatteryLevel.cpp
+++ b/Libs/Source/Simulator/Components/Sensors/SensorBatteryLevel.cpp
@@ -16,12 +16,12 @@
 
 #include "SDK/Simulator/Components/Sensors/SensorBatteryLevel.hpp"
 #include "SDK/SensorLayer/DataParsers/SensorDataParserBatteryLevel.hpp"
-#include <cmath>
 #include <SDK/Simulator/Kernel/Mock/System.hpp>
 #include "SDK/Simulator/OS/OS.hpp"
 #include "SDK/Simulator/Components/ComponentSimulator.hpp"
 
 #include <inttypes.h>
+#include <cmath>
 
 namespace Sensor
 {
@@ -105,7 +105,7 @@ void BatteryLevel::sensorRefresh()
     float level = mBattLevel.getBattLevel();
 
     OS::MutexCS cs(mDataMutex);
-    if (mPrevLevel > 0 && std::fabs(mPrevLevel - level) < 0.1) {
+    if (mPrevLevel > 0 && std::fabs(mPrevLevel - level) < 0.1f) {
         LOG_DEBUG("EXIT\n");
         return;
     }

--- a/Libs/Source/Simulator/Kernel/Mock/System.cpp
+++ b/Libs/Source/Simulator/Kernel/Mock/System.cpp
@@ -5,7 +5,6 @@
 
 // GetTickCount64() and Sleep() are Windows-only. Provide portable replacements.
 #ifndef _WIN32
-#include <cstdint>
 #include <time.h>
 #include <unistd.h>
 static inline uint64_t GetTickCount64()


### PR DESCRIPTION
Follow-ups from the review of #222. That PR fixed the substantive problem — `Mock/System.hpp` forcing TouchGFX and SDL2 headers on every simulator component that included it — but left a few loose ends in the files it touched. All four changes here are cosmetic or latent-UB cleanups; none changes behaviour on the simulator as currently built.

### `SensorBatteryLevel.cpp`

- Move `<cmath>` out from between two quoted project includes and into the standard-library group at the bottom, after `<inttypes.h>`. That order is what `.clang-format` would produce: `IncludeCategories` gives `^<.*\.h>` priority 1 and `^<.*` priority 2 (`.clang-format:54-58`), and the two sit in one contiguous block.
- Compare against `0.1f` rather than `0.1`, so the `float` from `std::fabs` isn't promoted to `double` purely to be compared. The comparison result is identical for every input, since no float lies between `double(0.1)` and `double(0.1f)`. This was the one unaddressed item from both review threads on #222.

### `Mock/System.cpp`

- Drop the `#include <cstdint>` inside the `#ifndef _WIN32` block. The unconditional include four lines above already covers the `uint32_t`/`uint64_t` uses in that block.

### `Mock/Logger.hpp`

- Add `<cstdio>` for `sprintf`/`snprintf`/`vsnprintf`. These were resolving only because `Kernel.hpp` — the header's sole includer in the repo — happens to include `Mock/AppMemory.hpp` (which includes `<cstdio>`) two lines earlier at `Kernel.hpp:18`. That's sibling include order, the same class of fragility #222 set out to remove, and it would break the moment someone reordered those four mock includes or included `Logger.hpp` on its own.
- Deliberately nothing else: `va_list`/`va_start` and the fixed-width integer types come from `ILogger.hpp`, which includes `<cstdarg>` and `<cstdint>` directly (`ILogger.hpp:14-15`), so they're already covered by a first-party include.

### `Mock/AppMemory.hpp`

- Print `size_t` with `%zu` instead of `%d`. The mismatch is undefined behaviour on both targets, though benign in practice either way: a signedness mismatch on the 32-bit MSVC simulator, and on the 64-bit Linux simulator it reads the low four bytes of an eight-byte argument, which still holds the true size for any allocation under 2 GiB. The specifier should match the type regardless. Both occurrences in the file are fixed; there are no others.

## Verification

MSVC build of the Running app simulator, which per the source manifests is the only build that compiles `Libs/Source/Simulator/**` (the host tests and the ARM builds don't cover these files):

- `SensorBatteryLevel.cpp`, `Mock/System.cpp` and `Kernel.cpp` (which pulls in both `Logger.hpp` and `AppMemory.hpp`) all recompile — **0 warnings, 0 errors** at `/W3` — and `Application.exe` still links.

## Deliberately not included

Three larger items from the #222 review are left out, as none is a nit and each deserves its own change:

1. **`Simulator/Kernel/Kernel.hpp` still pulls in TouchGFX** via `Mock/Logger.hpp` → `touchgfx/Utils.hpp` (for `touchgfx_printf`). So #222's "headless" claim holds for SDL2 but not for TouchGFX. Fixing it means giving `Logger` a `.cpp` and moving the inline implementation out of the header, which also means adding it to four source manifests.
2. **`Mock/System.cpp` itself still can't compile headless** — `SystemGUI::exit()` needs SDL2. If linking `Mock::System::GetTimeMs()` into a host-test binary is the actual goal, `SystemGUI` wants splitting into its own TU.
3. **No regression guard.** `linux-simulator.yml` is non-gating despite being the job that does most of the real verification for simulator changes. A `Tests/Host` target that compiles a TU including `Mock/System.hpp` with no SDL2/TouchGFX include paths on the command line would make #222's invariant self-defending, rather than a convention that survives only until someone re-adds an include.

## Separately: two real bugs in `Mock/Logger.hpp`, not fixed here

Both are pre-existing, unrelated to includes, and live in the same function — `Logger::svlog`:

1. **`Logger.hpp:101`** — `touchgfx_printf("%s%s%%s", timeBuff, level, userMsg)`. `%%s` is an escaped literal `%s`, so `userMsg` is never consumed: any log call with no module/func/line metadata silently drops its message and emits a literal `%s`. The same line passes `level` to `%s`, but this branch is reachable with `level == nullptr` — via `vprintf` → `mvprintf(nullptr, nullptr, nullptr, 0, …)` at `Logger.hpp:52-55` — which is UB.
2. **`Logger.hpp:78-81` / `:99`** — `levelBuff` is `static` but only written when `level != nullptr`, then printed unconditionally. So a call that has metadata but a null level prints the *previous* call's level tag.

Left alone on purpose so this PR stays reviewable as pure hygiene — fixing them changes observable log output, which would falsify this PR's own "no behaviour change" premise. Happy to fix them here if you'd rather, or open it separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulator compatibility when logging memory allocation sizes.
  * Corrected battery-level comparison precision for more consistent sensor behavior.
* **Refactor**
  * Updated simulator portability and logging includes without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->