### PR TITLE
feat(variants): version variants in lockstep with their target app

### DIFF
--- a/Examples/Apps/Variants/README.md
+++ b/Examples/Apps/Variants/README.md
@@ -23,7 +23,7 @@ compiled-app matrix (no `*-CMake` directory) by design.
 | `appid` | The variant's OWN unique 16-hex uappID — never the target's (see allocation below) |
 | `target` | Directory name of the base app under `Examples/Apps/` (e.g. `Hiking`). The target's uappID is read from its freshly built `.uapp` at pack time, so it can never drift from the binary |
 | `type` | App type — must match the target's (`Activity`/`Utility`/`Clockface`; glance targets are rejected by the kernel) |
-| `appver` | Alias content revision `A.B.C` — bump when this variant's config changes |
+| *(version)* | Not a manifest field: variants carry the **same version as their target app** — derived at pack time from the freshly built target `.uapp`, so everything in one `una-apps-*` release shares one version. A config-only change still ships under the next release's version |
 | `min_target_version` | Minimum target app version, `0.0.0` = any |
 | `origin` | `shipped` for everything in this tree (`user` is reserved for on-watch CreateVariant) |
 | `config` | Path (relative to the manifest) of the embedded config JSON; must carry `"schema": 1` |

--- a/Examples/Apps/Variants/README.md
+++ b/Examples/Apps/Variants/README.md
@@ -40,7 +40,7 @@ Variant uappIDs live in the same 16-hex namespace as app `APP_ID`s
    `.uapp` headers and all manifests) and the kernel independently rejects a collision at
    boot scan — but catch it here, not on a customer's watch.
 3. Once shipped, an ID is permanent: the phone's update/uninstall bookkeeping keys on it.
-   Bump `appver` for content changes; never reuse or rotate the ID.
+   Content changes simply ship under the next release's version; never reuse or rotate the ID.
 
 Current allocations:
 

--- a/Examples/Apps/Variants/Walking/manifest.json
+++ b/Examples/Apps/Variants/Walking/manifest.json
@@ -3,7 +3,6 @@
     "appid": "A1E5D3B7C9F04A82",
     "target": "Hiking",
     "type": "Activity",
-    "appver": "1.0.0",
     "min_target_version": "0.0.0",
     "origin": "shipped",
     "config": "config.json",

