### PR TITLE
ci(apps): keep HRMonitor out of the apps release zip

### DIFF
--- a/.github/workflows/apps-ci.yml
+++ b/.github/workflows/apps-ci.yml
@@ -111,10 +111,22 @@ jobs:
       - name: Prepare release zip
         env:
           REF_NAME: ${{ github.ref_name }}
+          # Apps that are still built and CI-tested, but do NOT ship on the watch and
+          # are therefore left out of the release zip. Space-separated app names.
+          # HRMonitor is a pure SDK reference example, unlike its siblings under
+          # Examples/Apps which are the real shipping apps.
+          # NOT the same knob as APPS_EXCLUDED (see generate-app-list.py): that one
+          # drops an app from the build matrix entirely, so it stops being compiled
+          # and CI-tested. Use this one to ship less, that one to build less.
+          RELEASE_EXCLUDED_APPS: HRMonitor
         run: |
           mkdir -p temp/apps
           for dir in artifacts/app-*; do
             app=$(basename "$dir" | sed 's/^app-//')
+            if echo " $RELEASE_EXCLUDED_APPS " | grep -qF " $app "; then
+              echo "Excluding $app from the release zip (does not ship on the watch)"
+              continue
+            fi
             mkdir -p "temp/apps/$app"
             find "$dir" -name "*.uapp" -exec cp {} "temp/apps/$app/" \;
           done

--- a/Utilities/Scripts/Update-Watch-Apps.ps1
+++ b/Utilities/Scripts/Update-Watch-Apps.ps1
@@ -30,8 +30,8 @@
       * The launcher / app list rebuilds only at boot -> reboot the watch after.
       * A .uapp that fails the kernel CRC is silently dropped (app won't appear).
       * D:\Apps also contains "SharedData" (not an app) - never touched, since there
-        is no matching source subfolder. HRMonitor ships in the zip but not on the
-        watch - skipped under the default (update-only).
+        is no matching source subfolder. The zip holds only apps that ship on the
+        watch (HRMonitor, an SDK example, is excluded), so -InstallNew is safe.
 
 .PARAMETER Source
     The una-apps release: either the .zip file or an already-extracted folder


### PR DESCRIPTION
## What

Stop packaging `HRMonitor` into the `una-apps-<tag>.zip` produced by an `apps-v*` release.

## Why

Everything under `Examples/Apps/` ships on the production watch **except** `HRMonitor`, which is a pure SDK reference example. It was still being copied into the release zip, so anyone installing from that zip (e.g. via `Update-Watch-Apps.ps1 -InstallNew`) picked up an app the watch does not ship.

This is CI catching up to already-documented policy — the kernel's `Docs/Versioning-and-Releases.md` §6.1/§6.2 states the factory file set is "all example apps **except HRMonitor**" and that OTA uploads exclude it too.

## How

The `release` job's *Prepare release zip* step now filters its staging loop through a new `RELEASE_EXCLUDED_APPS` env var (space-separated app names, currently just `HRMonitor`), logging each skip into the Actions log.

Deliberately **not** done via the existing `APPS_EXCLUDED` knob in `.github/scripts/generate-app-list.py`: that filters the `prepare` job's build matrix, which would stop HRMonitor being compiled and CI-tested on every push and let it rot silently. Filtering at packaging time keeps it building, and since `release` still has `needs: [cmake-build]`, a broken HRMonitor continues to block a release. The added comment cross-references the two knobs so the wrong lever doesn't get grabbed later.

Also refreshed the header comment in `Utilities/Scripts/Update-Watch-Apps.ps1`, which explicitly documented the old behaviour ("HRMonitor ships in the zip but not on the watch"). That script's *logic* needs no change — `$srcApps` is derived from source subfolders, so an absent HRMonitor is a clean no-op across the update, `-InstallNew` and `-Verify` paths.

## Testing

- Simulated the staging loop locally over four fake artifact dirs: `Running`, `Hiking`, `GlanceHR` staged; `HRMonitor` excluded.
- Edge cases exercised under `bash -e`: substring names (`HR`, `Monitor`, `GlanceHR`) correctly kept, empty/unset var keeps everything, multi-entry lists work, and the loop completes under `errexit` (a failing `grep` in an `if` condition is exempt).
- `apps-ci.yml` validated with PyYAML.
- No behaviour change on non-tag pushes or PRs — the `release` job is gated on `refs/tags/apps-v`.

## Note for the next apps release

The first `apps-v*` tag cut after this merges will produce a zip with 14 apps instead of 15. A watch that received HRMonitor from an older zip keeps it — this script never removes on-device apps that are absent from the source, by design. Delete it manually if you want it gone from a bench unit.
