### PR TITLE
fix(apps): report accumulated ascent as the summary elevation everywhere

### DIFF
--- a/Examples/Apps/Cycling/Software/Libs/Header/ActivitySummary.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/ActivitySummary.hpp
@@ -37,7 +37,7 @@ struct ActivitySummary {
     time_t time;        ///< Total track time in seconds
     float distance;     ///< Total track distance in m
     float speedAvg;     ///< Average speed in m/s
-    float elevation;    ///< Elevation in m
+    float elevation;    ///< Accumulated elevation gain (ascent) in m
     float paceAvg;      ///< Average pace in s/m
     float hrMax;        ///< Maximum Heart Rate in bpm
     float hrAvg;        ///< Average Heart Rate in bpm

--- a/Examples/Apps/Cycling/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/ActivityWriter.cpp
@@ -437,7 +437,7 @@ bool ActivityWriter::saveSummary(const TrackData& track)
     writer.add("duration", static_cast<uint32_t>(track.duration));
     writer.add("distance", track.distance);
     writer.add("hr_avg", track.hrAvg);
-    writer.add("elevation", track.ascent - track.descent);
+    writer.add("elevation", track.ascent);  // accumulated gain, matching the on-watch summary
     writer.add("activity_type", "cycling");
     writer.endMap();
 

--- a/Examples/Apps/Hiking/Software/Libs/Header/ActivitySummary.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/ActivitySummary.hpp
@@ -38,7 +38,7 @@ struct ActivitySummary {
     float distance;     ///< Total track distance in m
     float speedAvg;     ///< Average speed in m/s
     uint32_t steps;     ///< Total steps count
-    float elevation;    ///< Elevation in m
+    float elevation;    ///< Accumulated elevation gain (ascent) in m
     float paceAvg;      ///< Average pace in s/m
     float hrMax;        ///< Maximum Heart Rate in bpm
     float hrAvg;        ///< Average Heart Rate in bpm

--- a/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/ActivityWriter.cpp
@@ -467,7 +467,7 @@ bool ActivityWriter::saveSummary(const TrackData& track)
     writer.add("duration", static_cast<uint32_t>(track.duration));
     writer.add("distance", track.distance);
     writer.add("hr_avg", track.hrAvg);
-    writer.add("elevation", track.ascent - track.descent);
+    writer.add("elevation", track.ascent);  // accumulated gain, matching the on-watch summary
     writer.add("activity_type", sportName(mSport));
     writer.endMap();
 

--- a/Examples/Apps/Running/Software/Libs/Header/ActivitySummary.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/ActivitySummary.hpp
@@ -37,7 +37,7 @@ struct ActivitySummary {
     time_t time;        ///< Total track time in seconds
     float distance;     ///< Total track distance in m
     float speedAvg;     ///< Average speed in m/s
-    float elevation;    ///< Elevation in m
+    float elevation;    ///< Accumulated elevation gain (ascent) in m
     float paceAvg;      ///< Average pace in s/m
     float hrMax;        ///< Maximum Heart Rate in bpm
     float hrAvg;        ///< Average Heart Rate in bpm

--- a/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp
@@ -496,7 +496,7 @@ bool ActivityWriter::saveSummary(const TrackData& track)
     writer.add("duration", static_cast<uint32_t>(track.duration));
     writer.add("distance", track.distance);
     writer.add("hr_avg", track.hrAvg);
-    writer.add("elevation", track.ascent - track.descent);
+    writer.add("elevation", track.ascent);  // accumulated gain, matching the on-watch summary
     writer.add("activity_type", "running");
     writer.endMap();
 

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -1057,7 +1057,7 @@ void Service::buildPartialSummary()
     mSummary.time      = mTimeCounter.getValueActive();
     mSummary.distance  = mDistanceCounter.getValueActive();
     mSummary.speedAvg  = speedFromTotals(mSummary.distance, mSummary.time);
-    mSummary.elevation = mAltitudeCounter.getCurrent();
+    mSummary.elevation = mAltitudeCounter.getAscent();
     mSummary.paceAvg   = getPace(mSummary.speedAvg, mSpeedCounter.getMinValid());
     mSummary.hrMax     = mHrCounter.getMaximum();
     mSummary.hrAvg     = mHrCounter.getAverage();

--- a/Examples/Apps/Treadmill/Software/Libs/Header/ActivitySummary.hpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Header/ActivitySummary.hpp
@@ -37,7 +37,7 @@ struct ActivitySummary {
     time_t time;        ///< Total track time in seconds
     float distance;     ///< Total track distance in m
     float speedAvg;     ///< Average speed in m/s
-    float elevation;    ///< Elevation in m
+    float elevation;    ///< Accumulated elevation gain (ascent) in m
     float paceAvg;      ///< Average pace in s/m
     float hrMax;        ///< Maximum Heart Rate in bpm
     float hrAvg;        ///< Average Heart Rate in bpm

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/ActivityWriter.cpp
@@ -478,7 +478,7 @@ bool ActivityWriter::saveSummary(const TrackData& track)
     writer.add("duration", static_cast<uint32_t>(track.duration));
     writer.add("distance", track.distance);
     writer.add("hr_avg", track.hrAvg);
-    writer.add("elevation", track.ascent - track.descent);
+    writer.add("elevation", track.ascent);  // accumulated gain, matching the on-watch summary
     writer.add("activity_type", "treadmill");
     writer.endMap();
 

--- a/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Treadmill/Software/Libs/Sources/Service.cpp
@@ -983,7 +983,7 @@ void Service::buildPartialSummary()
     mSummary.time      = mTimeCounter.getValueActive();
     mSummary.distance  = mDistanceCounter.getValueActive();
     mSummary.speedAvg  = speedFromTotals(mSummary.distance, mSummary.time);
-    mSummary.elevation = mAltitudeCounter.getCurrent();
+    mSummary.elevation = mAltitudeCounter.getAscent();
     mSummary.paceAvg   = getPace(mSummary.speedAvg, mSpeedCounter.getMinValid());
     mSummary.hrMax     = mHrCounter.getMaximum();
     mSummary.hrAvg     = mHrCounter.getAverage();


### PR DESCRIPTION
## What

Finishes the job started by 1b876802 ("show accumulated ascent for summary ELEV. GAIN"), which fixed
Hiking and Cycling but left three inconsistencies behind.

1. **Running and Treadmill** still assigned `mAltitudeCounter.getCurrent()` to `mSummary.elevation`, so
   the same `ActivitySummary::elevation` field meant *accumulated gain* in two apps and *absolute
   altitude* in the other two.
2. **`ActivityWriter::saveSummary`** wrote `"elevation"` as `ascent - descent` in all four apps — net
   elevation change, which is ~0 for any loop route and never matches the gain shown on the watch.
   Now writes `track.ascent`.
3. **The doc comment** on `ActivitySummary::elevation` still said `///< Elevation in m` in all four
   apps after the July fix changed what the field holds.

10 files, 10 lines, no logic beyond the substitutions.

## Observable impact

**None on the watch.** Neither Running's nor Treadmill's `TrackSummaryView` renders `summary.elevation`,
and the value persisted to `Activity/summary.json` is unreachable: it is loaded at `Service::init` and
pushed to the GUI, but the only two routes into `TrackSummaryScreen` (the pause menu's `ID_SUMMARY`, and
the automatic hop after `TrackSaved`) both require an activity, and `startTrack()` zeroes `mSummary`
first. `Model::isTrackSummaryAvailable()` — presumably the hook for a "view last activity" entry — has
no callers in any app. So this change is latent: it stops the wrong value being persisted under a field
the sibling apps use for gain.

**The sidecar change does leave the watch**, alongside the `.fit`.

## ⚠️ Cross-repo: the phone team needs to know

`"elevation"` in the per-activity sidecar (`Activity/YYYYMM/activity_<timestamp>.json`) changes meaning
from net elevation change to accumulated gain. Nothing in this repo or the kernel reads that key, so the
phone app is the only consumer.

There is **no schema version** in the sidecar, so a reader cannot distinguish an old file (net) from a
new one (gain). Activities already on a watch keep the old semantics. The defensive alternative was to
add a new `"ascent"` key and leave `"elevation"` alone — worth a second opinion before merge, since
reverting the semantic later is harder than not changing it now.

## Verification

- Native ARM builds (Ninja + CubeIDE arm-gcc 14.3) of all four apps: no compile or link errors,
  `.uapp` images produced for each.
- Reviewed by an independent agent sweep across all 15 app directories: no missed sibling. **Workout**
  (the fifth activity app) feeds an altitude counter but never writes elevation to either JSON, so
  there was nothing to fix there. Every remaining `getCurrent()` feed drives a widget labelled
  "ELEVATION"/"Elevation" (current altitude — correct), never "ELEV. GAIN".
- No host test asserts sidecar JSON content, so nothing needed updating. The only related test
  (`Tests/Host/apps/Running/ActivityWriter_test.cpp:288`) covers failure handling.

## Follow-ups (not in this PR)

- A host test pinning the new sidecar semantic, to stop it drifting back.
- `Workout`'s altitude counter is fed, paused and resumed but never read — pre-existing, out of scope.
- The "view last activity" screen that `isTrackSummaryAvailable()` was written for is still unbuilt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activity summaries now report accumulated elevation gain (ascent) consistently.
  * Corrected full and partial summaries to avoid using net elevation or current altitude.
* **Documentation**
  * Clarified that the elevation field represents total ascent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->