### PR TITLE
feat(treadmill): widen and speed up the Calibrate & Save distance picker

### DIFF
--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/PickerLogic.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/PickerLogic.hpp
@@ -18,8 +18,8 @@ namespace PickerLogic {
 
 // -----------------------------------------------------------------------------
 // Distance: whole.fraction, displayed in km or mi. The fraction step comes from
-// the Menu descriptor (0.05 for intervals, 0.01 for calibrate); the displayed
-// hundredths are derived from it so one template covers both.
+// the Menu descriptor (0.05 for the intervals pickers); the displayed hundredths
+// are derived from it. Calibrate & Save uses DistanceFine below instead.
 // -----------------------------------------------------------------------------
 template<typename Menu>
 struct Distance {
@@ -91,6 +91,133 @@ struct Distance {
 
         p.renderSubtitleSingle(imperial ? T_TEXT_MILES_SUB : T_TEXT_KILOMETERS);
         p.renderValue(leftActive, left, right, ".", up1, up2);
+    }
+};
+
+// -----------------------------------------------------------------------------
+// DistanceFine: whole.tenth.hundredth, displayed in km or mi (Calibrate & Save).
+//
+// Where Distance above has two stages over a fixed fraction step, this keeps the
+// value as one integer count of 0.01 units and lets each stage pick only the step
+// size. Two consequences, both deliberate: a press at the top of a place carries
+// into the place above it (5.99 +0.01 -> 6.00, one press) and the whole range
+// wraps (99.99 +0.01 -> 0.00), so any treadmill-console reading is a few presses
+// away in either direction.
+// -----------------------------------------------------------------------------
+template<typename Menu>
+struct DistanceFine {
+    enum Stage { WHOLE = 0, TENTH, HUNDREDTH };
+
+    /// Number of 0.01-unit steps in the range; the value wraps modulo this.
+    static constexpr uint16_t kRange = Menu::kCountHund;
+
+    // Widening the range past 0..99.99 means widening the value type too: the
+    // descriptor computes kCountHund in uint16_t, so it would silently truncate.
+    static_assert(static_cast<uint32_t>(Menu::kMaxWhole + 1) * 100u <= UINT16_MAX,
+                  "Picker range no longer fits uint16_t -- widen kCountHund and hund together");
+    static_assert(kRange % Menu::kStepWhole == 0,
+                  "The whole-unit step must divide the range, else wrapping skips values");
+
+    Stage    stage    = WHOLE;
+    bool     imperial = false;
+    uint16_t hund     = 0;      ///< Value in hundredths of a display unit.
+
+    void seed(float meters, bool isImperial)
+    {
+        imperial = isImperial;
+        float units = meters / 1000.0f;            // km
+        if (imperial) units = SDK::Utils::kmToMiles(units);
+
+        // Ordered so that anything not provably in range -- negative, over-range,
+        // or NaN, which compares false both ways -- avoids an out-of-range
+        // float->integer cast rather than relying on the comparison to catch it.
+        const float counts = units * 100.0f + 0.5f;
+        if (!(counts >= 1.0f)) {
+            hund = 0;
+        } else if (counts >= static_cast<float>(kRange)) {
+            hund = static_cast<uint16_t>(kRange - 1u);
+        } else {
+            hund = static_cast<uint16_t>(counts);
+        }
+        stage = WHOLE;
+    }
+
+    /// Units-of-0.01 moved by one press at the current stage.
+    uint16_t step() const
+    {
+        switch (stage) {
+        case WHOLE: return Menu::kStepWhole;
+        case TENTH: return Menu::kStepTenth;
+        default:    return Menu::kStepHund;
+        }
+    }
+
+    void inc() { hund = wrapAdd(hund, step()); }
+    void dec() { hund = wrapAdd(hund, static_cast<uint16_t>(kRange - step())); }
+
+    /// Move to the next-finer place; false when already at the finest (= confirm).
+    bool advance()
+    {
+        if (stage == HUNDREDTH) return false;
+        stage = (stage == WHOLE) ? TENTH : HUNDREDTH;
+        return true;
+    }
+
+    /// Step back to the next-coarser place; false when already at the coarsest.
+    bool retreat()
+    {
+        if (stage == WHOLE) return false;
+        stage = (stage == HUNDREDTH) ? TENTH : WHOLE;
+        return true;
+    }
+
+    /// Chosen value in metres.
+    float meters() const
+    {
+        const float units = hund / 100.0f;
+        const float km    = imperial ? SDK::Utils::milesToKm(units) : units;
+        return km * 1000.0f;
+    }
+
+    void render(TwoTonePicker& p) const
+    {
+        char whole[4], fracHi[4], fracLo[4], up1[4], up2[4];
+        std::snprintf(whole, sizeof whole, "%02u", static_cast<unsigned>(hund / 100u));
+        std::snprintf(fracHi, sizeof fracHi, "%u", static_cast<unsigned>((hund / 10u) % 10u));
+        std::snprintf(fracLo, sizeof fracLo, "%u", static_cast<unsigned>(hund % 10u));
+
+        // Wrapping turns the upcoming column into a circular list, so unlike the
+        // clamped pickers both slots are always populated.
+        activePlace(up1, wrapAdd(hund, step()));
+        activePlace(up2, wrapAdd(hund, static_cast<uint16_t>(2u * step())));
+
+        p.renderSubtitleSingle(imperial ? T_TEXT_MILES_SUB : T_TEXT_KILOMETERS);
+        p.renderValue3(segment(), whole, fracHi, fracLo, up1, up2);
+    }
+
+private:
+    static uint16_t wrapAdd(uint16_t value, uint16_t delta)
+    {
+        return static_cast<uint16_t>((value + delta) % kRange);
+    }
+
+    TwoTonePicker::Segment segment() const
+    {
+        switch (stage) {
+        case WHOLE: return TwoTonePicker::SEG_WHOLE;
+        case TENTH: return TwoTonePicker::SEG_FRAC_HI;
+        default:    return TwoTonePicker::SEG_FRAC_LO;
+        }
+    }
+
+    /// Format only the place being edited -- that is all the upcoming column shows.
+    void activePlace(char (&out)[4], uint16_t value) const
+    {
+        switch (stage) {
+        case WHOLE: std::snprintf(out, sizeof out, "%02u", static_cast<unsigned>(value / 100u)); break;
+        case TENTH: std::snprintf(out, sizeof out, "%u", static_cast<unsigned>((value / 10u) % 10u)); break;
+        default:    std::snprintf(out, sizeof out, "%u", static_cast<unsigned>(value % 10u)); break;
+        }
     }
 };
 

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TwoTonePicker.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TwoTonePicker.hpp
@@ -27,6 +27,9 @@
 class TwoTonePicker : public TwoTonePickerBase
 {
 public:
+    /// Which slot of a three-part value is being edited (see renderValue3()).
+    enum Segment : uint8_t { SEG_WHOLE = 0, SEG_FRAC_HI, SEG_FRAC_LO };
+
     TwoTonePicker();
     virtual ~TwoTonePicker() {}
 
@@ -53,9 +56,37 @@ public:
                      const char* left, const char* right, const char* sep,
                      const char* up1, const char* up2);
 
+    /**
+     * Render a three-slot "<whole>.<fracHi><fracLo>" value, where any one of the
+     * three slots is the active (teal SemiBold) one -- used by the Calibrate & Save
+     * picker, which edits the whole part, tenths and hundredths separately.
+     *
+     * The two fraction digits get one fixed-width centred slot each, sized to the
+     * SemiBold digit advance, so they hold their position as the active weight moves
+     * between them; the upcoming column is centred under the active digit instead of
+     * left-aligned across both.
+     *
+     * @param active           slot being edited.
+     * @param whole            formatted whole part (right-aligned into the separator).
+     * @param fracHi/fracLo    single tenths / hundredths digit.
+     * @param up1/up2          upcoming values of the active slot ("" to blank).
+     */
+    void renderValue3(Segment active,
+                      const char* whole, const char* fracHi, const char* fracLo,
+                      const char* up1, const char* up2);
+
 private:
     static touchgfx::colortype teal();
     static touchgfx::colortype grey();
+
+    /// Advance width of one 60px digit, i.e. the width of one fraction slot.
+    static uint16_t digitSlotWidth();
+
+    /// Fourth value slot: the hundredths digit. The generated base only provides
+    /// left / separator / right, which is all the two-stage pickers need.
+    touchgfx::TextAreaWithOneWildcard valFracLo;
+    static const uint16_t VALFRACLO_SIZE = 3;
+    touchgfx::Unicode::UnicodeChar valFracLoBuffer[VALFRACLO_SIZE];
 };
 
 #endif // TWOTONEPICKER_HPP

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
@@ -105,18 +105,20 @@ struct Root {
             static constexpr uint16_t kCountFrac = 20;     ///< 0.00..0.95 in 0.05 steps
         };
 
