### PR TITLE
feat(intervals): raise the max interval duration to 60:55

### DIFF
--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/IntervalsTimer.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/IntervalsTimer.hpp
@@ -15,8 +15,8 @@ public:
     /**
      * @brief Update timer for a time-based metric -- shows MM:SS + description label.
      *
-     * Time is clamped to 59:59. If sec > 3599, display freezes at "59:59"
-     * (non-nominal; restrict maximum interval duration in settings).
+     * Time is clamped to 99:59. If sec > 5999, display freezes at "99:59"
+     * (non-nominal; the settings picker caps interval duration at 60:55).
      *
      * @param sec    Seconds (remaining / elapsed / open depending on metric).
      * @param metric TIME_OPEN -> "Open", TIME_REMAINING -> "Remaining", TIME_ELAPSED -> "Elapsed".
@@ -35,7 +35,7 @@ public:
     /**
      * @brief Update timer for alert screens -- MM:SS only, no description, no line.
      *
-     * Time is clamped to 59:59. Description widget is hidden.
+     * Time is clamped to 99:59. Description widget is hidden.
      */
     void setRemainingTime(std::time_t sec);
 
@@ -57,7 +57,7 @@ public:
     void setDescriptionVisible(bool visible);
 
 private:
-    /** @brief Clamp @p sec to [0, 3599] and display as MM:SS. */
+    /** @brief Clamp @p sec to [0, 5999] and display as MM:SS. */
     void setTimerClamped(std::time_t sec);
 
     void setTimerMS(uint8_t mm, uint8_t ss);

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceIntervals.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceIntervals.hpp
@@ -32,7 +32,7 @@ public:
 
     /**
      * @brief Update the timer for a time-based metric (TIME_OPEN / TIME_REMAINING / TIME_ELAPSED).
-     * @param sec    Seconds value, clamped to 59:59.
+     * @param sec    Seconds value, clamped to 99:59.
      * @param metric Determines the description label.
      */
     void setPhaseTime(std::time_t sec, Track::IntervalsMetric metric);

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
@@ -83,9 +83,9 @@ struct Root {
         // 2-part time picker (shared by RunTime / RestTime screens)
         // Items are built at runtime -- no fixed enum.
         struct TimePicker {
-            static constexpr uint16_t kMaxMin   = 5;    ///< Max minutes: 0..5
+            static constexpr uint16_t kMaxMin   = 60;   ///< Max minutes: 0..60
             static constexpr uint16_t kStepMin  = 1;
-            static constexpr uint16_t kCountMin = kMaxMin / kStepMin + 1; // 6
+            static constexpr uint16_t kCountMin = kMaxMin / kStepMin + 1; // 61
 
             static constexpr uint16_t kMaxSec   = 55;   ///< Max seconds: 0..55 (step 5)
             static constexpr uint16_t kStepSec  = 5;

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/trackintervalsalert_screen/TrackIntervalsAlertView.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/trackintervalsalert_screen/TrackIntervalsAlertView.hpp
@@ -31,7 +31,7 @@ public:
 
     /**
      * @brief Update the timer -- always shows remaining time, no description, no line.
-     * @param sec Seconds remaining in the current phase, clamped to 59:59.
+     * @param sec Seconds remaining in the current phase, clamped to 99:59.
      */
     void setPhaseTime(std::time_t sec);
 

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/IntervalsTimer.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/IntervalsTimer.cpp
@@ -2,7 +2,9 @@
 #include <texts/TextKeysAndLanguages.hpp>
 #include <touchgfx/Color.hpp>
 
-static const std::time_t kMaxIntervalSec = 3599; // 59:59
+// Largest value the MM:SS field can render; the picker tops out well below this
+// (60:55), so the clamp only ever bites on open-ended count-up phases.
+static const std::time_t kMaxIntervalSec = 5999; // 99:59
 
 IntervalsTimer::IntervalsTimer()
 {

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/IntervalsTimer.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/IntervalsTimer.hpp
@@ -15,8 +15,8 @@ public:
     /**
      * @brief Update timer for a time-based metric -- shows MM:SS + description label.
      *
-     * Time is clamped to 59:59. If sec > 3599, display freezes at "59:59"
-     * (non-nominal; restrict maximum interval duration in settings).
+     * Time is clamped to 99:59. If sec > 5999, display freezes at "99:59"
+     * (non-nominal; the settings picker caps interval duration at 60:55).
      *
      * @param sec    Seconds (remaining / elapsed / open depending on metric).
      * @param metric TIME_OPEN -> "Open", TIME_REMAINING -> "Remaining", TIME_ELAPSED -> "Elapsed".
@@ -35,7 +35,7 @@ public:
     /**
      * @brief Update timer for alert screens -- MM:SS only, no description, no line.
      *
-     * Time is clamped to 59:59. Description widget is hidden.
+     * Time is clamped to 99:59. Description widget is hidden.
      */
     void setRemainingTime(std::time_t sec);
 
@@ -57,7 +57,7 @@ public:
     void setDescriptionVisible(bool visible);
 
 private:
-    /** @brief Clamp @p sec to [0, 3599] and display as MM:SS. */
+    /** @brief Clamp @p sec to [0, 5999] and display as MM:SS. */
     void setTimerClamped(std::time_t sec);
 
     void setTimerMS(uint8_t mm, uint8_t ss);

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceIntervals.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceIntervals.hpp
@@ -32,7 +32,7 @@ public:
 
     /**
      * @brief Update the timer for a time-based metric (TIME_OPEN / TIME_REMAINING / TIME_ELAPSED).
-     * @param sec    Seconds value, clamped to 59:59.
+     * @param sec    Seconds value, clamped to 99:59.
      * @param metric Determines the description label.
      */
     void setPhaseTime(std::time_t sec, Track::IntervalsMetric metric);

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
@@ -83,9 +83,9 @@ struct Root {
         // 2-part time picker (shared by RunTime / RestTime screens)
         // Items are built at runtime -- no fixed enum.
         struct TimePicker {
-            static constexpr uint16_t kMaxMin   = 5;    ///< Max minutes: 0..5
+            static constexpr uint16_t kMaxMin   = 60;   ///< Max minutes: 0..60
             static constexpr uint16_t kStepMin  = 1;
-            static constexpr uint16_t kCountMin = kMaxMin / kStepMin + 1; // 6
+            static constexpr uint16_t kCountMin = kMaxMin / kStepMin + 1; // 61
 
             static constexpr uint16_t kMaxSec   = 55;   ///< Max seconds: 0..55 (step 5)
             static constexpr uint16_t kStepSec  = 5;

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/trackintervalsalert_screen/TrackIntervalsAlertView.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/trackintervalsalert_screen/TrackIntervalsAlertView.hpp
@@ -31,7 +31,7 @@ public:
 
     /**
      * @brief Update the timer -- always shows remaining time, no description, no line.
-     * @param sec Seconds remaining in the current phase, clamped to 59:59.
+     * @param sec Seconds remaining in the current phase, clamped to 99:59.
      */
     void setPhaseTime(std::time_t sec);
 

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/IntervalsTimer.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/IntervalsTimer.cpp
@@ -2,7 +2,9 @@
 #include <texts/TextKeysAndLanguages.hpp>
 #include <touchgfx/Color.hpp>
 
-static const std::time_t kMaxIntervalSec = 3599; // 59:59
+// Largest value the MM:SS field can render; the picker tops out well below this
+// (60:55), so the clamp only ever bites on open-ended count-up phases.
+static const std::time_t kMaxIntervalSec = 5999; // 99:59
 
 IntervalsTimer::IntervalsTimer()
 {


### PR DESCRIPTION
## What

Raises the maximum interval duration in the **Running** and **Treadmill** apps from **5:55** to **60:55**. Applies to both the **Run** and the **Rest** phase.

## Why one constant covers four screens

`MenuIntervalsRunTime` and `MenuIntervalsRestTime`, in both apps, all instantiate `PickerLogic::Time<>` over the same `Intervals::TimePicker` descriptor. So the range is a single knob:

```cpp
static constexpr uint16_t kMaxMin = 60;   // was 5
```

Seconds stay `0..55` in steps of 5, so the new ceiling is exactly **60:55 = 3655 s**.

## The part that wasn't the picker

Raising `kMaxMin` alone would have looked broken. `IntervalsTimer` clamped its MM:SS readout at `3599` (59:59), and `setTimerClamped` is the single choke point feeding the track face, the phase-alert screen and the countdown. A 60:55 phase would have sat frozen at "59:59" for its first 56 seconds before appearing to start.

The clamp is now `5999` (99:59) — the largest value the `"%02u:%02u"` field can actually render. Setting it to the widget's real display limit rather than to 3655 means it expresses an invariant of the format string instead of a policy number that has to be chased every time the picker range moves.

## Behaviour change beyond the ask

Open-ended count-up phases (warm-up, cool-down, "Open" run/rest) previously froze at 59:59 and now count on to 99:59. This falls out of the clamp change, is strictly more correct, and matches how the menu labels already fold hours into minutes. Flagging it because it is user-visible and wasn't part of the original request.

## Checked, no change needed

- **Storage** — `runTime`/`restTime` are `uint32_t` seconds; `SettingsSerializer` does no per-field clamping, so 3655 round-trips through `settings.json` untouched.
- **Menu labels** — already render `hms.m + (hms.h * 60)`, so they show "60:55 min" with no edit.
- **FIT output** — `durationValue = runTime * 1000` = 3,655,000 ms, written as `.u32`; comfortably in range.
- **State machine** — phase timing is `time_t` elapsed-vs-target throughout; no pre-phase-end thresholds scale with phase length.
- **`uint8_t` cast** in `setTimerMS` — the clamp runs first, so `sec / 60 <= 99` for every caller; the 255-minute overflow is unreachable.
- **Other apps** — Running and Treadmill are the only apps with interval screens; Cycling, Hiking, Workout and Stopwatch have no `TimePicker`.
- **Docs/tests** — nothing hard-codes 5:55 or 355 s.

## Verification

Both app simulators build and link cleanly (MSVC x86 Debug), which compiles the real `PickerLogic::Time<TimePicker>` instantiation against the new constant.

## Known ergonomic limitation

`kStepMin` is still 1 and the picker has no key auto-repeat — `handleKeyEvent` only sees discrete L1/L2 clicks, so reaching 60 minutes takes up to 60 presses. Left as-is deliberately: a coarser step would make values like 7 or 12 minutes unreachable. Long-press acceleration or a variable step above a threshold would be a separate change.
