### PR TITLE
fix(simulator): repair the format and overflow bugs in Mock::Logger::svlog

### DIFF
--- a/Libs/Header/SDK/Simulator/Kernel/Mock/Logger.hpp
+++ b/Libs/Header/SDK/Simulator/Kernel/Mock/Logger.hpp
@@ -65,6 +65,37 @@ public:
 private:
     static inline OS::Mutex mMutexLog;
 
+    /**
+     * @brief   snprintf() that reports how much it actually wrote rather than
+     *          how much it would have written, so the result is safe to use as
+     *          a buffer offset.
+     * @return  Characters written, excluding the terminator: never more than
+     *          size - 1, and 0 when size is 0 or the encoding failed.
+     *
+     * The format attribute keeps -Wformat checking on the call sites, which a
+     * plain variadic wrapper would otherwise hide from the compiler.
+     */
+#if defined(__GNUC__)
+    __attribute__((format(printf, 3, 4)))
+#endif
+    static size_t appendTo(char* buf, size_t size, const char* fmt, ...)
+    {
+        if (size == 0) {
+            return 0;
+        }
+
+        va_list args;
+        va_start(args, fmt);
+        const int written = vsnprintf(buf, size, fmt, args);
+        va_end(args);
+
+        if (written < 0) {
+            return 0;
+        }
+
+        return (static_cast<size_t>(written) < size - 1) ? static_cast<size_t>(written) : size - 1;
+    }
+
     static void svlog(const char* level, const char* module_name, const char* func, int line,
         const char* fmt, va_list args)
     {
@@ -75,21 +106,21 @@ private:
         char timeBuff[16] = { 0 };
         sprintf(timeBuff, "%10u ", time);
 
-        static char levelBuff[10]{};
+        char levelBuff[10] = { 0 };
         if (level) {
-            sprintf(levelBuff, "-%s- ", level);
+            snprintf(levelBuff, sizeof(levelBuff), "-%s- ", level);
         }
 
         static char meta[64]{};
-        int idx = 0;
+        size_t idx = 0;
         if (module_name) {
-            idx += snprintf(&meta[idx], sizeof(meta) - idx, "%s::", module_name);
+            idx += appendTo(&meta[idx], sizeof(meta) - idx, "%s::", module_name);
         }
         if (func) {
-            idx += snprintf(&meta[idx], sizeof(meta) - idx, "%s", func);
+            idx += appendTo(&meta[idx], sizeof(meta) - idx, "%s", func);
         }
         if (line != 0) {
-            idx += snprintf(&meta[idx], sizeof(meta) - idx, "%s%d", func ? "::" : "", line);
+            idx += appendTo(&meta[idx], sizeof(meta) - idx, "%s%d", func ? "::" : "", line);
         }
 
         char userMsg[2048];
@@ -98,7 +129,7 @@ private:
         if (idx) {
             touchgfx_printf("%s%s%-36s: %s", timeBuff, levelBuff, meta, userMsg);
         } else {
-            touchgfx_printf("%s%s%%s", timeBuff, level, userMsg);
+            touchgfx_printf("%s%s%s", timeBuff, levelBuff, userMsg);
         } 
     }
 };


### PR DESCRIPTION
Four fixes to `Mock::Logger::svlog`. The first two are the bugs #247 documented but deliberately left alone, since fixing them changes observable log output and #247 claimed no behaviour change. The two overflows came out of review of this PR.

## 1. The no-metadata branch threw the caller's message away

```cpp
touchgfx_printf("%s%s%%s", timeBuff, level, userMsg);
```

`%%s` is an escaped literal `%s`, so `userMsg` was never consumed: the line printed a literal `%s` and discarded the message. The same call passed the raw `level` pointer to `%s`, which for every in-repo caller of this branch is `nullptr` — both `ILogger::printf` and `ILogger::vprintf` funnel into `mvprintf(nullptr, nullptr, nullptr, 0, …)` — and that's undefined behaviour. MSVC's UCRT happens to print `(null)` rather than crashing.

Now prints `timeBuff`, the formatted level tag and `userMsg`, matching the shape of the metadata branch directly above it. That this is the *intended* shape is corroborated by `AppSystem/system.cpp:98`, an `ILogger::printf` caller that hand-embeds its own `-E- system::una_init_kernel:98:` prefix into the message text — i.e. the printf path is expected to emit the message verbatim, with no automatic metadata.

## 2. `levelBuff` leaked a stale level tag

It was `static` but only written when `level != nullptr`, then printed unconditionally, so a call carrying metadata but no level emitted the *previous* call's tag. It's now a plain local, zero-initialised exactly like `timeBuff` above it, so an absent level yields an empty tag instead of a stale one.

## 3. `levelBuff`'s `sprintf` → `snprintf`

`"-%s- "` needs `strlen(level) + 4` bytes against a 10-byte buffer, so a level string of 7+ characters overflowed it (`"VERBOSE"` needs 11). Unreachable via the `LOG` macros, which pass `"D"`/`"I"`/`"W"`/`"E"`, but making the buffer a local in (2) moved the landing site of any such overflow from static storage to the stack — so bounding it belongs with that change rather than after it.

## 4. The `meta` accumulation could write out of bounds

`snprintf` returns the length it *would* have written, so

```cpp
idx += snprintf(&meta[idx], sizeof(meta) - idx, ...)
```

