### PR TITLE
fix(apps): keep no-fix GPS speed out of the Cycling/Hiking maxima

### DIFF
--- a/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
@@ -84,7 +84,9 @@ private:
     SDK::Metric::MonotonicCounter<float>                mDistanceCounter;
     SDK::Metric::VariableCounter                        mSpeedCounter;
     /// Smooths the GPS speed for the live speed / pace readout only; the FIT
-    /// records, averages and maxima stay on the raw samples in mSpeedCounter.
+    /// record series and the maxima stay on the unsmoothed samples in
+    /// mSpeedCounter. The averages are not involved either way -- they come
+    /// from the distance and time totals, not from a mean of these samples.
     SDK::Metric::SpeedSmoother<skPaceSmoothingTicks>    mSpeedSmoother;
     SDK::Metric::VariableCounter                        mHrCounter;
     uint8_t                                             mHrSource = 0;      ///< Latest HR source (HeartRateEx::Source) for the icon + FIT hr_source.

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -312,13 +312,15 @@ void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)
     } else if (mSensorGpsSpeed.matchesDriver(handle)) {
         SDK::SensorDataParser::GpsSpeed parser(data[0]);
         if (parser.isDataValid()) {
-            mSpeedCounter.add(parser.getSpeed());
-            // Latched separately for the smoothed live readout, which -- unlike
-            // the counter above -- drops samples taken without a current fix.
-            // isSpeedValid() already excludes dead reckoning.
-            mGpsSpeedMs    = parser.getSpeed();
-            mGpsSpeedValid = parser.isSpeedValid();
-            mGpsSpeedFresh = true;
+            mGpsSpeedMs    = parser.getSpeed();  // raw instantaneous speed
+            mGpsSpeedValid = parser.isSpeedValid();  // already excludes dead reckoning
+            mGpsSpeedFresh = true;   // consumed by the pace smoother each tick
+            // Only feed a current (valid-fix) speed into the aggregated metrics
+            // so acquisition / fix-loss / dead-reckoning readings don't inflate
+            // the max-speed statistics.
+            if (mGpsSpeedValid) {
+                mSpeedCounter.add(mGpsSpeedMs);
+            }
             LOG_DEBUG("Speed:    %.2f m/s (valid %u)\n", mGpsSpeedMs, mGpsSpeedValid);
         }
     } else if (mSensorGpsDistance.matchesDriver(handle)) {

--- a/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Hiking/Software/Libs/Header/Service.hpp
@@ -91,7 +91,9 @@ private:
     SDK::Metric::MonotonicCounter<float>                mDistanceCounter;
     SDK::Metric::VariableCounter                        mSpeedCounter;
     /// Smooths the GPS speed for the live pace / speed readout only; the FIT
-    /// records, averages and maxima stay on the raw samples in mSpeedCounter.
+    /// record series and the maxima stay on the unsmoothed samples in
+    /// mSpeedCounter. The averages are not involved either way -- they come
+    /// from the distance and time totals, not from a mean of these samples.
     SDK::Metric::SpeedSmoother<skPaceSmoothingTicks>    mSpeedSmoother;
     SDK::Metric::VariableCounter                        mHrCounter;
     uint8_t                                             mHrSource = 0;      ///< Latest HR source (HeartRateEx::Source) for the icon + FIT hr_source.

--- a/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Hiking/Software/Libs/Sources/Service.cpp
@@ -327,13 +327,15 @@ void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)
     } else if (mSensorGpsSpeed.matchesDriver(handle)) {
         SDK::SensorDataParser::GpsSpeed parser(data[0]);
         if (parser.isDataValid()) {
-            mSpeedCounter.add(parser.getSpeed());
-            // Latched separately for the smoothed live readout, which -- unlike
-            // the counter above -- drops samples taken without a current fix.
-            // isSpeedValid() already excludes dead reckoning.
-            mGpsSpeedMs    = parser.getSpeed();
-            mGpsSpeedValid = parser.isSpeedValid();
-            mGpsSpeedFresh = true;
+            mGpsSpeedMs    = parser.getSpeed();  // raw instantaneous speed
+            mGpsSpeedValid = parser.isSpeedValid();  // already excludes dead reckoning
+            mGpsSpeedFresh = true;   // consumed by the pace smoother each tick
+            // Only feed a current (valid-fix) speed into the aggregated metrics
+            // so acquisition / fix-loss / dead-reckoning readings don't inflate
+            // the max-speed statistics.
+            if (mGpsSpeedValid) {
+                mSpeedCounter.add(mGpsSpeedMs);
+            }
             LOG_DEBUG("Speed:    %.2f m/s (valid %u)\n", mGpsSpeedMs, mGpsSpeedValid);
         }
     } else if (mSensorGpsDistance.matchesDriver(handle)) {

--- a/Examples/Apps/Running/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Running/Software/Libs/Header/Service.hpp
@@ -105,7 +105,9 @@ private:
     SDK::Metric::MonotonicCounter<float>                mDistanceCounter;
     SDK::Metric::VariableCounter                        mSpeedCounter;
     /// Smooths the GPS speed for the live pace / speed readout only; the FIT
-    /// records, averages and maxima stay on the raw samples in mSpeedCounter.
+    /// record series and the maxima stay on the unsmoothed samples in
+    /// mSpeedCounter. The averages are not involved either way -- they come
+    /// from the distance and time totals, not from a mean of these samples.
     SDK::Metric::SpeedSmoother<skPaceSmoothingTicks>    mSpeedSmoother;
     SDK::Metric::VariableCounter                        mHrCounter;
     uint8_t                                             mHrSource = 0;      ///< Latest HR source (HeartRateEx::Source) for the icon + FIT hr_source.

--- a/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Running/Software/Libs/Sources/Service.cpp
@@ -351,7 +351,8 @@ void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)
             mGpsDeadReckoning = parser.isDeadReckoning();
             mGpsSpeedFresh    = true;   // consumed by the pace smoother each tick
             // Only feed a current (valid-fix) speed into the aggregated metrics
