### PR TITLE
feat(ci): shipped variants as first-class CI-built artifacts (Walking)

### DIFF
--- a/.github/scripts/generate-app-list.py
+++ b/.github/scripts/generate-app-list.py
@@ -38,7 +38,7 @@ for root, dirs, files in os.walk(base_path):
 variants = set()
 variants_path = os.path.join(base_path, 'Variants')
 if os.path.isdir(variants_path):
-    for dir_name in sorted(os.listdir(variants_path)):
+    for dir_name in os.listdir(variants_path):
         if os.path.isfile(os.path.join(variants_path, dir_name, 'manifest.json')):
             if dir_name not in apps_excluded:
                 variants.add(dir_name)

--- a/.github/scripts/generate-app-list.py
+++ b/.github/scripts/generate-app-list.py
@@ -29,8 +29,19 @@ for root, dirs, files in os.walk(base_path):
             parts = rel_path.split(os.sep)
             if len(parts) >= 1 and parts[0] and parts[0] != '.':
                 app_name = parts[0]
-                if app_name not in apps_excluded:
+                if app_name not in apps_excluded and app_name != 'Variants':
                     apps.add(app_name)
 
-output = {'apps': sorted(list(apps))}
+# Shipped variants: code-less alias .uapps packed after the app build (no
+# -CMake dir, so they can never appear in the compiled-app matrix above).
+# See Examples/Apps/Variants/README.md.
+variants = set()
+variants_path = os.path.join(base_path, 'Variants')
+if os.path.isdir(variants_path):
+    for dir_name in sorted(os.listdir(variants_path)):
+        if os.path.isfile(os.path.join(variants_path, dir_name, 'manifest.json')):
+            if dir_name not in apps_excluded:
+                variants.add(dir_name)
+
+output = {'apps': sorted(list(apps)), 'variants': sorted(list(variants))}
 print(json.dumps(output))

--- a/.github/workflows/apps-ci.yml
+++ b/.github/workflows/apps-ci.yml
@@ -102,6 +102,9 @@ jobs:
           path: built-apps
           pattern: app-*
 
+      # No Pillow installed: fine while every variant uses icons: "target"
+      # (the PNG conversion path in make_variant.py imports PIL lazily). The
+      # first custom-PNG-icon variant needs a pip install here.
       - name: Pack and verify variant ${{ matrix.variant }}
         run: |
           python3 Utilities/Scripts/app_merging/pack_variants.py \