--- a/Utilities/Scripts/app_merging/make_variant.py
+++ b/Utilities/Scripts/app_merging/make_variant.py
@@ -116,7 +116,9 @@ def main() -> int:
     parser.add_argument("-type", required=True, choices=list(APP_TYPES.keys()),
                         help="Application type (must match the target's)")
     parser.add_argument("-appver", type=parse_semver_u32, default=(0x00010000, "1.0.0"),
-                        help="Alias content revision A.B.C (default 1.0.0)")
+                        help="Version to stamp into the alias, A.B.C with optional suffix "
+                             "(shipped variants pass the target app's version; "
+                             "default 1.0.0)")
     parser.add_argument("-min_target_version", type=parse_semver_u32, default=(0, "0.0.0"),
                         help="Minimum target app version A.B.C (default: any)")
     parser.add_argument("-origin", choices=list(ORIGINS.keys()), default="shipped",
@@ -194,7 +196,7 @@ def main() -> int:
     logging.info(f"Name            : {args.name}")
     logging.info(f"ID              : {args.appid:016X}")
     logging.info(f"Target ID       : {args.target_appid:016X}")
-    logging.info(f"Alias revision  : {app_version}")
+    logging.info(f"Version         : {app_version}")
     logging.info(f"Min target ver  : {min_target}")
     logging.info(f"Origin          : {args.origin}")
     logging.info(f"Flags           : 0x{flags:08X}")

--- a/Utilities/Scripts/app_merging/pack_variants.py
+++ b/Utilities/Scripts/app_merging/pack_variants.py
@@ -67,6 +67,8 @@ def version_of(uapp: Path) -> int:
     """uappVersion (u32 at offset 8) of a built .uapp."""
     with open(uapp, "rb") as f:
         raw = f.read(12)
+    if len(raw) != 12:
+        fail(f"{uapp} is too short to carry a MainHeader")
     return struct.unpack_from("<I", raw, 8)[0]
 
 

--- a/Utilities/Scripts/app_merging/pack_variants.py
+++ b/Utilities/Scripts/app_merging/pack_variants.py
@@ -25,6 +25,8 @@ import zlib
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+from make_variant import make_file_safe_name  # noqa: E402  (same package, no installer)
 
 MAIN_HEADER_SIZE = 48
 ICONS_SIZE = 3600 + 900
@@ -77,12 +79,14 @@ def version_string_of(uapp: Path, app_name: str) -> str:
 
     app_merging.py names outputs <safe-name>_<version>.uapp where <version>
     keeps any pre-release suffix (1.3.0-rc4) that the packed u32 cannot carry,
-    so the filename is the richest source. Falls back to the header's A.B.C
+    so the filename is the richest source. Uses the same filename-safe
+    normalization the artifact producer used, case-insensitively (rglob
+    matches case-insensitively on Windows). Falls back to the header's A.B.C
     for a bare <name>.uapp.
     """
     stem = uapp.stem
-    prefix = app_name + "_"
-    if stem.startswith(prefix) and stem != prefix:
+    prefix = make_file_safe_name(app_name) + "_"
+    if stem.lower().startswith(prefix.lower()) and len(stem) > len(prefix):
         return stem[len(prefix):]
     v = version_of(uapp)
     return f"{(v >> 16) & 0xFF}.{(v >> 8) & 0xFF}.{v & 0xFF}"
@@ -90,9 +94,10 @@ def version_string_of(uapp: Path, app_name: str) -> str:
 
 def find_built_uapp(name: str, search_roots: list[Path]) -> Path | None:
     """Newest compiled <Name>*.uapp under any search root (aliases excluded)."""
+    safe = make_file_safe_name(name)
     candidates = []
     for root in search_roots:
-        candidates += list(root.rglob(f"{name}_*.uapp")) + list(root.rglob(f"{name}.uapp"))
+        candidates += list(root.rglob(f"{safe}_*.uapp")) + list(root.rglob(f"{safe}.uapp"))
     candidates = [c for c in candidates if not is_alias(c)]
     if not candidates:
         return None
@@ -265,6 +270,12 @@ def main() -> int:
         if version_of(packed[0]) != version_of(target_uapp):
             fail(f"{name}: alias uappVersion 0x{version_of(packed[0]):08X} is not "
                  f"in lockstep with the target's 0x{version_of(target_uapp):08X}")
+        expected_stem = f"{make_file_safe_name(name)}_{target_version}"
+        if packed[0].stem != expected_stem:
+            # The u32 check above cannot see pre-release suffixes; the
+            # filename carries the full string, so pin it too.
+            fail(f"{name}: packed filename {packed[0].name} does not carry the "
+                 f"target's full version ({expected_stem}.uapp expected)")
 
     print(f"pack_variants: {len(manifests)} variant(s) packed and verified -> {args.out}")
     return 0

--- a/Utilities/Scripts/app_merging/pack_variants.py
+++ b/Utilities/Scripts/app_merging/pack_variants.py
@@ -63,6 +63,29 @@ def is_alias(uapp: Path) -> bool:
     return bool(header_of(uapp)[1] & FLAG_APP_VARIANT_ALIAS)
 
 
+def version_of(uapp: Path) -> int:
+    """uappVersion (u32 at offset 8) of a built .uapp."""
+    with open(uapp, "rb") as f:
+        raw = f.read(12)
+    return struct.unpack_from("<I", raw, 8)[0]
+
+
+def version_string_of(uapp: Path, app_name: str) -> str:
+    """The full version string of a built app, filename first.
+
+    app_merging.py names outputs <safe-name>_<version>.uapp where <version>
+    keeps any pre-release suffix (1.3.0-rc4) that the packed u32 cannot carry,
+    so the filename is the richest source. Falls back to the header's A.B.C
+    for a bare <name>.uapp.
+    """
+    stem = uapp.stem
+    prefix = app_name + "_"
+    if stem.startswith(prefix) and stem != prefix:
+        return stem[len(prefix):]
+    v = version_of(uapp)
+    return f"{(v >> 16) & 0xFF}.{(v >> 8) & 0xFF}.{v & 0xFF}"
+
+
 def find_built_uapp(name: str, search_roots: list[Path]) -> Path | None:
     """Newest compiled <Name>*.uapp under any search root (aliases excluded)."""
     candidates = []
@@ -165,10 +188,13 @@ def main() -> int:
     args.out.mkdir(parents=True, exist_ok=True)
     for m in manifests:
         spec = json.loads(m.read_text())
-        missing = [k for k in ("name", "appid", "target", "type", "appver", "config")
+        missing = [k for k in ("name", "appid", "target", "type", "config")
                    if k not in spec]
         if missing:
             fail(f"{m}: manifest is missing required key(s): {', '.join(missing)}")
+        if "appver" in spec:
+            fail(f"{m}: 'appver' is no longer a manifest key -- variants version "
+                 "in lockstep with their target app (same release, same version)")
         name = spec["name"]
         dirname = m.parent.name
         print(f"packing variant {name} (from {m})")
@@ -198,6 +224,11 @@ def main() -> int:
             fail(f"{name}: manifest type '{spec['type']}' does not match the "
                  f"target binary's type bits ({target_type})")
 
+        # Variants carry the same version as the app they release alongside:
+        # derived from the freshly built target, never from the manifest.
+        target_version = version_string_of(target_uapp, spec["target"])
+        print(f"  version (lockstep with target): {target_version}")
+
         out_dir = args.out / dirname
         out_dir.mkdir(parents=True, exist_ok=True)
         for stale in out_dir.glob("*.uapp"):
@@ -209,7 +240,7 @@ def main() -> int:
                "-target_uapp", str(target_uapp),
                "-config", str(m.parent / spec["config"]),
                "-type", spec["type"],
-               "-appver", spec["appver"],
+               "-appver", target_version,
                "-min_target_version", spec.get("min_target_version", "0.0.0"),
                "-origin", spec.get("origin", "shipped"),
                "-out", str(out_dir)]
@@ -229,6 +260,9 @@ def main() -> int:
         if len(packed) != 1:
             fail(f"{name}: expected exactly one packed .uapp, found {len(packed)}")
         verify_alias(packed[0], int(spec["appid"], 16), uappid_of(target_uapp))
+        if version_of(packed[0]) != version_of(target_uapp):
+            fail(f"{name}: alias uappVersion 0x{version_of(packed[0]):08X} is not "
+                 f"in lockstep with the target's 0x{version_of(target_uapp):08X}")
 
     print(f"pack_variants: {len(manifests)} variant(s) packed and verified -> {args.out}")
     return 0


### PR DESCRIPTION
Variants now carry the **same version as the apps they are released alongside**, rather than a manifest-pinned revision of their own.

## Why

One `una-apps-vX` release should mean one version everywhere: the registry `"version"` field, the artifact filenames, and the phone's bookkeeping all read consistently. Variants are tiny, so re-shipping an unchanged alias under the new release version costs nothing and removes a second versioning scheme to reason about.

## How

- `pack_variants.py` derives the version from the **freshly built target `.uapp`**: filename first (`Hiking_1.3.0-rc4.uapp` → `1.3.0-rc4`, keeping pre-release suffixes the packed u32 can't carry), header `A.B.C` as fallback for bare names. Post-pack verification asserts the alias's `uappVersion` equals the target's.
- The manifest's `appver` field is **removed** — and explicitly rejected with a clear error, so a stale manifest can't silently pin an old version.
- README updated; Walking's manifest drops `appver`.

## Verified locally

- Lockstep pack: `Walking_1.3.0-8-<sha>.uapp` with alias revision identical to the target build's (suffix included).
- Bare-name fallback: version `1.3.0` from the target header.
- A manifest still carrying `appver` fails with a message pointing at the new rule.

Note: this amends the design doc's original "alias content revision" semantics for `uappVersion` (shipped variants; user-created variants via the future M3 CreateVariant are unaffected — the kernel stamps those itself). Doc update can ride the pending design-doc status PR in the kernel repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Variants now automatically inherit the target app’s release version when packaged.
  - Variant content updates are included in the next release without changing the permanent variant ID.
  - Prerelease version information is preserved during packaging.

- **Documentation**
  - Updated variant guidance to reflect automatic version inheritance.

- **Bug Fixes**
  - Improved validation prevents obsolete version settings and confirms packaged variant versions match the target app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->