### PR TITLE
fix(apps): smooth the live pace readout over a rolling window

### DIFF
--- a/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
@@ -8,6 +8,7 @@
 #include "SDK/Metrics/MonotonicTime.hpp"
 #include "SDK/Metrics/MonotonicCounter.hpp"
 #include "SDK/Metrics/VariableCounter.hpp"
+#include "SDK/Metrics/SpeedSmoother.hpp"
 #include "SDK/Metrics/DeltaCounter.hpp"
 #include "SDK/Metrics/ThrottledSample.hpp"
 #include "SDK/Filters/SimpleLPF.hpp"
@@ -35,6 +36,12 @@ private:
     static constexpr float    skMapDistanceThreshold = 10.0f; // meters
     static constexpr uint32_t skMapMaxPoints         = 70;
     static constexpr uint32_t skBatteryLogPeriodMs   = 5 * 60 * 1000;
+
+    /// Window, in 1 Hz track ticks, over which the live speed / pace readout is
+    /// averaged. Ten seconds cuts the GPS speed noise to about a third -- enough
+    /// to hold a target speed by -- while still tracking a real change of effort
+    /// fast enough to be useful.
+    static constexpr std::size_t skPaceSmoothingTicks = 10;
 
     // -- Infrastructure -------------------------------------------------------
 
@@ -64,12 +71,21 @@ private:
     SDK::Sensor::Connection mSensorWristMotion;
     bool                    mIsSensorsConnected = false;
 
+    // -- Latched GPS speed (drives the smoothed live readout) ------------------
+
+    float mGpsSpeedMs    = 0.0f;  ///< Latest raw GPS speed sample.
+    bool  mGpsSpeedValid = false; ///< Sample came from a current, non-dead-reckoned fix.
+    bool  mGpsSpeedFresh = false; ///< A speed sample arrived since the last track tick.
+
     // -- Metrics --------------------------------------------------------------
 
     SDK::Metric::MonotonicTime<SDK::Interface::ISystem> mTimeTracker;
     SDK::Metric::MonotonicCounter<std::time_t>          mTimeCounter;
     SDK::Metric::MonotonicCounter<float>                mDistanceCounter;
     SDK::Metric::VariableCounter                        mSpeedCounter;
+    /// Smooths the GPS speed for the live speed / pace readout only; the FIT
+    /// records, averages and maxima stay on the raw samples in mSpeedCounter.
+    SDK::Metric::SpeedSmoother<skPaceSmoothingTicks>    mSpeedSmoother;
     SDK::Metric::VariableCounter                        mHrCounter;
     uint8_t                                             mHrSource = 0;      ///< Latest HR source (HeartRateEx::Source) for the icon + FIT hr_source.
     uint8_t                                             mHrOpticalBpm = 0;  ///< Latest raw optical (PPG) bpm, for the FIT hr_optical series.