@@ -115,11 +118,19 @@ jobs:
         with:
           name: app-${{ matrix.variant }}
           path: variants-out/${{ matrix.variant }}/*.uapp
+          if-no-files-found: error
 
   release:
     runs-on: ubuntu-latest
     needs: [cmake-build, pack-variants]
-    if: startsWith(github.ref, 'refs/tags/apps-v')
+    # pack-variants is skipped when no variants exist; that must not skip the
+    # release with it (skipped needs propagate by default), so spell out the
+    # acceptable results instead.
+    if: >-
+      startsWith(github.ref, 'refs/tags/apps-v') &&
+      !cancelled() &&
+      needs.cmake-build.result == 'success' &&
+      (needs.pack-variants.result == 'success' || needs.pack-variants.result == 'skipped')
     permissions:
       contents: write
     env:

--- a/.github/workflows/apps-ci.yml
+++ b/.github/workflows/apps-ci.yml
@@ -16,6 +16,7 @@ jobs:
     container: python:3.11-slim
     outputs:
       apps: ${{ steps.generate.outputs.apps }}
+      variants: ${{ steps.generate.outputs.variants }}
     steps:
       - name: Setup GIT
         # Debian base image (python:3.11-slim) — not affected by the Ubuntu security
@@ -32,6 +33,7 @@ jobs:
         run: |
           output=$(python3 .github/scripts/generate-app-list.py)
           echo "apps=$(echo "$output" | jq -c .apps)" >> $GITHUB_OUTPUT
+          echo "variants=$(echo "$output" | jq -c .variants)" >> $GITHUB_OUTPUT
 
   cmake-build:
     runs-on: ubuntu-latest
@@ -79,9 +81,44 @@ jobs:
           name: app-${{ matrix.app }}
           path: Examples/Apps/${{ matrix.app }}/Software/App*/*-CMake/build/*.uapp
 
+  # Shipped variants (Examples/Apps/Variants/*) are code-less alias .uapps
+  # packed against the freshly built target binaries, so they run after the
+  # app matrix. Each variant is uploaded as an app-<Name> artifact, which the
+  # release job's existing app-* glob then zips like any compiled app.
+  pack-variants:
+    runs-on: ubuntu-latest
+    needs: [prepare, cmake-build]
+    if: needs.prepare.outputs.variants != '[]'
+    strategy:
+      matrix:
+        variant: ${{ fromJson(needs.prepare.outputs.variants) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Download built apps
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: built-apps
+          pattern: app-*
+
+      - name: Pack and verify variant ${{ matrix.variant }}
+        run: |
+          python3 Utilities/Scripts/app_merging/pack_variants.py \
+            --apps-root Examples/Apps \
+            --built-apps built-apps \
+            --only "${{ matrix.variant }}" \
+            --out variants-out
+
+      - name: Upload variant artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: app-${{ matrix.variant }}
+          path: variants-out/${{ matrix.variant }}/*.uapp
+
   release:
     runs-on: ubuntu-latest
-    needs: [cmake-build]
+    needs: [cmake-build, pack-variants]
     if: startsWith(github.ref, 'refs/tags/apps-v')
     permissions:
       contents: write

--- a/Examples/Apps/Variants/README.md
+++ b/Examples/Apps/Variants/README.md
@@ -1,0 +1,57 @@
+# Shipped activity variants
+
+A **variant** is a code-less alias `.uapp` that makes an existing app binary appear in the
+launcher as a separate activity (design: una-kernel `Docs/Multi-Activity-Apps-Design.md`).
+Each subdirectory here is the source of truth for one **shipped** variant:
+
+```
+Variants/<Name>/
+├── manifest.json   # identity + packing parameters (see below)
+└── config.json     # the embedded VariantConfig JSON (schema/name/fit/features)
+```
+
+CI packs every manifest after the app build (`pack_variants.py` driving `make_variant.py`)
+and publishes the resulting `.uapp` exactly like a compiled app: an `app-<Name>` artifact
+and a `<Name>/` folder inside the `una-apps-*.zip` release. Variants are NOT part of the
+compiled-app matrix (no `*-CMake` directory) by design.
+
+## manifest.json fields
+
+| Field | Meaning |
+|---|---|
+| `name` | Launcher name (ASCII, max 15 chars) and output file stem |
+| `appid` | The variant's OWN unique 16-hex uappID — never the target's (see allocation below) |
+| `target` | Directory name of the base app under `Examples/Apps/` (e.g. `Hiking`). The target's uappID is read from its freshly built `.uapp` at pack time, so it can never drift from the binary |
+| `type` | App type — must match the target's (`Activity`/`Utility`/`Clockface`; glance targets are rejected by the kernel) |
+| `appver` | Alias content revision `A.B.C` — bump when this variant's config changes |
+| `min_target_version` | Minimum target app version, `0.0.0` = any |
+| `origin` | `shipped` for everything in this tree (`user` is reserved for on-watch CreateVariant) |
+| `config` | Path (relative to the manifest) of the embedded config JSON; must carry `"schema": 1` |
+| `icons` | `"target"` = copy both icons out of the built target `.uapp` (the v1 convention), or `{"normal": "icon_60x60.png", "small": "icon_30x30.png"}` for custom PNGs |
+
+## AppID allocation rule
+
+Variant uappIDs live in the same 16-hex namespace as app `APP_ID`s
+(`Examples/Apps/<App>/Software/App*/*-CMake/CMakeLists.txt`):
+
+1. Generate a random 16-hex value (e.g. `python3 -c "import secrets; print(secrets.token_hex(8).upper())"`).
+2. It must collide with **nothing**: any app's `APP_ID` or any other variant manifest.
+   `pack_variants.py` enforces this on every CI run (it reads the IDs out of all built
+   `.uapp` headers and all manifests) and the kernel independently rejects a collision at
+   boot scan — but catch it here, not on a customer's watch.
+3. Once shipped, an ID is permanent: the phone's update/uninstall bookkeeping keys on it.
+   Bump `appver` for content changes; never reuse or rotate the ID.
+
+Current allocations:
+
+| Variant | appid | Target |
+|---|---|---|
+| Walking | `A1E5D3B7C9F04A82` | Hiking (`A1F3C92B7E4D8A10`) |
+
+## Local build
+
+```bash
+# after building the target app (e.g. Hiking) so its .uapp exists:
+python3 Utilities/Scripts/app_merging/pack_variants.py \
+    --apps-root Examples/Apps --out Output/variants
+```

--- a/Examples/Apps/Variants/Walking/config.json
+++ b/Examples/Apps/Variants/Walking/config.json
@@ -1,0 +1,1 @@
+{"schema":1,"name":"Walking","fit":{"sport":11,"subSport":0}}

--- a/Examples/Apps/Variants/Walking/manifest.json
+++ b/Examples/Apps/Variants/Walking/manifest.json
@@ -1,0 +1,11 @@
+{
+    "name": "Walking",
+    "appid": "A1E5D3B7C9F04A82",
+    "target": "Hiking",
+    "type": "Activity",
+    "appver": "1.0.0",
+    "min_target_version": "0.0.0",
+    "origin": "shipped",
+    "config": "config.json",
+    "icons": "target"
+}

--- a/Utilities/Scripts/app_merging/make_variant.py
+++ b/Utilities/Scripts/app_merging/make_variant.py
@@ -77,6 +77,15 @@ def convert_icon_to_abgr2222(png_path: Path) -> bytes:
     return bytes(bmp_data)
 
 
+def uappid_of(uapp_path: Path) -> int:
+    """The uappID (first u64, little-endian) of a built .uapp."""
+    with open(uapp_path, "rb") as f:
+        raw = f.read(8)
+    if len(raw) != 8:
+        raise ValueError(f"{uapp_path} is too short to carry a MainHeader")
+    return struct.unpack("<Q", raw)[0]
+
+
 def icons_from_uapp(uapp_path: Path) -> tuple[bytes, bytes]:
     """Extract both icons from an existing .uapp (real app or alias) at the
     fixed post-MainHeader offsets -- the same copy the kernel's CreateVariant
@@ -97,8 +106,11 @@ def main() -> int:
     parser.add_argument("-name", required=True, help="Variant launcher name (max 15 chars, ASCII)")
     parser.add_argument("-appid", type=parse_appid_64, required=True,
                         help="The variant's OWN unique 16-hex AppID (not the target's)")
-    parser.add_argument("-target_appid", type=parse_appid_64, required=True,
+    parser.add_argument("-target_appid", type=parse_appid_64, default=None,
                         help="16-hex AppID of the base app this variant runs")
+    parser.add_argument("-target_uapp", type=Path, default=None,
+                        help="Read the target AppID out of a built .uapp instead of "
+                             "-target_appid (keeps CI in lockstep with the binary)")
     parser.add_argument("-config", type=Path, required=True,
                         help="Path to the variant config JSON to embed")
     parser.add_argument("-type", required=True, choices=list(APP_TYPES.keys()),
@@ -121,6 +133,11 @@ def main() -> int:
         parser.error("-name must fit 15 bytes (NUL-terminated 16-byte field)")
     if not args.name.isascii():
         parser.error("-name must be ASCII (the wildcard fonts cover ASCII only)")
+
+    if (args.target_appid is None) == (args.target_uapp is None):
+        parser.error("provide exactly one of -target_appid / -target_uapp")
+    if args.target_uapp is not None:
+        args.target_appid = uappid_of(args.target_uapp)
     if args.appid == args.target_appid:
         parser.error("-appid must differ from -target_appid (an alias cannot claim "
                      "the target's own identity; the kernel rejects the collision at scan)")

--- a/Utilities/Scripts/app_merging/pack_variants.py
+++ b/Utilities/Scripts/app_merging/pack_variants.py
@@ -30,7 +30,10 @@ MAIN_HEADER_SIZE = 48
 ICONS_SIZE = 3600 + 900
 PAYLOAD_OFFSET = MAIN_HEADER_SIZE + ICONS_SIZE
 PAYLOAD_SIZE = 32
+FLAGS_OFFSET = 20
 FLAG_APP_VARIANT_ALIAS = 0x40
+APP_TYPE_MASK = 0x03
+APP_TYPES = {"Activity": 0, "Utility": 1, "Glance": 2, "Clockface": 3}
 
 
 def fail(msg: str) -> None:
@@ -38,16 +41,34 @@ def fail(msg: str) -> None:
     sys.exit(1)
 
 
-def uappid_of(uapp: Path) -> int:
+def header_of(uapp: Path) -> tuple[int, int]:
+    """(uappID, flags) from a .uapp MainHeader."""
     with open(uapp, "rb") as f:
-        return struct.unpack("<Q", f.read(8))[0]
+        raw = f.read(MAIN_HEADER_SIZE)
+    if len(raw) != MAIN_HEADER_SIZE:
+        fail(f"{uapp} is too short to carry a MainHeader")
+    uappid = struct.unpack_from("<Q", raw, 0)[0]
+    flags = struct.unpack_from("<I", raw, FLAGS_OFFSET)[0]
+    return uappid, flags
+
+
+def uappid_of(uapp: Path) -> int:
+    return header_of(uapp)[0]
+
+
+def is_alias(uapp: Path) -> bool:
+    """True for a code-less variant alias. In CI the artifacts directory can
+    already contain OTHER variants' outputs (matrix jobs upload as they
+    finish), so alias files must never count as compiled-app inputs."""
+    return bool(header_of(uapp)[1] & FLAG_APP_VARIANT_ALIAS)
 
 
 def find_built_uapp(name: str, search_roots: list[Path]) -> Path | None:
-    """Newest <Name>*.uapp under any search root (CI artifacts or build dirs)."""
+    """Newest compiled <Name>*.uapp under any search root (aliases excluded)."""
     candidates = []
     for root in search_roots:
         candidates += list(root.rglob(f"{name}_*.uapp")) + list(root.rglob(f"{name}.uapp"))
+    candidates = [c for c in candidates if not is_alias(c)]
     if not candidates:
         return None
     return max(candidates, key=lambda p: p.stat().st_mtime)
@@ -66,11 +87,20 @@ def verify_alias(path: Path, expected_appid: int, expected_target: int) -> None:
         fail(f"{path.name}: alias must carry libcVersion=0 and serviceSize=0")
     if not (flags & FLAG_APP_VARIANT_ALIAS):
         fail(f"{path.name}: FLAG_APP_VARIANT_ALIAS missing (flags=0x{flags:02X})")
+    if flags & ~0x7F:
+        fail(f"{path.name}: flags outside the alias mask (0x{flags:08X})")
+    if 0 not in data[24:40]:
+        fail(f"{path.name}: app_name is not NUL-terminated within 16 bytes")
+    normal_icon, small_icon = struct.unpack_from("<II", data, 40)
+    if normal_icon != 3600 or small_icon != 900:
+        fail(f"{path.name}: icon size fields must be 3600/900")
 
     (payload_ver, target, _min_ver, _origin, config_size) = \
         struct.unpack_from("<IQIBI", data, PAYLOAD_OFFSET)
     if payload_ver != 1:
         fail(f"{path.name}: unexpected payloadVersion {payload_ver}")
+    if config_size > 8192:
+        fail(f"{path.name}: configSize {config_size} exceeds the kernel's 8192-byte bound")
     if target != expected_target:
         fail(f"{path.name}: payload target {target:016X} != built target {expected_target:016X}")
     if len(data) != PAYLOAD_OFFSET + PAYLOAD_SIZE + config_size + 4:
@@ -106,9 +136,19 @@ def main() -> int:
     search_roots = [args.built_apps if args.built_apps else args.apps_root]
 
     # ---- AppID allocation rule: collide with nothing ------------------------
+    # Alias files are skipped: in CI they are other variants' outputs, whose
+    # IDs are already accounted for by the manifest-vs-manifest check below.
     ids: dict[int, str] = {}
+    seen_files: dict[int, str] = {}
     for uapp in search_roots[0].rglob("*.uapp"):
-        ids.setdefault(uappid_of(uapp), f"built app {uapp.name}")
+        if is_alias(uapp):
+            continue
+        appid = uappid_of(uapp)
+        if appid in seen_files and seen_files[appid] != uapp.name:
+            fail(f"built apps {seen_files[appid]} and {uapp.name} share appID "
+                 f"{appid:016X}")
+        seen_files[appid] = uapp.name
+        ids.setdefault(appid, f"built app {uapp.name}")
     for m in manifests:
         spec = json.loads(m.read_text())
         appid = int(spec["appid"], 16)
@@ -125,14 +165,43 @@ def main() -> int:
     args.out.mkdir(parents=True, exist_ok=True)
     for m in manifests:
         spec = json.loads(m.read_text())
+        missing = [k for k in ("name", "appid", "target", "type", "appver", "config")
+                   if k not in spec]
+        if missing:
+            fail(f"{m}: manifest is missing required key(s): {', '.join(missing)}")
         name = spec["name"]
+        dirname = m.parent.name
         print(f"packing variant {name} (from {m})")
+
+        # The artifact name and upload glob are keyed on the DIRECTORY name,
+        # so a directory name that shadows a compiled app would collide with
+        # its app-<Name> artifact.
+        if (args.apps_root / dirname).is_dir():
+            fail(f"{dirname}: variant directory name shadows an app directory")
 
         target_uapp = find_built_uapp(spec["target"], search_roots)
         if target_uapp is None:
             fail(f"{name}: no built .uapp found for target '{spec['target']}' "
                  f"under {search_roots[0]}")
         print(f"  target binary: {target_uapp}")
+
+        # The manifest's type must match the target binary's (the kernel
+        # adopts the target's type bits regardless), and glance targets are
+        # rejected outright, mirroring the kernel's scan rules -- catch both
+        # at packaging time, not on a watch.
+        _, target_flags = header_of(target_uapp)
+        target_type = target_flags & APP_TYPE_MASK
+        if target_type == APP_TYPES["Glance"]:
+            fail(f"{name}: target '{spec['target']}' is glance-typed; "
+                 "variants of glance apps are not supported")
+        if APP_TYPES.get(spec["type"]) != target_type:
+            fail(f"{name}: manifest type '{spec['type']}' does not match the "
+                 f"target binary's type bits ({target_type})")
+
+        out_dir = args.out / dirname
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for stale in out_dir.glob("*.uapp"):
+            stale.unlink()
 
         cmd = [sys.executable, str(SCRIPT_DIR / "make_variant.py"),
                "-name", name,
@@ -143,7 +212,7 @@ def main() -> int:
                "-appver", spec["appver"],
                "-min_target_version", spec.get("min_target_version", "0.0.0"),
                "-origin", spec.get("origin", "shipped"),
-               "-out", str(args.out / name)]
+               "-out", str(out_dir)]
 
         icons = spec.get("icons", "target")
         if icons == "target":
@@ -156,7 +225,7 @@ def main() -> int:
         if result.returncode != 0:
             fail(f"{name}: make_variant.py failed (exit {result.returncode})")
 
-        packed = list((args.out / name).glob("*.uapp"))
+        packed = list(out_dir.glob("*.uapp"))
         if len(packed) != 1:
             fail(f"{name}: expected exactly one packed .uapp, found {len(packed)}")
         verify_alias(packed[0], int(spec["appid"], 16), uappid_of(target_uapp))

--- a/Utilities/Scripts/app_merging/pack_variants.py
+++ b/Utilities/Scripts/app_merging/pack_variants.py
@@ -1,0 +1,169 @@
+"""Pack every shipped variant under Examples/Apps/Variants/ (CI + local driver).
+
+For each `Variants/<Name>/manifest.json` this script locates the freshly built
+target `.uapp`, enforces the AppID allocation rule (a variant's uappID must
+collide with nothing: any built app or any other manifest — see
+Examples/Apps/Variants/README.md), drives `make_variant.py` to pack the alias,
+and structurally verifies the emitted file against the on-disk contract the
+kernel validator enforces (layout offsets, flag, sizes, trailing CRC).
+
+Usage:
+    pack_variants.py --apps-root Examples/Apps --out Output/variants
+        [--built-apps <dir>]    # where to find built .uapp files
+                                # (default: search app build dirs under apps-root;
+                                #  in CI, point it at the downloaded artifacts)
+
+Exit codes: 0 = all variants packed + verified, 1 = any failure.
+"""
+
+import argparse
+import json
+import struct
+import subprocess
+import sys
+import zlib
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+MAIN_HEADER_SIZE = 48
+ICONS_SIZE = 3600 + 900
+PAYLOAD_OFFSET = MAIN_HEADER_SIZE + ICONS_SIZE
+PAYLOAD_SIZE = 32
+FLAG_APP_VARIANT_ALIAS = 0x40
+
+
+def fail(msg: str) -> None:
+    print(f"pack_variants: ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def uappid_of(uapp: Path) -> int:
+    with open(uapp, "rb") as f:
+        return struct.unpack("<Q", f.read(8))[0]
+
+
+def find_built_uapp(name: str, search_roots: list[Path]) -> Path | None:
+    """Newest <Name>*.uapp under any search root (CI artifacts or build dirs)."""
+    candidates = []
+    for root in search_roots:
+        candidates += list(root.rglob(f"{name}_*.uapp")) + list(root.rglob(f"{name}.uapp"))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def verify_alias(path: Path, expected_appid: int, expected_target: int) -> None:
+    """Structural check mirroring the kernel's Validator::aliasIsValid rules."""
+    data = path.read_bytes()
+    if len(data) < PAYLOAD_OFFSET + PAYLOAD_SIZE + 4:
+        fail(f"{path.name}: too short ({len(data)} bytes)")
+
+    (uappid, _ver, libc, service_size, flags) = struct.unpack_from("<QIIII", data, 0)
+    if uappid != expected_appid:
+        fail(f"{path.name}: header uappID {uappid:016X} != manifest {expected_appid:016X}")
+    if libc != 0 or service_size != 0:
+        fail(f"{path.name}: alias must carry libcVersion=0 and serviceSize=0")
+    if not (flags & FLAG_APP_VARIANT_ALIAS):
+        fail(f"{path.name}: FLAG_APP_VARIANT_ALIAS missing (flags=0x{flags:02X})")
+
+    (payload_ver, target, _min_ver, _origin, config_size) = \
+        struct.unpack_from("<IQIBI", data, PAYLOAD_OFFSET)
+    if payload_ver != 1:
+        fail(f"{path.name}: unexpected payloadVersion {payload_ver}")
+    if target != expected_target:
+        fail(f"{path.name}: payload target {target:016X} != built target {expected_target:016X}")
+    if len(data) != PAYLOAD_OFFSET + PAYLOAD_SIZE + config_size + 4:
+        fail(f"{path.name}: file size does not match configSize {config_size}")
+
+    stored_crc = struct.unpack_from("<I", data, len(data) - 4)[0]
+    if zlib.crc32(data[:-4]) & 0xFFFFFFFF != stored_crc:
+        fail(f"{path.name}: trailing CRC32 mismatch")
+
+    print(f"  verified {path.name}: appid={uappid:016X} target={target:016X} "
+          f"config={config_size}B crc=0x{stored_crc:08X}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apps-root", type=Path, required=True,
+                        help="Examples/Apps directory (manifests live in Variants/)")
+    parser.add_argument("--built-apps", type=Path, default=None,
+                        help="Directory searched recursively for built .uapp files "
+                             "(default: the apps-root itself, i.e. local build dirs)")
+    parser.add_argument("--only", default=None,
+                        help="Pack a single variant by directory name (the AppID "
+                             "uniqueness check still runs over everything)")
+    parser.add_argument("--out", type=Path, required=True, help="Output directory")
+    args = parser.parse_args()
+
+    variants_root = args.apps_root / "Variants"
+    manifests = sorted(variants_root.glob("*/manifest.json"))
+    if not manifests:
+        print(f"pack_variants: no manifests under {variants_root}, nothing to do")
+        return 0
+
+    search_roots = [args.built_apps if args.built_apps else args.apps_root]
+
+    # ---- AppID allocation rule: collide with nothing ------------------------
+    ids: dict[int, str] = {}
+    for uapp in search_roots[0].rglob("*.uapp"):
+        ids.setdefault(uappid_of(uapp), f"built app {uapp.name}")
+    for m in manifests:
+        spec = json.loads(m.read_text())
+        appid = int(spec["appid"], 16)
+        if appid in ids:
+            fail(f"{m.parent.name}: appid {spec['appid']} collides with {ids[appid]}")
+        ids[appid] = f"variant {m.parent.name}"
+
+    # ---- pack + verify -------------------------------------------------------
+    if args.only is not None:
+        manifests = [m for m in manifests if m.parent.name == args.only]
+        if not manifests:
+            fail(f"--only {args.only}: no such variant under {variants_root}")
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    for m in manifests:
+        spec = json.loads(m.read_text())
+        name = spec["name"]
+        print(f"packing variant {name} (from {m})")
+
+        target_uapp = find_built_uapp(spec["target"], search_roots)
+        if target_uapp is None:
+            fail(f"{name}: no built .uapp found for target '{spec['target']}' "
+                 f"under {search_roots[0]}")
+        print(f"  target binary: {target_uapp}")
+
+        cmd = [sys.executable, str(SCRIPT_DIR / "make_variant.py"),
+               "-name", name,
+               "-appid", spec["appid"],
+               "-target_uapp", str(target_uapp),
+               "-config", str(m.parent / spec["config"]),
+               "-type", spec["type"],
+               "-appver", spec["appver"],
+               "-min_target_version", spec.get("min_target_version", "0.0.0"),
+               "-origin", spec.get("origin", "shipped"),
+               "-out", str(args.out / name)]
+
+        icons = spec.get("icons", "target")
+        if icons == "target":
+            cmd += ["-icons_from", str(target_uapp)]
+        else:
+            cmd += ["-normal_icon", str(m.parent / icons["normal"]),
+                    "-small_icon", str(m.parent / icons["small"])]
+
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            fail(f"{name}: make_variant.py failed (exit {result.returncode})")
+
+        packed = list((args.out / name).glob("*.uapp"))
+        if len(packed) != 1:
+            fail(f"{name}: expected exactly one packed .uapp, found {len(packed)}")
+        verify_alias(packed[0], int(spec["appid"], 16), uappid_of(target_uapp))
+
+    print(f"pack_variants: {len(manifests)} variant(s) packed and verified -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

Walking (the M2 shipped variant) was customer-visible but not reproducible from the repo: no committed definition, `make_variant.py` never invoked by any build, invisible to the `-CMake`-based CI app matrix, absent from the release zip. It only ever existed as a hand-built `.uapp`.

## What this PR does

**1. Canonical Walking definition** — `Examples/Apps/Variants/Walking/`:
- `manifest.json`: **appid `A1E5D3B7C9F04A82`** (the ID already field-tested on device 709724 — permanent from here on), target `Hiking`, type Activity, appver 1.0.0, `icons: "target"` (copied out of the built Hiking binary — the v1 convention from the design doc, and exactly how the tested artifact was built).
- `config.json`: the embedded VariantConfig JSON (`schema:1`, name Walking, `fit.sport=11`), byte-identical to the field-tested config.
- `README.md`: layout docs + the **AppID allocation rule**: variant uappIDs share the 16-hex namespace with app `APP_ID`s; generate randomly, must collide with *nothing* (any app's ID or any other manifest — enforced by `pack_variants.py` on every run, and independently rejected by the kernel at boot scan), and are permanent once shipped (phone bookkeeping keys on them; bump `appver` for content changes, never rotate the ID).

**2. CI wiring** — new `pack-variants` matrix job in `apps-ci.yml` (after `cmake-build`): packs each committed variant against the **freshly built** target binary — the target appID is read out of the built `.uapp` header at pack time (new minimal `-target_uapp` flag on `make_variant.py`; the packer is otherwise reused as-is), so it can never drift from the binary. Each variant uploads as an `app-<Name>` artifact, which means the **release job needed zero changes**: its existing `app-*` glob zips Walking into `una-apps-*.zip` as `Walking/Walking_1.0.0.uapp` — the per-app-folder shape `Update-Watch-Apps.ps1` already consumes. `generate-app-list.py` additionally emits the variant list; the compiled-app matrix is byte-identical to before (variants have no `-CMake` dir), so HRMonitor's status is untouched.

**3. Verification built into every run** — `pack_variants.py` structurally verifies each emitted alias against the kernel validator's rules (header flag/`serviceSize=0`/`libcVersion=0`, payloadVersion 1, exact size vs `configSize`, trailing CRC32) — the same contract locked by the kernel's `Tests/Host/kernel/VariantAlias_test.cpp` golden fixture — and fails CI on any AppID collision.

## Verified locally

- `generate-app-list.py` → apps list unchanged + `variants: ["Walking"]`.
- Packed in both modes (local build tree, and the CI `app-*` artifacts shape): **identical 4645-byte `Walking_1.0.0.uapp`**, target resolved to `A1F3C92B7E4D8A10` from the built Hiking, structural verify green.
- Collision guard: a manifest reusing Hiking's ID fails the build with a clear error.

## Going forward

Adding a shipped variant = one new `Variants/<Name>/` directory (manifest + config), nothing else — CI discovery, packing, artifact naming and release zipping are all automatic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Walking activity variant, including its configuration, identity, and compatibility metadata.
  * Variants are now packaged and validated alongside compiled apps for release distribution.
  * App and variant listings are generated with consistent sorting and duplicate AppID protection.

* **Documentation**
  * Added guidance covering variant structure, manifests, AppID allocation, release behavior, and local packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->