let `idx` run past `sizeof(meta)`. The next call then computed a `size_t` size argument that underflowed to ~1.8e19 and wrote through a pointer already past the end. A 46-character module prefix plus a 26-character function name reaches `idx = 80` against a 64-byte buffer.

That's less remote than a hand-picked prefix suggests: `LOG_MODULE_PRX` **defaults to `__FILENAME__`** (`UnaLogger/Logger.h:67-69`), so any translation unit that doesn't define its own contributes a whole filename.

Fixed by introducing `appendTo()`, an `snprintf` wrapper that reports what it *actually* wrote rather than what it would have written, making the return value safe to accumulate as an offset. `idx` becomes `size_t` and is now bounded by `sizeof(meta) - 1` by construction. The three call sites keep their original shape.

`appendTo()` carries `__attribute__((format(printf, 3, 4)))` under `__GNUC__`. A plain variadic wrapper hides its format string from the compiler, which would have silently dropped the `-Wformat=2` coverage the gcc simulator build enables — `una/Makefile:85-92` builds that flag list with `$(addprefix -W,$(WARN))`, so `-Wformat=2` never appears literally in the file and is easy to miss. Indices 3 and 4 are correct because `appendTo` is a *static* member, so there's no implicit `this`. Note the same makefile appends `-Wno-error` after those flags (`:176`), so format problems there surface as warnings rather than build failures, and that job is non-gating — which is precisely why keeping the diagnostic alive is worth two lines.

## Reachability — (1) and (2) are latent, not live

- **Nothing compiled into the simulator** calls `ILogger::printf`/`vprintf`. There are two first-party callers — `AppSystem/system.cpp:98` and `:325` — but that file is the ARM `.uapp` runtime and appears in no simulator vcxproj, so it never reaches this mock.
- No in-repo path passes a null level *alongside* metadata: `Logger_message` always supplies one of `"D"`/`"I"`/`"W"`/`"E"` from the `LOG` macros (`UnaLogger/Logger.h:140-141`), so (2) needs a direct `mvprintf` call to trigger.

Both are reachable by **app** code: `SDK::Kernel` exposes `ILogger` as the public `log` member (`SDK/Kernel/Kernel.hpp:61`) and `IKIP` publishes `IID_LOGGER` (served at `Simulator/Kernel/Kernel.cpp:107`), so any app calling `kernel.log.printf(...)` lands on (1) as things stand.

## Verification

**1. Standalone repro of both output branches**, MSVC, with `touchgfx_printf` stubbed to `printf`:

```
== Bug 1: no-metadata branch (ILogger::printf path, level == nullptr) ==
  [before]       1234 (null)%s
  [after ]       1234 hello 42
== Bug 2: stale level tag when level == nullptr but metadata present ==
  [before] meta-branch prints: '-E- modA::f '
  [before] meta-branch prints: '-E- modB::g '      <-- stale "-E- "
  [after ] meta-branch prints: '-E- modA::f '
  [after ] meta-branch prints: 'modB::g '
```

**2. Canary test for (4)** — a guard string placed immediately after `meta`:

```
== long prefix (overflow case) ==
  before: idx= 80  size arg for a further append would be 18446744073709551600
          canary: CLOBBERED
  after : idx= 63  size arg for a further append would be 1
          canary: intact   meta='SomeVeryLongScreenPresenterBase_1234567890.cpp::onVeryLongDescr'
== typical prefix (must be unchanged by the clamp) ==
  before: idx= 36  meta='Sensor.BattLevel::sensorRefresh::108' canary: intact
  after : idx= 36  meta='Sensor.BattLevel::sensorRefresh::108' canary: intact
```

The old code demonstrably writes out of bounds; the new code truncates cleanly. Typical input is byte-identical either way, so the clamp is behaviour-neutral on anything the codebase actually logs.

**3. gcc 14.3 under the simulator's own warning set**, since MSVC never checked either form and the attribute only bites on gcc:

```
[1] the three real call sites, attribute on  -> clean, no false positives
[2] a deliberate %s-versus-int mismatch      -> warning: format '%s' expects argument of
                                                type 'char*', but argument 4 has type 'int'
[3] same mismatch, attribute removed         -> 0 diagnostics
```

So the annotation is demonstrably doing the work, and the real formats don't trip it.

**4. Full MSVC build of the Running app simulator.** Links cleanly, with no warnings from `Logger.hpp` or any of its includers. The app simulator builds are the only ones that compile `Libs/Source/Simulator/**` at all — MSVC locally, gcc for the Linux job in CI; the host tests and the ARM builds don't cover these files. (The tree carries pre-existing warnings — `C4305` in `InstanceSensorLayer.cpp`, `C4244` in the Running app's `Service.cpp`, an STL `<semaphore>`/C++20 notice — all in files this PR doesn't touch.)

## Deliberately unchanged

**`meta` stays `static`.** Unlike `levelBuff` it's only printed when `idx != 0`, which implies this call wrote at offset 0, and `snprintf` always NUL-terminates — so it can't leak a previous call's contents. Needless as a `static`, but not a bug, and de-static-ing it isn't needed for any fix here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected log output when metadata is unavailable so messages display properly.
  * Improved logging reliability by safely handling empty buffers, encoding failures, and output length limits.
  * Enhanced formatting consistency for logger metadata and severity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->