--- a/Examples/Apps/Cycling/Software/Libs/Header/Track.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Track.hpp
@@ -32,11 +32,15 @@ enum class State {
  *
  * All distances are in metres, speeds in m/s, pace in s/m, times in seconds.
  * The GUI converts to display units as needed.
+ *
+ * @note This snapshot exists for the GUI only. The live speed and pace it
+ *       carries are smoothed for readability; the raw samples still back the
+ *       FIT records, session averages and maxima.
  */
 struct Data {
 
     // Pace, s/m
-    float pace        = 0.0f;
+    float pace        = 0.0f;   ///< Live pace, smoothed over a rolling window (see SpeedSmoother)
     float lapPace     = 0.0f;
 
     // Distance, m
@@ -59,7 +63,7 @@ struct Data {
     float maxLapHR     = 0.0f;
 
     // Speed, m/s
-    float speed       = 0.0f;
+    float speed       = 0.0f;   ///< Live speed, smoothed over the same window as pace
     float avgSpeed    = 0.0f;
     float maxSpeed    = 0.0f;
     float avgLapSpeed = 0.0f;

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -74,6 +74,7 @@ Service::Service(SDK::Kernel &kernel)
     mTimeCounter.init();
     mDistanceCounter.init();
     mSpeedCounter.init(0.5f, 300.0f);
+    mSpeedSmoother.init(0.5f, 300.0f);  // same valid range as the raw counter
     mHrCounter.init(20.0f, 300.0f);
     mAltitudeCounter.init(2.0f);
 }
@@ -312,7 +313,13 @@ void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)
         SDK::SensorDataParser::GpsSpeed parser(data[0]);
         if (parser.isDataValid()) {
             mSpeedCounter.add(parser.getSpeed());
-            LOG_DEBUG("Speed:    %.2f m/s\n", parser.getSpeed());
+            // Latched separately for the smoothed live readout, which -- unlike
+            // the counter above -- drops samples taken without a current fix.
+            // isSpeedValid() already excludes dead reckoning.
+            mGpsSpeedMs    = parser.getSpeed();
+            mGpsSpeedValid = parser.isSpeedValid();
+            mGpsSpeedFresh = true;
+            LOG_DEBUG("Speed:    %.2f m/s (valid %u)\n", mGpsSpeedMs, mGpsSpeedValid);
         }
     } else if (mSensorGpsDistance.matchesDriver(handle)) {
         SDK::SensorDataParser::GpsDistance parser(data[0]);
@@ -654,6 +661,9 @@ void Service::startTrack(std::time_t utc)
 
     mDistanceCounter.reset();
     mSpeedCounter.reset();
+    mSpeedSmoother.reset();
+    mGpsSpeedValid = false;
+    mGpsSpeedFresh = false;
     mHrCounter.reset();
     mHrSource = 0;  // don't carry a prior track's HR source/readings into the new session
     mHrOpticalBpm = 0;
@@ -718,7 +728,22 @@ void Service::processTrack()
     mTrackData.lapDistance = mDistanceCounter.getLapValueActive();
 
     // Speed, m/s
-    mTrackData.speed       = mSpeedCounter.getCurrent();
+    //
+    // The live speed and pace shown to the user are the rolling-window mean of
+    // the GPS speed, not the latest sample: a single sample's noise moves the
+    // readout far more than any real change of effort does. Fed here rather than
+    // from the GPS_SPEED callback so the window advances once per track tick even
+    // when a sample is missing, which ages a lost fix out of the window instead
+    // of holding it forward. Advanced only while ACTIVE, so the readout freezes
+    // for the duration of a pause. That is a deliberate change:
+    // VariableCounter::add() latches its current value before its own pause
+    // check, so the old readout went on tracking the raw speed of a standing
+    // rider while the activity was paused.
+    if (mTrackState == Track::State::ACTIVE) {
+        mSpeedSmoother.tick(mGpsSpeedMs, mGpsSpeedValid && mGpsSpeedFresh);
+        mGpsSpeedFresh = false;
+    }
+    mTrackData.speed       = mSpeedSmoother.getSpeed();
     mTrackData.avgSpeed    = speedFromTotals(mTrackData.distance, mTrackData.totalTime);
     mTrackData.maxSpeed    = mSpeedCounter.getMaximum();
     mTrackData.avgLapSpeed = speedFromTotals(mTrackData.lapDistance, mTrackData.lapTime);
@@ -726,7 +751,7 @@ void Service::processTrack()
 
     // Pace, s/m
     const float kMinSpeed = mSpeedCounter.getMinValid();
-    mTrackData.pace    = getPace(mTrackData.speed, kMinSpeed);
+    mTrackData.pace    = mSpeedSmoother.getPace();
     mTrackData.lapPace = getPace(mTrackData.avgLapSpeed, kMinSpeed);
 
     // HR
@@ -974,6 +999,9 @@ void Service::pauseTrack(bool pause)
         mTimeCounter.resume();
         mDistanceCounter.resume();
         mSpeedCounter.resume();
+        // Drop the pre-pause window: those samples describe the effort before
+        // the break, so blending them into the resumed readout would be wrong.
+        mSpeedSmoother.reset();
         mHrCounter.resume();
         mAltitudeCounter.resume();
 

--- a/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
@@ -10,6 +10,7 @@
 #include "SDK/Metrics/MonotonicTime.hpp"
 #include "SDK/Metrics/MonotonicCounter.hpp"
 #include "SDK/Metrics/VariableCounter.hpp"
+#include "SDK/Metrics/SpeedSmoother.hpp"
 #include "SDK/Metrics/DeltaCounter.hpp"
 #include "SDK/Metrics/ThrottledSample.hpp"
 #include "SDK/Filters/SimpleLPF.hpp"
@@ -37,6 +38,12 @@ private:
     static constexpr float    skMapDistanceThreshold = 10.0f; // meters
     static constexpr uint32_t skMapMaxPoints         = 70;
     static constexpr uint32_t skBatteryLogPeriodMs   = 5 * 60 * 1000;
+
+    /// Window, in 1 Hz track ticks, over which the live pace / speed readout is
+    /// averaged. Ten seconds cuts the GPS speed noise to about a third -- enough
+    /// to hold a target pace by -- while still tracking a real change of effort
+    /// fast enough to be useful.
+    static constexpr std::size_t skPaceSmoothingTicks = 10;
 
     // -- Infrastructure -------------------------------------------------------
 
@@ -71,12 +78,21 @@ private:
     SDK::Sensor::Connection mSensorWristMotion;
     bool                    mIsSensorsConnected = false;
 
+    // -- Latched GPS speed (drives the smoothed live readout) ------------------
+
+    float mGpsSpeedMs    = 0.0f;  ///< Latest raw GPS speed sample.
+    bool  mGpsSpeedValid = false; ///< Sample came from a current, non-dead-reckoned fix.
+    bool  mGpsSpeedFresh = false; ///< A speed sample arrived since the last track tick.
+
     // -- Metrics --------------------------------------------------------------
 
     SDK::Metric::MonotonicTime<SDK::Interface::ISystem> mTimeTracker;
     SDK::Metric::MonotonicCounter<std::time_t>          mTimeCounter;
     SDK::Metric::MonotonicCounter<float>                mDistanceCounter;
     SDK::Metric::VariableCounter                        mSpeedCounter;
+    /// Smooths the GPS speed for the live pace / speed readout only; the FIT
+    /// records, averages and maxima stay on the raw samples in mSpeedCounter.
+    SDK::Metric::SpeedSmoother<skPaceSmoothingTicks>    mSpeedSmoother;
     SDK::Metric::VariableCounter                        mHrCounter;
     uint8_t                                             mHrSource = 0;      ///< Latest HR source (HeartRateEx::Source) for the icon + FIT hr_source.
     uint8_t                                             mHrOpticalBpm = 0;  ///< Latest raw optical (PPG) bpm, for the FIT hr_optical series.

--- a/Examples/Apps/Hiking/Software/Libs/Header/Track.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Track.hpp
@@ -32,11 +32,15 @@ enum class State {
  *
  * All distances are in metres, speeds in m/s, pace in s/m, times in seconds.
  * The GUI converts to display units as needed.
+ *
+ * @note This snapshot exists for the GUI only. The live speed and pace it
+ *       carries are smoothed for readability; the raw samples still back the
+ *       FIT records, session averages and maxima.
  */
 struct Data {
 
     // Pace, s/m
-    float pace        = 0.0f;
+    float pace        = 0.0f;   ///< Live pace, smoothed over a rolling window (see SpeedSmoother)
     float avgPace     = 0.0f;
     float lapPace     = 0.0f;
 
@@ -60,7 +64,7 @@ struct Data {
     float maxLapHR     = 0.0f;
 
     // Speed, m/s
-    float speed       = 0.0f;
+    float speed       = 0.0f;   ///< Live speed, smoothed over the same window as pace
     float avgSpeed    = 0.0f;
     float maxSpeed    = 0.0f;
     float avgLapSpeed = 0.0f;

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -83,6 +83,7 @@ Service::Service(SDK::Kernel &kernel)
     mTimeCounter.init();
     mDistanceCounter.init();
     mSpeedCounter.init(0.5f, 300.0f);
+    mSpeedSmoother.init(0.5f, 300.0f);  // same valid range as the raw counter
     mHrCounter.init(20.0f, 300.0f);
     mAltitudeCounter.init(2.0f);
     mStepCounter.init();
@@ -327,7 +328,13 @@ void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)
         SDK::SensorDataParser::GpsSpeed parser(data[0]);
         if (parser.isDataValid()) {
             mSpeedCounter.add(parser.getSpeed());
-            LOG_DEBUG("Speed:    %.2f m/s\n", parser.getSpeed());
+            // Latched separately for the smoothed live readout, which -- unlike
+            // the counter above -- drops samples taken without a current fix.
+            // isSpeedValid() already excludes dead reckoning.
+            mGpsSpeedMs    = parser.getSpeed();
+            mGpsSpeedValid = parser.isSpeedValid();
+            mGpsSpeedFresh = true;
+            LOG_DEBUG("Speed:    %.2f m/s (valid %u)\n", mGpsSpeedMs, mGpsSpeedValid);
         }
     } else if (mSensorGpsDistance.matchesDriver(handle)) {
         SDK::SensorDataParser::GpsDistance parser(data[0]);
@@ -682,6 +689,9 @@ void Service::startTrack(std::time_t utc)
 
     mDistanceCounter.reset();
     mSpeedCounter.reset();
+    mSpeedSmoother.reset();
+    mGpsSpeedValid = false;
+    mGpsSpeedFresh = false;
     mHrCounter.reset();
     mHrSource = 0;  // don't carry a prior track's HR source/readings into the new session
     mHrOpticalBpm = 0;
@@ -748,7 +758,22 @@ void Service::processTrack()
     mTrackData.lapDistance = mDistanceCounter.getLapValueActive();
 
     // Speed, m/s
-    mTrackData.speed        = mSpeedCounter.getCurrent();
+    //
+    // The live speed and pace shown to the user are the rolling-window mean of
+    // the GPS speed, not the latest sample: a single sample's noise moves the
+    // pace readout by tens of seconds per kilometre, which is unusable for
+    // holding a target pace. Fed here rather than from the GPS_SPEED callback so
+    // the window advances once per track tick even when a sample is missing,
+    // which ages a lost fix out of the window instead of holding it forward.
+    // Advanced only while ACTIVE, so the readout freezes for the duration of a
+    // pause. That is a deliberate change: VariableCounter::add() latches its
+    // current value before its own pause check, so the old readout went on
+    // tracking the raw speed of a standing runner while the activity was paused.
+    if (mTrackState == Track::State::ACTIVE) {
+        mSpeedSmoother.tick(mGpsSpeedMs, mGpsSpeedValid && mGpsSpeedFresh);
+        mGpsSpeedFresh = false;
+    }
+    mTrackData.speed        = mSpeedSmoother.getSpeed();
     mTrackData.avgSpeed     = speedFromTotals(mTrackData.distance, mTrackData.totalTime);
     mTrackData.maxSpeed     = mSpeedCounter.getMaximum();
     mTrackData.avgLapSpeed  = speedFromTotals(mTrackData.lapDistance, mTrackData.lapTime);
@@ -756,7 +781,7 @@ void Service::processTrack()
 
     // Pace, s/m
     const float kMinSpeed  = mSpeedCounter.getMinValid();
-    mTrackData.pace        = getPace(mTrackData.speed, kMinSpeed);
+    mTrackData.pace        = mSpeedSmoother.getPace();
     mTrackData.avgPace     = getPace(mTrackData.avgSpeed, kMinSpeed);
     mTrackData.lapPace     = getPace(mTrackData.avgLapSpeed, kMinSpeed);
 
@@ -1018,6 +1043,9 @@ void Service::pauseTrack(bool pause)
         mTimeCounter.resume();
         mDistanceCounter.resume();
         mSpeedCounter.resume();
+        // Drop the pre-pause window: those samples describe the effort before
+        // the break, so blending them into the resumed readout would be wrong.
+        mSpeedSmoother.reset();
         mHrCounter.resume();
         mAltitudeCounter.resume();
         mStepCounter.resume();

--- a/Examples/Apps/Running/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Service.hpp
@@ -10,6 +10,7 @@
 #include "SDK/Metrics/MonotonicTime.hpp"
 #include "SDK/Metrics/MonotonicCounter.hpp"
 #include "SDK/Metrics/VariableCounter.hpp"
+#include "SDK/Metrics/SpeedSmoother.hpp"
 #include "SDK/Metrics/DeltaCounter.hpp"
 #include "SDK/Metrics/ThrottledSample.hpp"
 #include "SDK/Filters/SimpleLPF.hpp"
@@ -43,6 +44,12 @@ private:
 
     static constexpr uint32_t skBatteryLogPeriodMs   = 5 * 60 * 1000;
     static constexpr float    skFusionSampleRateHz   = 100.0f;
+
+    /// Window, in 1 Hz track ticks, over which the live pace / speed readout is
+    /// averaged. Ten seconds cuts the GPS speed noise to about a third -- enough
+    /// to hold a target pace by -- while still tracking a real change of effort
+    /// fast enough to be useful inside an interval repeat.
+    static constexpr std::size_t skPaceSmoothingTicks = 10;
 
     // -- Infrastructure -------------------------------------------------------
 
@@ -87,6 +94,7 @@ private:
     } mGradeData{};
     float       mGpsSpeedMs       = 0.0f; ///< Latest raw GPS speed (instantaneous source).
     bool        mGpsSpeedValid    = false;
+    bool        mGpsSpeedFresh    = false; ///< A speed sample arrived since the last track tick.
     bool        mGpsDeadReckoning = false;
     std::time_t mLastCalibUtc     = 0;   ///< For per-tick delta_t.
 
@@ -96,6 +104,9 @@ private:
     SDK::Metric::MonotonicCounter<std::time_t>          mTimeCounter;
     SDK::Metric::MonotonicCounter<float>                mDistanceCounter;
     SDK::Metric::VariableCounter                        mSpeedCounter;
+    /// Smooths the GPS speed for the live pace / speed readout only; the FIT
+    /// records, averages and maxima stay on the raw samples in mSpeedCounter.
+    SDK::Metric::SpeedSmoother<skPaceSmoothingTicks>    mSpeedSmoother;
     SDK::Metric::VariableCounter                        mHrCounter;
     uint8_t                                             mHrSource = 0;      ///< Latest HR source (HeartRateEx::Source) for the icon + FIT hr_source.
     uint8_t                                             mHrOpticalBpm = 0;  ///< Latest raw optical (PPG) bpm, for the FIT hr_optical series.

--- a/Examples/Apps/Running/Software/Libs/Header/Track.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Track.hpp
@@ -76,11 +76,15 @@ struct IntervalsData {
  *
  * All distances are in metres, speeds in m/s, pace in s/m, times in seconds.
  * The GUI converts to display units as needed.
+ *
+ * @note This snapshot exists for the GUI only. The live speed and pace it
+ *       carries are smoothed for readability; the raw samples still back the
+ *       FIT records, session averages and maxima.
  */
 struct Data {
 
     // Pace, s/m
-    float pace        = 0.0f;
+    float pace        = 0.0f;   ///< Live pace, smoothed over a rolling window (see SpeedSmoother)
     float avgPace     = 0.0f;
     float lapPace     = 0.0f;
 
@@ -104,7 +108,7 @@ struct Data {
     float maxLapHR      = 0.0f;
 
     // Speed, m/s
-    float speed        = 0.0f;
+    float speed        = 0.0f;   ///< Live speed, smoothed over the same window as pace
     float avgSpeed     = 0.0f;
     float maxSpeed     = 0.0f;
     float avgLapSpeed  = 0.0f;

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -87,6 +87,7 @@ Service::Service(SDK::Kernel &kernel)
     mTimeCounter.init();
     mDistanceCounter.init();
     mSpeedCounter.init(0.5f, 300.0f);
+    mSpeedSmoother.init(0.5f, 300.0f);  // same valid range as the raw counter
     mHrCounter.init(20.0f, 300.0f);
     mAltitudeCounter.init(2.0f);
 
@@ -348,6 +349,7 @@ void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)
             mGpsSpeedMs       = parser.getSpeed();  // raw instantaneous speed
             mGpsSpeedValid    = parser.isSpeedValid();
             mGpsDeadReckoning = parser.isDeadReckoning();
+            mGpsSpeedFresh    = true;   // consumed by the pace smoother each tick
             // Only feed a current (valid-fix) speed into the aggregated metrics
             // so acquisition/fix-loss readings don't pollute avg/max/distance.
             if (mGpsSpeedValid) {
@@ -761,6 +763,7 @@ void Service::startTrack(std::time_t utc)
 
     mDistanceCounter.reset();
     mSpeedCounter.reset();
+    mSpeedSmoother.reset();
     mHrCounter.reset();
     mHrSource = 0;  // don't carry a prior track's HR source/readings into the new session
     mHrOpticalBpm = 0;
@@ -776,6 +779,7 @@ void Service::startTrack(std::time_t utc)
     // for this session.
     mGradeData = {};
     mGpsSpeedValid    = false;
+    mGpsSpeedFresh    = false;
     mGpsDeadReckoning = false;
     mLastCalibUtc     = 0;
     mCalibrator.load();
@@ -865,7 +869,22 @@ void Service::processTrack()
     mTrackData.lapDistance = mDistanceCounter.getLapValueActive();
 
     // Speed, m/s
-    mTrackData.speed = mSpeedCounter.getCurrent();
+    //
+    // The live speed and pace shown to the user are the rolling-window mean of
+    // the GPS speed, not the latest sample: a single sample's noise moves the
+    // pace readout by tens of seconds per kilometre, which is unusable for
+    // holding a target pace. Fed here rather than from the GPS_SPEED callback so
+    // the window advances once per track tick even when a sample is missing,
+    // which ages a lost fix out of the window instead of holding it forward.
+    // Advanced only while ACTIVE, so the readout freezes for the duration of a
+    // pause. That is a deliberate change: VariableCounter::add() latches its
+    // current value before its own pause check, so the old readout went on
+    // tracking the raw speed of a standing runner while the activity was paused.
+    if (mTrackState == Track::State::ACTIVE) {
+        mSpeedSmoother.tick(mGpsSpeedMs, mGpsSpeedValid && mGpsSpeedFresh);
+        mGpsSpeedFresh = false;
+    }
+    mTrackData.speed = mSpeedSmoother.getSpeed();
 
     mTrackData.avgSpeed    = speedFromTotals(mTrackData.distance, mTrackData.totalTime);
     mTrackData.maxSpeed    = mSpeedCounter.getMaximum();
@@ -875,7 +894,7 @@ void Service::processTrack()
 
     // Pace, s/m
     const float kMinSpeed = mSpeedCounter.getMinValid();
-    mTrackData.pace = getPace(mTrackData.speed, kMinSpeed);
+    mTrackData.pace = mSpeedSmoother.getPace();
     mTrackData.avgPace = getPace(mTrackData.avgSpeed, kMinSpeed);
     mTrackData.lapPace = getPace(mTrackData.avgLapSpeed, kMinSpeed);
 
@@ -1173,6 +1192,9 @@ void Service::pauseTrack(bool pause)
         mTimeCounter.resume();
         mDistanceCounter.resume();
         mSpeedCounter.resume();
+        // Drop the pre-pause window: those samples describe the effort before
+        // the break, so blending them into the resumed readout would be wrong.
+        mSpeedSmoother.reset();
         mHrCounter.resume();
         mAltitudeCounter.resume();
 

--- a/Libs/Header/SDK/Metrics/SpeedSmoother.hpp
+++ b/Libs/Header/SDK/Metrics/SpeedSmoother.hpp
@@ -1,0 +1,188 @@
+/**
+ * @file SpeedSmoother.hpp
+ * @brief Rolling-window smoother for the live speed / pace display
+ */
+
+#ifndef SDK_METRICS_SPEED_SMOOTHER_HPP
+#define SDK_METRICS_SPEED_SMOOTHER_HPP
+
+#include <cstddef>
+
+namespace SDK::Metric {
+
+/**
+ * @brief Rolling-window mean of instantaneous speed, and the pace derived from it.
+ *
+ * A raw GPS speed sample carries enough noise (typically a few tenths of a m/s)
+ * that the pace derived from a single sample swings by tens of seconds per
+ * kilometre from one second to the next, which makes the live pace readout
+ * useless for holding a target pace. This class averages the last
+ * @p WindowTicks samples so the readout is stable enough to run to, while still
+ * reflecting a genuine change of effort within the window length.
+ *
+ * Averaging the speed and then inverting (rather than averaging the pace) is
+ * the physically meaningful operation: with uniform sampling the window mean
+ * speed equals window distance / window time, so the smoothed pace is the pace
+ * actually run over the window. Averaging pace samples would bias the result
+ * toward the slow samples.
+ *
+ * @tparam WindowTicks Window length in ticks. tick() is expected to be called
+ *                     at a fixed cadence (1 Hz in the activity apps), so this
+ *                     is also the window length in seconds.
+ *
+ * @note This smooths the *displayed* value only. Recorded FIT speed, session
+ *       averages and maxima should keep using the raw samples.
+ */
+template <std::size_t WindowTicks>
+class SpeedSmoother {
+    static_assert(WindowTicks > 0, "SpeedSmoother needs a non-empty window");
+
+public:
+    /**
+     * @brief Construct and zero-initialize all state. Call init() before use.
+     */
+    SpeedSmoother()
+        : mMinValid(0.0f)
+        , mMaxValid(0.0f)
+        , mSamples{}
+        , mHasSample{}
+        , mNext(0)
+        , mIsInitialized(false)
+    {
+    }
+
+    ~SpeedSmoother() = default;
+
+    /**
+     * @brief Initialize the smoother with a valid measurement range.
+     *
+     * @param minValid Speed (m/s) below which no pace is reported. Samples
+     *                 below it still enter the window -- slowing to a walk must
+     *                 pull the mean down -- but a window mean at or below this
+     *                 floor yields no pace, matching the "---" readout.
+     * @param maxValid Speed (m/s) above which a sample is discarded as bogus.
+     *                 One spike would otherwise corrupt the whole window.
+     * @return true on success, false if minValid >= maxValid
+     */
+    bool init(float minValid, float maxValid)
+    {
+        if (minValid >= maxValid) {
+            return false;
+        }
+        mMinValid      = minValid;
+        mMaxValid      = maxValid;
+        mIsInitialized = true;
+        reset();
+        return true;
+    }
+
+    /**
+     * @brief Discard the window. The valid range set by init() is preserved.
+     *
+     * Call this whenever the samples already in the window no longer describe
+     * the current effort: at track start, and on resume after a pause.
+     */
+    void reset()
+    {
+        for (std::size_t i = 0; i < WindowTicks; i++) {
+            mSamples[i]   = 0.0f;
+            mHasSample[i] = false;
+        }
+        mNext = 0;
+    }
+
+    /**
+     * @brief Advance the window by one tick.
+     *
+     * Must be called once per tick even when no speed is available, so that the
+     * window ages: a lost fix empties it after WindowTicks ticks and the pace
+     * goes unavailable instead of being held forward forever.
+     *
+     * @param speedMs Current speed in m/s (ignored when @p valid is false)
+     * @param valid   true when @p speedMs comes from a current, trustworthy fix
+     */
+    void tick(float speedMs, bool valid)
+    {
+        if (!mIsInitialized) {
+            return;
+        }
+
+        const bool usable = valid && speedMs >= 0.0f && speedMs <= mMaxValid;
+
+        mSamples[mNext]   = usable ? speedMs : 0.0f;
+        mHasSample[mNext] = usable;
+        mNext             = (mNext + 1) % WindowTicks;
+    }
+
+    /**
+     * @brief Window mean speed in m/s, or 0.0 when the window holds no samples.
+     */
+    float getSpeed() const
+    {
+        float       sum   = 0.0f;
+        std::size_t count = 0;
+
+        // Summed on demand rather than kept incrementally: at one tick per
+        // second the cost is irrelevant, and it cannot accumulate drift.
+        for (std::size_t i = 0; i < WindowTicks; i++) {
+            if (mHasSample[i]) {
+                sum += mSamples[i];
+                count++;
+            }
+        }
+
+        return (count > 0) ? (sum / static_cast<float>(count)) : 0.0f;
+    }
+
+    /**
+     * @brief Smoothed pace in s/m, or 0.0 when no pace can be reported
+     *        (empty window, or a mean at or below the minValid floor).
+     */
+    float getPace() const
+    {
+        const float speed = getSpeed();
+        return (speed > mMinValid) ? (1.0f / speed) : 0.0f;
+    }
+
+    /**
+     * @brief Number of samples currently in the window (0 .. WindowTicks).
+     */
+    std::size_t getSampleCount() const
+    {
+        std::size_t count = 0;
+        for (std::size_t i = 0; i < WindowTicks; i++) {
+            if (mHasSample[i]) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * @brief Returns true while the window holds at least one sample.
+     */
+    bool isValid() const { return getSampleCount() > 0; }
+
+    /**
+     * @brief Window length in ticks, as configured by the template argument.
+     */
+    static constexpr std::size_t getWindowTicks() { return WindowTicks; }
+
+    /** @brief Minimum valid speed passed to init(). */
+    float getMinValid() const { return mMinValid; }
+
+    /** @brief Maximum valid speed passed to init(). */
+    float getMaxValid() const { return mMaxValid; }
+
+private:
+    float       mMinValid;                /* Speed floor below which no pace is reported */
+    float       mMaxValid;                /* Speed ceiling above which a sample is bogus */
+    float       mSamples[WindowTicks];    /* Ring of the last WindowTicks samples */
+    bool        mHasSample[WindowTicks];  /* Which ring slots hold a usable sample */
+    std::size_t mNext;                    /* Ring slot the next tick() writes */
+    bool        mIsInitialized;           /* True after init() has been called */
+};
+
+}  // namespace SDK::Metric
+
+#endif // SDK_METRICS_SPEED_SMOOTHER_HPP

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(una-sdk-host-tests
     sensorlayer/GyroscopeParser_test.cpp
     sensorlayer/SensorConnection_test.cpp
     metrics/MonotonicCounter_test.cpp
+    metrics/SpeedSmoother_test.cpp
     utils/ClockTime_test.cpp
     utils/Utils_test.cpp
     utils/CopyUtf8_test.cpp

--- a/Tests/Host/metrics/SpeedSmoother_test.cpp
+++ b/Tests/Host/metrics/SpeedSmoother_test.cpp
@@ -1,0 +1,278 @@
+/**
+ * @file SpeedSmoother_test.cpp
+ * @brief Unit tests for SDK::Metric::SpeedSmoother
+ */
+
+#include <gtest/gtest.h>
+
+#include "SDK/Metrics/SpeedSmoother.hpp"
+
+#include <cmath>
+#include <limits>
+
+namespace {
+
+constexpr float kMinValid = 0.5f;    // m/s, matches the activity apps
+constexpr float kMaxValid = 300.0f;  // m/s
+
+using Smoother = SDK::Metric::SpeedSmoother<10>;
+
+Smoother makeSmoother()
+{
+    Smoother s;
+    EXPECT_TRUE(s.init(kMinValid, kMaxValid));
+    return s;
+}
+
+/// Feed @p count valid ticks of the same speed.
+void feed(Smoother &s, float speedMs, int count)
+{
+    for (int i = 0; i < count; i++) {
+        s.tick(speedMs, true);
+    }
+}
+
+}  // namespace
+
+TEST(SpeedSmoother, InitRejectsInvertedRange)
+{
+    Smoother s;
+    EXPECT_FALSE(s.init(10.0f, 10.0f));
+    EXPECT_FALSE(s.init(20.0f, 10.0f));
+    EXPECT_TRUE(s.init(0.5f, 300.0f));
+}
+
+TEST(SpeedSmoother, ReportsNothingBeforeAnySample)
+{
+    Smoother s = makeSmoother();
+
+    EXPECT_FALSE(s.isValid());
+    EXPECT_EQ(0u, s.getSampleCount());
+    EXPECT_FLOAT_EQ(0.0f, s.getSpeed());
+    EXPECT_FLOAT_EQ(0.0f, s.getPace());
+}
+
+TEST(SpeedSmoother, IgnoredWithoutInit)
+{
+    Smoother s;  // no init()
+
+    s.tick(3.0f, true);
+
+    EXPECT_FALSE(s.isValid());
+    EXPECT_FLOAT_EQ(0.0f, s.getSpeed());
+}
+
+TEST(SpeedSmoother, PaceIsTheReciprocalOfTheWindowMean)
+{
+    Smoother s = makeSmoother();
+
+    feed(s, 3.0f, 10);  // 3 m/s == 5:33 /km
+
+    EXPECT_FLOAT_EQ(3.0f, s.getSpeed());
+    EXPECT_FLOAT_EQ(1.0f / 3.0f, s.getPace());
+}
+
+TEST(SpeedSmoother, AveragesOverAPartiallyFilledWindow)
+{
+    Smoother s = makeSmoother();
+
+    // The readout must appear immediately, averaged over what is available,
+    // rather than staying blank until the window fills.
+    s.tick(2.0f, true);
+    EXPECT_EQ(1u, s.getSampleCount());
+    EXPECT_FLOAT_EQ(2.0f, s.getSpeed());
+
+    s.tick(4.0f, true);
+    EXPECT_EQ(2u, s.getSampleCount());
+    EXPECT_FLOAT_EQ(3.0f, s.getSpeed());
+}
+
+TEST(SpeedSmoother, SuppressesSingleSampleNoise)
+{
+    Smoother s = makeSmoother();
+
+    feed(s, 3.0f, 10);
+    ASSERT_NEAR(333.3f, s.getPace() * 1000.0f, 0.1f);  // 3 m/s == 5:33 /km
+
+    // A 4 m/s outlier on a 3 m/s run: the raw readout would jump a full 83 s/km
+    // (5:33 -> 4:10). Averaged over ten ticks it may move by about a tenth of
+    // that, which is the whole point of the window.
+    s.tick(4.0f, true);
+
+    const float secPerKmSmoothed = s.getPace() * 1000.0f;
+    EXPECT_NEAR(322.6f, secPerKmSmoothed, 0.1f);  // 5:23, not 4:10
+}
+
+TEST(SpeedSmoother, OldSamplesLeaveTheWindow)
+{
+    Smoother s = makeSmoother();
+
+    feed(s, 2.0f, 10);
+    ASSERT_FLOAT_EQ(2.0f, s.getSpeed());
+
+    // A full window of the new speed must displace every old sample, so a
+    // sustained change of effort is eventually reported in full.
+    feed(s, 4.0f, 10);
+
+    EXPECT_EQ(10u, s.getSampleCount());
+    EXPECT_FLOAT_EQ(4.0f, s.getSpeed());
+}
+
+TEST(SpeedSmoother, ConvergesMonotonicallyOnAStepChange)
+{
+    Smoother s = makeSmoother();
+
+    feed(s, 2.0f, 10);
+
+    float previous = s.getSpeed();
+    for (int i = 0; i < 10; i++) {
+        s.tick(4.0f, true);
+        const float current = s.getSpeed();
+        EXPECT_GT(current, previous) << "tick " << i;
+        EXPECT_LE(current, 4.0f) << "tick " << i;
+        previous = current;
+    }
+    EXPECT_FLOAT_EQ(4.0f, previous);
+}
+
+TEST(SpeedSmoother, InvalidTicksAreSkippedButStillAgeTheWindow)
+{
+    Smoother s = makeSmoother();
+
+    feed(s, 3.0f, 10);
+    ASSERT_EQ(10u, s.getSampleCount());
+
+    // A dropped sample must not be read as a stop: the mean holds while the
+    // sample count falls.
+    s.tick(0.0f, false);
+    EXPECT_EQ(9u, s.getSampleCount());
+    EXPECT_FLOAT_EQ(3.0f, s.getSpeed());
+
+    // A lost fix for a whole window empties it, so the pace goes unavailable
+    // instead of being held forward forever.
+    for (int i = 0; i < 9; i++) {
+        s.tick(0.0f, false);
+    }
+    EXPECT_EQ(0u, s.getSampleCount());
+    EXPECT_FALSE(s.isValid());
+    EXPECT_FLOAT_EQ(0.0f, s.getPace());
+}
+
+TEST(SpeedSmoother, DiscardsOutOfRangeSpikes)
+{
+    Smoother s = makeSmoother();
+
+    feed(s, 3.0f, 8);
+    s.tick(kMaxValid + 1.0f, true);  // bogus chipset reading
+    s.tick(-1.0f, true);             // negative speed is impossible
+
+    // Both spikes occupy a ring slot -- they age like any other tick -- but
+    // neither contributes to the mean.
+    EXPECT_EQ(8u, s.getSampleCount());
+    EXPECT_FLOAT_EQ(3.0f, s.getSpeed());
+}
+
+TEST(SpeedSmoother, SlowSamplesPullTheMeanDown)
+{
+    Smoother s = makeSmoother();
+
+    // Below-floor samples are real: stopping must slow the readout rather than
+    // being filtered out of the average.
+    feed(s, 4.0f, 5);
+    feed(s, 0.0f, 5);
+
+    EXPECT_EQ(10u, s.getSampleCount());
+    EXPECT_FLOAT_EQ(2.0f, s.getSpeed());
+    EXPECT_FLOAT_EQ(0.5f, s.getPace());
+}
+
+TEST(SpeedSmoother, NoPaceWhileStopped)
+{
+    Smoother s = makeSmoother();
+
+    feed(s, 0.2f, 10);  // below the 0.5 m/s floor
+
+    EXPECT_TRUE(s.isValid());
+    EXPECT_FLOAT_EQ(0.2f, s.getSpeed());
+    EXPECT_FLOAT_EQ(0.0f, s.getPace()) << "a stopped runner has no pace to show";
+}
+
+TEST(SpeedSmoother, NoPaceExactlyAtTheFloor)
+{
+    Smoother s = makeSmoother();
+
+    feed(s, kMinValid, 10);
+
+    EXPECT_FLOAT_EQ(0.0f, s.getPace());
+}
+
+TEST(SpeedSmoother, ResetDropsTheWindowButKeepsTheRange)
+{
+    Smoother s = makeSmoother();
+
+    feed(s, 3.0f, 10);
+    s.reset();
+
+    EXPECT_EQ(0u, s.getSampleCount());
+    EXPECT_FLOAT_EQ(0.0f, s.getSpeed());
+    EXPECT_FLOAT_EQ(kMinValid, s.getMinValid());
+    EXPECT_FLOAT_EQ(kMaxValid, s.getMaxValid());
+
+    // Still usable after a reset, with no trace of the old window.
+    feed(s, 5.0f, 1);
+    EXPECT_FLOAT_EQ(5.0f, s.getSpeed());
+}
+
+TEST(SpeedSmoother, ResetPartWayThroughTheRingDropsEverything)
+{
+    Smoother s = makeSmoother();
+
+    // The resume-from-pause path resets mid-ring, not on a window boundary, so
+    // the write cursor is left part-way along the buffer.
+    feed(s, 3.0f, 3);
+    s.reset();
+
+    EXPECT_EQ(0u, s.getSampleCount());
+    EXPECT_FLOAT_EQ(0.0f, s.getSpeed());
+
+    feed(s, 5.0f, 1);
+    EXPECT_EQ(1u, s.getSampleCount());
+    EXPECT_FLOAT_EQ(5.0f, s.getSpeed()) << "no pre-reset sample may survive";
+}
+
+TEST(SpeedSmoother, RejectsNaNSamples)
+{
+    Smoother s = makeSmoother();
+
+    feed(s, 3.0f, 5);
+    s.tick(std::numeric_limits<float>::quiet_NaN(), true);
+
+    EXPECT_EQ(5u, s.getSampleCount());
+    EXPECT_FLOAT_EQ(3.0f, s.getSpeed());
+}
+
+TEST(SpeedSmoother, WindowLengthOfOneIsPassThrough)
+{
+    SDK::Metric::SpeedSmoother<1> s;
+    ASSERT_TRUE(s.init(kMinValid, kMaxValid));
+
+    s.tick(3.0f, true);
+    EXPECT_FLOAT_EQ(3.0f, s.getSpeed());
+
+    s.tick(4.0f, true);
+    EXPECT_FLOAT_EQ(4.0f, s.getSpeed());
+
+    s.tick(0.0f, false);
+    EXPECT_FALSE(s.isValid());
+}
+
+TEST(SpeedSmoother, LongRunDoesNotDriftTheMean)
+{
+    Smoother s = makeSmoother();
+
+    // An hour of ticks: the mean is summed on demand, so it must not drift.
+    feed(s, 3.3f, 3600);
+
+    EXPECT_FLOAT_EQ(3.3f, s.getSpeed());
+    EXPECT_FLOAT_EQ(1.0f / 3.3f, s.getPace());
+}


### PR DESCRIPTION
## The problem

The live pace on the Running track screen was `1 / (latest raw 1 Hz GPS speed sample)`. GPS Doppler
speed noise of ~0.15 m/s puts roughly ±17 s/km of jitter on that reciprocal, which is far larger
than any real change of effort — so the readout was too noisy to pace a workout or a race by.

Simulating a steady 5:33 /km run with σ = 0.15 m/s:

| window | jitter (sd) | peak-to-peak | observed range |
| --- | --- | --- | --- |
| 1 s (before) | 16.9 s/km | 114 s/km | 4:49 .. 6:43 |
| **10 s (this PR)** | **5.1 s/km** | **35 s/km** | 5:18 .. 5:53 |
| 30 s | 2.8 s/km | 19 s/km | 5:24 .. 5:43 |

## The fix

A new header-only `SDK::Metric::SpeedSmoother<N>`: a fixed-capacity ring of the last N
one-per-second samples whose mean feeds the readout.

**Why mean the speed and then invert**, rather than meaning pace samples — under uniform sampling
the window mean speed equals window distance / window time, so the result is the pace actually run
over the window. Meaning pace samples would bias toward the slow ones.

**Why a boxcar rather than an EMA** (we already have `SDK::Filter::SimpleLPF`) — an EMA of
comparable smoothing takes ~45 s to settle, which is poor pacing feedback. A boxcar is fully
settled after N seconds and is explainable to a user as "your pace over the last 10 s".

**Why N = 10** — 3.3× less jitter while a genuine change of effort still shows in full within 10 s,
so it stays useful inside an interval repeat. Going to 15 s buys only 0.7 s/km more stability for
50% more lag. It is a single named constant per app if we want to tune it or expose it in the
settings menu later.

## Behaviour under the awkward cases

- **Lost fix** — the smoother is advanced from the 1 Hz track tick rather than the `GPS_SPEED`
  callback, so the window ages even when no sample arrives. A lost fix expires out of the window
  and the readout falls back to `---`, instead of the old behaviour of holding a stale pace
  indefinitely. A freshness latch also covers the sensor stream stalling outright.
- **Stopping** — samples below the 0.5 m/s floor are admitted into the window, so slowing to a walk
  pulls the readout down. Only the resulting mean is gated against the floor to produce `---`.
- **Bogus samples** — anything above the 300 m/s ceiling is discarded, so one chipset spike cannot
  corrupt the whole window.
- **Pause** — see the deliberate behaviour change below.
- **Lap boundary** — deliberately does *not* reset; instantaneous pace is not a per-lap metric.

## Scope

Only the GUI-facing `Track::Data` `speed` and `pace` change. The FIT records, the session and lap
averages, and the maxima all still come from the raw samples in `mSpeedCounter`, which is untouched.

Wired into three apps, with different visible effect in each:

- **Running** shows live pace — this is the fix that was asked for.
- **Cycling** shows live speed, which gets the same treatment through the shared field.
- **Hiking**'s track screen currently shows only the *average* pace, so nothing changes on screen
  there today. It is wired for consistency across these heavily-copied services, so a future live
  face gets the smoothed value for free. Happy to drop the Hiking hunk if reviewers would rather
  not carry unused wiring.

**Treadmill is deliberately excluded** — its speed is cadence-derived rather than GPS-derived and
already has its own hold-forward behaviour, so it does not have this problem.

## One deliberate behaviour change beyond the smoothing

The readout now **freezes while an activity is paused**. `VariableCounter::add()` latches its
current value *before* its own pause check, and `processTrack()` runs while `PAUSED`, so the old
readout went on tracking raw GPS speed while the wearer stood still. Freezing matches what the
other paused fields do and what users expect, but it is a change, not parity — flagging it
explicitly for review.

## Noted but deliberately not fixed here

Cycling and Hiking feed **every** sample into `mSpeedCounter`, ignoring the `SPEED_VALID` flag that
Running honours — so their averages and maxima include acquisition and dead-reckoning readings.
That is pre-existing, and fixing it would change recorded FIT and summary data, which does not
belong in a display-smoothing change. The new smoothed readout does honour the flag in all three
apps. Worth a follow-up if others agree it is a bug.

## Testing

- **18 new host unit tests** covering the ring arithmetic, partial-window warm-up, step-response
  monotonicity, invalid-tick ageing, fix-loss expiry, out-of-range and NaN rejection, the
  below-floor and at-floor gating, and the mid-ring reset that the resume-from-pause path actually
  takes. Full suite: **243 tests pass**.
- **Running, Cycling and Hiking simulators all compile and link clean** (MSVC x86 Debug), so the
  per-app wiring is compiled, not just the smoother.
- No new `.cpp`, so none of the four source manifests need syncing.

## Follow-ups (not in this PR)

- Kernel submodule bump to pick this up.
- Optionally expose the window length as a settings-menu choice, as Coros and Garmin do.