-        // Calibrate & Save "actual distance" picker (Treadmill, §5). Same whole
-        // ranges as the interval picker, but a finer 0.01-unit fraction step
-        // (0.00..0.99 -> 100 items) so the user can match the treadmill console
-        // distance precisely.
+        // Calibrate & Save "actual distance" picker (Treadmill, §5). The value is
+        // held as a single count of 0.01 display units (km or mi) spanning
+        // 0.00..99.99, wide enough for any treadmill console reading. Three stages
+        // select the step size -- whole unit / tenth / hundredth -- and a step at
+        // the top of a place carries into the one above it, so no reading is more
+        // than a handful of presses away. See PickerLogic::DistanceFine.
         struct CalibratePicker {
-            static constexpr uint16_t kMaxWholeKm   = 10;
-            static constexpr uint16_t kMaxWholeMi   = 6;
-            static constexpr uint16_t kCountWholeKm = kMaxWholeKm + 1;  ///< 0..10 -> 11 items
-            static constexpr uint16_t kCountWholeMi = kMaxWholeMi + 1;  ///< 0..6  -> 7 items
+            static constexpr uint16_t kMaxWhole  = 99;   ///< 0..99 whole units
+            static constexpr uint16_t kStepWhole = 100;  ///< 1.00 unit per press
+            static constexpr uint16_t kStepTenth = 10;   ///< 0.10 unit per press
+            static constexpr uint16_t kStepHund  = 1;    ///< 0.01 unit per press
 
-            static constexpr float    kFracStep  = 0.01f;  ///< Units (km or mi) per index step
-            static constexpr uint16_t kCountFrac = 100;    ///< 0.00..0.99 in 0.01 steps
+            /// Number of 0.01-unit steps in the range: 0.00..99.99 -> 10000.
+            static constexpr uint16_t kCountHund = (kMaxWhole + 1) * 100;
         };
     };
 

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/trackcalibrate_screen/TrackCalibrateView.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/trackcalibrate_screen/TrackCalibrateView.hpp
@@ -6,10 +6,12 @@
 #include <gui/containers/PickerLogic.hpp>
 
 /**
- * Post-run "Calibrate & Save" distance entry (§5). Uses the shared TwoTonePicker:
- * stage 1 edits the whole part, stage 2 the 0.01-unit fraction. R1 confirms /
- * advances; R2 steps back a stage, or (from stage 1) backs out to the pause menu
- * without saving (the activity stays paused until R1 confirms).
+ * Post-run "Calibrate & Save" distance entry (§5). Uses the shared TwoTonePicker
+ * in its three-slot layout: stage 1 edits whole units, stage 2 tenths, stage 3
+ * hundredths, over 0.00..99.99 with carry and wrap (PickerLogic::DistanceFine).
+ * R1 moves to the finer place and confirms from the last one; R2 steps back a
+ * place, or (from stage 1) backs out to the pause menu without saving (the
+ * activity stays paused until R1 confirms).
  */
 class TrackCalibrateView : public TrackCalibrateViewBase
 {
@@ -24,7 +26,7 @@ public:
 protected:
     using Menu = App::MenuNav::Root::Intervals::CalibratePicker;
 
-    PickerLogic::Distance<Menu> mLogic;
+    PickerLogic::DistanceFine<Menu> mLogic;
 
     virtual void handleKeyEvent(uint8_t key) override;
 };

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/TwoTonePicker.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/TwoTonePicker.cpp
@@ -1,11 +1,52 @@
 #include <gui/containers/TwoTonePicker.hpp>
 #include <gui/containers/Buttons.hpp>
 #include <touchgfx/Color.hpp>