-            // so acquisition/fix-loss readings don't pollute avg/max/distance.
+            // so acquisition / fix-loss / dead-reckoning readings don't inflate
+            // the max-speed statistics.
             if (mGpsSpeedValid) {
                 mSpeedCounter.add(mGpsSpeedMs);
             }

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(una-sdk-host-tests
     sensorlayer/SensorConnection_test.cpp
     metrics/MonotonicCounter_test.cpp
     metrics/SpeedSmoother_test.cpp
+    metrics/VariableCounter_test.cpp
     utils/ClockTime_test.cpp
     utils/Utils_test.cpp
     utils/CopyUtf8_test.cpp

--- a/Tests/Host/metrics/VariableCounter_test.cpp
+++ b/Tests/Host/metrics/VariableCounter_test.cpp
@@ -1,0 +1,195 @@
+/**
+ * @file VariableCounter_test.cpp
+ * @brief Unit tests for SDK::Metric::VariableCounter
+ *
+ * These pin the semantics the activity services depend on when they gate
+ * add() on a valid GPS fix: what getCurrent() reports for a sample that was
+ * never added, when isValid() flips, and what the maxima read when a session
+ * or lap saw no valid sample at all.
+ */
+
+#include <gtest/gtest.h>
+
+#include "SDK/Metrics/VariableCounter.hpp"
+
+namespace {
+
+constexpr float kMinValid = 0.5f;    // m/s, matches the activity apps
+constexpr float kMaxValid = 300.0f;  // m/s
+
+SDK::Metric::VariableCounter makeCounter()
+{
+    SDK::Metric::VariableCounter c;
+    EXPECT_TRUE(c.init(kMinValid, kMaxValid));
+    return c;
+}
+
+}  // namespace
+
+TEST(VariableCounter, InitRejectsInvertedRange)
+{
+    SDK::Metric::VariableCounter c;
+    EXPECT_FALSE(c.init(10.0f, 10.0f));
+    EXPECT_FALSE(c.init(20.0f, 10.0f));
+    EXPECT_TRUE(c.init(kMinValid, kMaxValid));
+}
+
+TEST(VariableCounter, CurrentLatchesBeforeTheRangeCheck)
+{
+    SDK::Metric::VariableCounter c = makeCounter();
+
+    // An out-of-range sample is excluded from the statistics but still becomes
+    // the "current" value. This is why a service that wants no out-of-range
+    // data anywhere must gate add() itself rather than rely on the range.
+    c.add(kMaxValid + 100.0f);
+
+    EXPECT_FLOAT_EQ(kMaxValid + 100.0f, c.getCurrent());
+    EXPECT_FALSE(c.isValid());
+    EXPECT_FLOAT_EQ(0.0f, c.getMaximum());
+}
+
+TEST(VariableCounter, CurrentLatchesBeforeThePauseCheck)
+{
+    SDK::Metric::VariableCounter c = makeCounter();
+
+    c.add(3.0f);
+    c.pause();
+    c.add(9.0f);
+
+    // The paused sample does not reach the statistics...
+    EXPECT_FLOAT_EQ(3.0f, c.getMaximum());
+    // ...but it does become the current value. A caller that stops calling
+    // add() while paused therefore freezes getCurrent(); one that keeps
+    // calling it does not.
+    EXPECT_FLOAT_EQ(9.0f, c.getCurrent());
+}
+
+TEST(VariableCounter, SkippedSamplesLeaveCurrentAtTheLastAdded)
+{
+    SDK::Metric::VariableCounter c = makeCounter();
+
+    c.add(4.0f);
+    // Caller decides the next samples are untrustworthy and skips them
+    // entirely, as the activity services do while the GPS fix is lost.
+    EXPECT_FLOAT_EQ(4.0f, c.getCurrent()) << "the last good value is held, not zeroed";
+}
+
+TEST(VariableCounter, ValidityIsStickyOnceASampleIsInRange)
+{
+    SDK::Metric::VariableCounter c = makeCounter();
+
+    EXPECT_FALSE(c.isValid());
+
+    c.add(0.1f);  // below the floor
+    EXPECT_FALSE(c.isValid());
+
+    c.add(3.0f);
+    EXPECT_TRUE(c.isValid());
+
+    // Still valid afterwards: it means "has seen a valid sample", not "the
+    // latest sample is valid". Anything using it as a FIT field-presence flag
+    // keeps claiming presence for the rest of the session.
+    c.add(kMaxValid + 1.0f);
+    EXPECT_TRUE(c.isValid());
+}
+
+TEST(VariableCounter, MaximaAreZeroWithoutAnyValidSample)
+{
+    SDK::Metric::VariableCounter c = makeCounter();
+
+    // A session that never saw a valid sample reports a maximum of 0, not a
+    // sentinel. A lap spent entirely without a fix therefore records
+    // max_speed = 0 even though its average, computed from distance and time,
+    // may be non-zero.
+    EXPECT_FLOAT_EQ(0.0f, c.getMaximum());
+    EXPECT_FLOAT_EQ(0.0f, c.getLapMaximum());
+    EXPECT_FLOAT_EQ(0.0f, c.getMinimum());
+    EXPECT_FLOAT_EQ(0.0f, c.getAverage()) << "count==0 must not divide";
+    EXPECT_FALSE(c.isValid());
+}
+
+TEST(VariableCounter, TracksAverageMinAndMaxOverValidSamples)
+{
+    SDK::Metric::VariableCounter c = makeCounter();
+
+    c.add(2.0f);
+    c.add(4.0f);
+    c.add(6.0f);
+
+    EXPECT_FLOAT_EQ(4.0f, c.getAverage());
+    EXPECT_FLOAT_EQ(2.0f, c.getMinimum());
+    EXPECT_FLOAT_EQ(6.0f, c.getMaximum());
+}
+
+TEST(VariableCounter, OutOfRangeSamplesAreExcludedFromStatistics)
+{
+    SDK::Metric::VariableCounter c = makeCounter();
+
+    c.add(3.0f);
+    c.add(0.1f);              // below the floor
+    c.add(kMaxValid + 1.0f);  // above the ceiling
+
+    EXPECT_FLOAT_EQ(3.0f, c.getAverage()) << "only the in-range sample counts";
+    EXPECT_FLOAT_EQ(3.0f, c.getMaximum());
+    EXPECT_FLOAT_EQ(3.0f, c.getMinimum());
+}
+
+TEST(VariableCounter, ResetLapClearsLapStatsButNotTotalsOrCurrent)
+{
+    SDK::Metric::VariableCounter c = makeCounter();
+
+    c.add(3.0f);
+    c.add(7.0f);
+    ASSERT_FLOAT_EQ(7.0f, c.getLapMaximum());
+
+    c.resetLap();
+
+    EXPECT_FLOAT_EQ(0.0f, c.getLapMaximum()) << "lap max restarts from nothing";
+    EXPECT_FLOAT_EQ(0.0f, c.getLapAverage());
+    EXPECT_FALSE(c.isLapValid());
+    EXPECT_FLOAT_EQ(7.0f, c.getMaximum()) << "session max survives a lap reset";
+    EXPECT_TRUE(c.isValid());
+    EXPECT_FLOAT_EQ(7.0f, c.getCurrent()) << "current survives a lap reset";
+}
+
+TEST(VariableCounter, ResetClearsEverythingButKeepsTheRange)
+{
+    SDK::Metric::VariableCounter c = makeCounter();
+
+    c.add(5.0f);
+    c.reset();
+
+    EXPECT_FLOAT_EQ(0.0f, c.getCurrent());
+    EXPECT_FLOAT_EQ(0.0f, c.getMaximum());
+    EXPECT_FALSE(c.isValid());
+    EXPECT_FALSE(c.isPaused());
+    EXPECT_FLOAT_EQ(kMinValid, c.getMinValid());
+    EXPECT_FLOAT_EQ(kMaxValid, c.getMaxValid());
+}
+
+TEST(VariableCounter, IgnoresSamplesBeforeInit)
+{
+    SDK::Metric::VariableCounter c;  // no init()
+
+    c.add(3.0f);
+
+    EXPECT_FLOAT_EQ(0.0f, c.getCurrent());
+    EXPECT_FALSE(c.isValid());
+}
+
+TEST(VariableCounter, ResumeRestoresAccumulation)
+{
+    SDK::Metric::VariableCounter c = makeCounter();
+
+    c.pause();
+    EXPECT_TRUE(c.isPaused());
+    c.add(9.0f);
+    EXPECT_FALSE(c.isValid());
+
+    c.resume();
+    EXPECT_FALSE(c.isPaused());
+    c.add(4.0f);
+
+    EXPECT_TRUE(c.isValid());
+    EXPECT_FLOAT_EQ(4.0f, c.getMaximum()) << "the paused sample never counted";
+}


### PR DESCRIPTION
Follow-up to #253, which flagged this while smoothing the live pace readout.

## The bug

Cycling and Hiking called `mSpeedCounter.add(parser.getSpeed())` for **every** GPS speed sample,
ignoring the parser's `SPEED_VALID` flag that Running has always honoured. That flag is false during
acquisition, during fix loss, and while the receiver is dead-reckoning — and a dead-reckoned speed is
*extrapolated*, so it can be arbitrarily wrong.

`mSpeedCounter` is read only for the maxima and the per-record speed, so the visible consequence is
an **inflated max speed**: `maxSpeed` / `maxLapSpeed` on screen, and `fitLap.speedMax` /
`fitTrack.speedMax` in the recorded activity. Max speed is a headline stat on a bike ride, and a
single bogus extrapolated sample sets it for the entire session.

The fix gates the `add()` on a valid fix, exactly as Running does. All three services now read
identically here, apart from Running's extra dead-reckoning latch that its stride calibrator needs.

## What is *not* affected

- **Averages don't move.** Average speed and average pace come from `speedFromTotals`
  (distance ÷ active time), never from a mean of these samples. `getAverage()` is never called on
  `mSpeedCounter` in any of the three apps.
- **Distance is untouched** — separate `GPS_DISTANCE` counter. Note it is *not* validity-gated
  either, so whatever that feed accumulates during a dropout still lands in the file. This PR cleans
  up the speed series and the maxima, not everything recorded during a dropout.

Running's comment claimed this gate protected "avg/max/distance". Only the maxima were ever
affected, so that comment is corrected here rather than copied into two more files — as is the same
inaccurate claim in all three `Service.hpp` headers, which #253 introduced.

## Two consequences reviewers should sign off on

Both are pre-existing Running behaviour that Cycling and Hiking now share, rather than anything new
to the codebase.

1. **Stale speed during a dropout.** `fitRecord.speed` is `mSpeedCounter.getCurrent()`, and `add()`
   latches its current value *before* its own range and pause checks. Skipping `add()` entirely
   during a fix loss therefore freezes `getCurrent()` at the last good speed, so these apps now
   record a repeated last-known-good speed instead of the current untrustworthy one. The record's
   coordinates go absent over the same gap, so the dropout stays detectable downstream. Marking
   SPEED absent while the fix is lost would be more honest, but that changes Running's shipped
   record semantics and should be done for all three apps together, not smuggled in here.

2. **A tunnel-heavy lap can record `max_speed` < `avg_speed`.** A lap that never gets a valid fix now
   reports a maximum of 0, while its average — computed from distance and time — can be non-zero.
   That is structurally legal FIT but looks wrong in Strava and in our own summary screen. Before
   this fix, dead-reckoned samples masked it by inflating the max. **Deliberately not clamped**:
   inventing a maximum would defeat the whole point of the fix. Making a zero-sample maximum *absent*
   needs lap/session field-presence flags in the encoder, which is a larger change.

Also worth knowing: before the very first fix, the FIT SPEED field is now correctly absent from
records rather than present holding a plausible-looking but untrustworthy value. Only
plausible-looking values were ever recorded — out-of-range garbage was already excluded by the
counter's 0.5–300 m/s range, and dead-reckoned speeds usually sit *inside* that range, which is
exactly what makes them harmful.

## Testing

There is no cheap host-testable seam on the app `Service` (it drags in kernel comm and sensor
plumbing). But every load-bearing behaviour asserted above is a `VariableCounter` property, and that
class had **no test at all** despite being header-only and dependency-free — so this PR adds
`Tests/Host/metrics/VariableCounter_test.cpp` (12 cases) pinning exactly the semantics the argument
rests on:

- `getCurrent()` latches before both the range check and the pause check
- skipping `add()` holds the last good value rather than zeroing
- `isValid()` is sticky once a single in-range sample lands (which is why it keeps asserting FIT
  field presence for the rest of a session)
- the maxima read `0.0` with no valid sample, and `getAverage()` does not divide by zero
- `resetLap()` clears lap state but not the totals or the current value

Full suite: **255 tests pass**. The three app simulators (Running, Cycling, Hiking) compile and link
clean under MSVC, and CI covers the ARM builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved speed statistics by excluding invalid, unavailable, and dead-reckoning GPS readings from aggregate and maximum-speed calculations.
  - Live speed smoothing continues to update independently, providing more reliable real-time readings.

- **Documentation**
  - Clarified how raw speed samples, smoothed live speed, maximums, and average-speed calculations are represented in activity records.

- **Tests**
  - Expanded coverage for speed and metric calculations, including pauses, resets, validity handling, and range filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->