+#include <touchgfx/Font.hpp>
+
+namespace {
+
+// Value / upcoming-value row geometry, mirroring TwoTonePickerBase so the extra
+// slot renderValue3() adds lines up with the generated ones.
+constexpr int16_t kValY   = 92;    ///< Big value row.
+constexpr int16_t kValH   = 80;
+constexpr int16_t kFracX  = 127;   ///< Left edge of the fraction, just past the separator.
+constexpr int16_t kLeftX  = 5;     ///< Left (whole-part) column.
+constexpr int16_t kLeftW  = 110;
+constexpr int16_t kRightW = 108;   ///< Full-width right column (two-stage layout).
+constexpr int16_t kUpY    = 151;   ///< First upcoming-value row.
+constexpr int16_t kUpH    = 50;
+constexpr int16_t kUp2Y   = 193;   ///< Second upcoming-value row.
+constexpr int16_t kUp2H   = 36;
+
+/// Poppins SemiBold 60 digit advance -- only used if the font is not bound yet.
+constexpr uint16_t kFallbackDigitW = 40;
+
+} // namespace
 
 touchgfx::colortype TwoTonePicker::teal() { return touchgfx::Color::getColorFromRGB(0, 128, 128); }
 touchgfx::colortype TwoTonePicker::grey() { return touchgfx::Color::getColorFromRGB(192, 192, 192); }
 
-TwoTonePicker::TwoTonePicker() {}
+uint16_t TwoTonePicker::digitSlotWidth()
+{
+    // Poppins figures are tabular, so any digit gives the slot width.
+    const touchgfx::Font* font = touchgfx::TypedText(T_TMP_SEMIBOLD_60).getFont();
+    const uint16_t width = (font != nullptr) ? font->getCharWidth('0') : 0;
+    return (width != 0) ? width : kFallbackDigitW;
+}
+
+TwoTonePicker::TwoTonePicker()
+{
+    // Hundredths slot: positioned per-render by renderValue3(). Added here rather
+    // than in initialize() so it is registered exactly once per construction.
+    // Screens that call renderValue() never write its buffer, so it stays blank.
+    valFracLoBuffer[0] = 0;
+    valFracLo.setPosition(kFracX + kFallbackDigitW, kValY, kFallbackDigitW, kValH);
+    valFracLo.setColor(grey());
+    valFracLo.setLinespacing(0);
+    valFracLo.setWildcard(valFracLoBuffer);
+    valFracLo.setTypedText(touchgfx::TypedText(T_TMP_LIGHT_60));
+    add(valFracLo);
+}
 
 void TwoTonePicker::initialize()
 {
@@ -76,8 +117,17 @@ void TwoTonePicker::renderValue(bool leftActive,
     valLeft.setWildcard(valLeftBuffer);
     valLeft.setColor(leftActive ? teal() : grey());
 
+    // Undo the three-slot layout in case this picker previously rendered it: give
+    // valRight its full-width box back and blank the hundredths slot, which would
+    // otherwise stay painted on top of it.
+    valFracLo.invalidate();
+    valFracLoBuffer[0] = 0;
+    valFracLo.setWildcard(valFracLoBuffer);
+
     // Right component: teal SemiBold when active, grey Light otherwise
     // (left-aligned from the separator).
+    valRight.invalidate();
+    valRight.setPosition(kFracX, kValY, kRightW, kValH);
     Unicode::strncpy(valRightBuffer, right, VALRIGHT_SIZE);
     valRight.setTypedText(touchgfx::TypedText(leftActive ? T_TMP_LIGHT_60_L : T_TMP_SEMIBOLD_60_L));
     valRight.setWildcard(valRightBuffer);
@@ -112,6 +162,81 @@ void TwoTonePicker::renderValue(bool leftActive,
     valLeft.invalidate();
     valSep.invalidate();
     valRight.invalidate();
+    nextVal.invalidate();
+    nextVal2.invalidate();
+}
+
+void TwoTonePicker::renderValue3(Segment active,
+                                 const char* whole, const char* fracHi, const char* fracLo,
+                                 const char* up1, const char* up2)
+{
+    const int16_t slotW = static_cast<int16_t>(digitSlotWidth());
+    const int16_t hiX   = kFracX;
+    const int16_t loX   = static_cast<int16_t>(kFracX + slotW);
+
+    const bool wholeActive = (active == SEG_WHOLE);
+    const bool hiActive    = (active == SEG_FRAC_HI);
+    const bool loActive    = (active == SEG_FRAC_LO);
+
+    // Separator: always grey, light. (Unicode::strncpy converts ASCII -> UnicodeChar;
+    // Unicode::snprintf "%s" expects a UnicodeChar*, so it must not be used here.)
+    Unicode::strncpy(valSepBuffer, ".", VALSEP_SIZE);
+    valSep.setColor(grey());
+
+    // Whole part: right-aligned into the separator, as in the two-stage layout.
+    Unicode::strncpy(valLeftBuffer, whole, VALLEFT_SIZE);
+    valLeft.setTypedText(touchgfx::TypedText(wholeActive ? T_TMP_SEMIBOLD_60_R : T_TMP_LIGHT_60_R));
+    valLeft.setWildcard(valLeftBuffer);
+    valLeft.setColor(wholeActive ? teal() : grey());
+
+    // Fraction digits: one digit centred in each fixed-width slot. Sizing the slot
+    // to the SemiBold advance (Light digits are a few px narrower) keeps both digits
+    // put as the active weight moves between them. Clear the old rects BEFORE
+    // resizing valRight down from its full-width box, else TouchGFX leaves the
+    // vacated area unpainted (leftover-digits artifact).
+    valRight.invalidate();
+    valRight.setPosition(hiX, kValY, slotW, kValH);
+    valRight.setTypedText(touchgfx::TypedText(hiActive ? T_TMP_SEMIBOLD_60 : T_TMP_LIGHT_60));
+    Unicode::strncpy(valRightBuffer, fracHi, VALRIGHT_SIZE);
+    valRight.setWildcard(valRightBuffer);
+    valRight.setColor(hiActive ? teal() : grey());
+
+    valFracLo.invalidate();
+    valFracLo.setPosition(loX, kValY, slotW, kValH);
+    valFracLo.setTypedText(touchgfx::TypedText(loActive ? T_TMP_SEMIBOLD_60 : T_TMP_LIGHT_60));
+    Unicode::strncpy(valFracLoBuffer, fracLo, VALFRACLO_SIZE);
+    valFracLo.setWildcard(valFracLoBuffer);
+    valFracLo.setColor(loActive ? teal() : grey());
+
+    nextVal.invalidate();
+    nextVal2.invalidate();
+
+    if (wholeActive) {
+        // Right-aligned under the whole part (pulls toward centre).
+        nextVal.setTypedText(touchgfx::TypedText(T_TMP_MEDIUM_40_R));
+        nextVal2.setTypedText(touchgfx::TypedText(T_TMP_MEDIUM_25_R));
+        nextVal.setPosition(kLeftX, kUpY, kLeftW, kUpH);
+        nextVal2.setPosition(kLeftX, kUp2Y, kLeftW, kUp2H);
+    } else {
+        // Centred under whichever fraction digit is being edited.
+        const int16_t x = hiActive ? hiX : loX;
+        nextVal.setTypedText(touchgfx::TypedText(T_TMP_MEDIUM_40));
+        nextVal2.setTypedText(touchgfx::TypedText(T_TMP_MEDIUM_25));
+        nextVal.setPosition(x, kUpY, slotW, kUpH);
+        nextVal2.setPosition(x, kUp2Y, slotW, kUp2H);
+    }
+
+    Unicode::strncpy(nextValBuffer, up1 ? up1 : "", NEXTVAL_SIZE);
+    Unicode::strncpy(nextVal2Buffer, up2 ? up2 : "", NEXTVAL2_SIZE);
+    nextVal.setWildcard(nextValBuffer);
+    nextVal2.setWildcard(nextVal2Buffer);
+    nextVal.setColor(grey());
+    nextVal2.setColor(grey());
+
+    valLeft.invalidate();
+    valSep.invalidate();
+    valRight.invalidate();
+    valFracLo.invalidate();
     nextVal.invalidate();
     nextVal2.invalidate();
 }

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/trackcalibrate_screen/TrackCalibrateView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/trackcalibrate_screen/TrackCalibrateView.cpp
@@ -21,22 +21,20 @@ void TrackCalibrateView::handleKeyEvent(uint8_t key)
     } else if (key == SDK::GUI::Button::L2) {
         mLogic.inc();
         mLogic.render(picker);
-    } else if (key == SDK::GUI::Button::R1) {     // confirm / advance stage
-        if (!mLogic.atFrac()) {
-            mLogic.toFrac();
+    } else if (key == SDK::GUI::Button::R1) {     // advance a place / confirm
+        if (mLogic.advance()) {
             mLogic.render(picker);
         } else {
             presenter->applyCalibration(mLogic.meters());
             application().gotoTrackSavedScreenNoTransition();
         }
-    } else if (key == SDK::GUI::Button::R2) {     // back / step back
-        if (!mLogic.atFrac()) {
+    } else if (key == SDK::GUI::Button::R2) {     // step back a place / back out
+        if (mLogic.retreat()) {
+            mLogic.render(picker);
+        } else {
             // Back out to the pause menu (Resume / Discard / Save) without
             // saving — the activity is still only paused, not stopped.
             application().gotoTrackActionScreenNoTransition();
-        } else {
-            mLogic.toWhole();
-            mLogic.render(picker);
         }
     }
 }


### PR DESCRIPTION
Fixes three problems with the Treadmill app's post-run **Calibrate & Save** distance picker, where the user enters the distance their treadmill console showed.

| Reported | Now |
| --- | --- |
| Maxed out at `10.99` | `0.00`–`99.99` |
| No wrap/carry — `5.99` → `6.00` took 100+ presses | One press |
| Two adjustment levels (whole units, hundredths) | Three (whole units, tenths, hundredths) |

## Approach

The old picker held a whole part and a fraction *index*, each clamped independently. This replaces it with `PickerLogic::DistanceFine`, which holds the value as **one integer count of 0.01 display units** and lets each stage select only the step size (`1.00` / `0.10` / `0.01`).

Carry and wrap then fall out of the arithmetic rather than needing special cases: a press at the top of a place moves the place above it, and the whole range wraps at both ends. That wrap also matters more than it used to — it halves the walk across the now much wider whole part (50 presses covers the full 0–99 span rather than 99).

`seed()` is clamped at both ends and no longer reaches an out-of-range float→integer cast.

## Display

`TwoTonePicker` only had two independently-coloured slots, so it gains a third via `renderValue3()`. The two fraction digits get one fixed-width centred slot each, sized to the SemiBold-60 digit advance. Poppins figures are tabular at 40 px, so **the digits land exactly where the previous left-aligned pair drew** and hold position as the teal highlight moves between them (Light-60 digits are 3 px narrower, which would otherwise shift the last digit). The upcoming-value column is centred under the active digit instead of spanning both.

```
stage 1        stage 2        stage 3
[05].99        05.[9]9        05.9[9]
step 1.00      step 0.10      step 0.01
```

R1 advances a place and confirms from the last one; R2 steps back a place and, from the first, still backs out to the pause menu without saving.

## Scope

`PickerLogic::Distance` / `Time` and the existing `renderValue()` are unchanged, so the four intervals pickers behave exactly as before. `renderValue()` now also restores the full-width layout and blanks the third slot, so the two rendering paths cannot interfere if a future screen ever mixes them. Only Treadmill's copies of these files are touched — Running has no calibrate screen.

## Verification

- **MSVC simulator build**: clean at the project's warning level, links.
- **Logic**: 30 assertions against the real header — clamping of over-range/negative/NaN seeds, carry both directions, wrap at both ends, stage walk, circular preview column, metric + imperial `meters()` round-trip. (Harness was scratch, not committed — see below.)
- **On the simulator**, driven through the real Save → Calibrate flow: all three stages highlight correctly; `00.06` +0.01 ×4 carries to `00.10`; the whole part wraps to `99.10` with no clipping; confirm reaches "Saved"; the intervals distance and time pickers render as before.

## Notes for review

- **No committed test.** The carry/wrap arithmetic is exactly the kind of thing that regresses silently, but `PickerLogic.hpp` pulls in TouchGFX via `TwoTonePicker.hpp`, so testing it needs a stub header shadowed onto the include path. That can't go into `Tests/Host`'s single executable without risking collisions (both Running and Treadmill ship a `Settings.hpp`), so it would want its own CMake target. Happy to add that here or as a follow-up — say which you'd prefer.
- **The whole part is still one 0–99 field**, by design decision. Splitting it into tens/units digits would cap any value at ~20 presses and is now a small change (a fourth stage at step `10.00`), but it was deliberately left out of scope.

The spec wording is updated in the kernel repo alongside this: UNAWatch/una-kernel#255.
