### PR TITLE
refactor(timer): retire the Sender the app landed with

### DIFF
--- a/Docs/Examples/Timer-Architecture.md
+++ b/Docs/Examples/Timer-Architecture.md
@@ -68,7 +68,6 @@ public:
 private:
     SDK::Kernel&          mKernel;
     bool                  mGuiStarted;
-    CustomMessage::Sender  mGuiSender;
     TimerManager          mTimerManager;
     SDK::HomeWidget       mWidget;
 
@@ -120,7 +119,8 @@ void Service::onFired(const Timer& timer)
 {
     playEffect(timer.effect);                 // backlight + buzzer/vibro pattern
     if (mGuiStarted) {
-        mGuiSender.fired(timer, false);        // GUI is up -> fired in-app
+        // GUI is up -> fired in-app
+        SDK::send_msg<CustomMessage::TimerFired>(mKernel, timer, false);
     } else {
         // Launch the GUI, then deliver the fire once it signals it is running.
         // (RequestAppRunGui)
@@ -257,10 +257,30 @@ struct TimerStateMsg : public SDK::MessageBase {
     uint32_t      remainingMs;  // frozen remainder (PAUSED)
     uint16_t      durationSec;
     Timer::Effect effect;
+
+    TimerStateMsg();            // type id + defaults
+    TimerStateMsg(TimerState state, uint32_t endTick, uint32_t remainingMs,
+                  uint16_t durationSec, Timer::Effect effect);   // delegates to the above
 };
 ```
 
-`TimerFired` adds a `background` flag (true when the fire happened while the GUI was closed), and the two recents messages carry a fixed three-entry `RecentEntry[]` by value. A `Sender` helper allocates, fills, sends, and releases each pool message for both directions.
+`TimerFired` adds a `background` flag (true when the fire happened while the GUI was closed), and the two recents messages carry a fixed three-entry `RecentEntry[]` by value.
+
+Each message type owns its field filling: alongside the defaulting default constructor, it has a constructor taking the fields it carries, delegating to that default. Sending is then one call in either direction — `SDK::send_msg<T>(kernel, args...)` allocates the message from the kernel pool, forwards `args...` to the constructor, sends it, and releases it, returning `false` if allocation or the send failed:
+
+```cpp
+// Service --> GUI
+SDK::send_msg<CustomMessage::TimerStateMsg>(mKernel, s.state, s.endTick, s.remainingMs,
+                                            s.durationSec, s.effect);
+SDK::send_msg<CustomMessage::TimerFired>(mKernel, timer, false);
+SDK::send_msg<CustomMessage::TimerRecents>(mKernel, list);
+
+// GUI --> Service
+SDK::send_msg<CustomMessage::TimerStart>(mKernel, timer.durationSec, timer.effect);
+SDK::send_msg<CustomMessage::TimerControl>(mKernel, CustomMessage::TimerCmd::PAUSE);
+```
+
+There is no per-app sender class. See [Alarm-Architecture.md](Alarm-Architecture.md#sending-messages) for the full `send_msg` / `make_msg` contract, including when a reply matters.
 
 **Message summary**:
 
@@ -378,7 +398,7 @@ una_app_build_app()
 
 - `Timer.hpp` — the shared `Timer` struct, `TimerState`, and the recents cap (single source of truth)
 - `TimerManager` — the countdown state machine and JSON recents store (host-testable over an injected tick)
-- `Commands.hpp` — the service↔GUI message contract and `Sender`
+- `Commands.hpp` — the service↔GUI message contract
 - `Service` — the service entry point, message loop, alerts, and home-widget pump
 
 ### Testability

--- a/Examples/Apps/Timer/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Timer/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -116,7 +116,6 @@ public:
 private:
     ModelListener*        modelListener;
     const SDK::Kernel&    mKernel;
-    CustomMessage::Sender mSrvSender;
 
     // IGuiLifeCycleCallback
     void onStart()   override;

--- a/Examples/Apps/Timer/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Timer/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -3,6 +3,7 @@
 #include <gui/common/FrontendApplication.hpp>
 
 #include "SDK/Kernel/KernelProviderGUI.hpp"
+#include "SDK/Messages/MessageGuard.hpp"
 #include "SDK/Port/TouchGFX/TouchGFXCommandProcessor.hpp"
 
 #include <algorithm>
@@ -14,10 +15,15 @@
 // Preset durations (seconds) shown at the top of the Main list.
 static constexpr uint16_t kPresetSec[] = { 60, 180, 300, 600, 900, 1800, 3600 };
 
+// Every countdown control is the same one-field message; only the sub-command differs.
+static void sendControl(const SDK::Kernel& kernel, CustomMessage::TimerCmd cmd)
+{
+    SDK::send_msg<CustomMessage::TimerControl>(kernel, cmd);
+}
+
 Model::Model()
     : modelListener(nullptr)
     , mKernel(SDK::KernelProviderGUI::GetInstance().getKernel())
-    , mSrvSender(mKernel)
 {
     SDK::TouchGFXCommandProcessor::GetInstance().setAppLifeCycleCallback(this);
     SDK::TouchGFXCommandProcessor::GetInstance().setCustomMessageHandler(this);
@@ -83,7 +89,7 @@ void Model::exitApp()
 
 void Model::startTimer(const Timer& timer)
 {
-    mSrvSender.start(timer.durationSec, timer.effect);
+    SDK::send_msg<CustomMessage::TimerStart>(mKernel, timer.durationSec, timer.effect);
 
     // Remember custom and modified-preset timers as recents; an unchanged preset
     // is already offered in the list, so it is not duplicated.
@@ -112,12 +118,12 @@ int16_t Model::editTimerIndex() const
     return 0;   // not in either list -> New
 }
 
-void Model::pauseTimer()  { mSrvSender.pause();  }
-void Model::resumeTimer() { mSrvSender.resume(); }
-void Model::resetTimer()  { mSrvSender.reset();  }
-void Model::stopTimer()   { mSrvSender.stop();   }
-void Model::repeatTimer() { mSrvSender.repeat(); }
-void Model::replayAlert() { mSrvSender.replayAlert(); }
+void Model::pauseTimer()  { sendControl(mKernel, CustomMessage::TimerCmd::PAUSE);  }
+void Model::resumeTimer() { sendControl(mKernel, CustomMessage::TimerCmd::RESUME); }
+void Model::resetTimer()  { sendControl(mKernel, CustomMessage::TimerCmd::RESET);  }
+void Model::stopTimer()   { sendControl(mKernel, CustomMessage::TimerCmd::STOP);   }
+void Model::repeatTimer() { sendControl(mKernel, CustomMessage::TimerCmd::REPEAT); }
+void Model::replayAlert() { sendControl(mKernel, CustomMessage::TimerCmd::REPLAY_ALERT); }
 
 uint32_t Model::getRemainingMs() const
 {
@@ -158,7 +164,7 @@ void Model::addRecent(const Timer& timer)
         mRecents.resize(CustomMessage::kMaxRecents);
     }
 
-    mSrvSender.saveRecents(mRecents);
+    SDK::send_msg<CustomMessage::TimerRecentsSave>(mKernel, mRecents);
 }
 
 void Model::removeRecent(const Timer& timer)
@@ -168,7 +174,7 @@ void Model::removeRecent(const Timer& timer)
 
     // A preset (not in recents) leaves the list unchanged -- nothing to persist.
     if (mRecents.size() != before) {
-        mSrvSender.saveRecents(mRecents);
+        SDK::send_msg<CustomMessage::TimerRecentsSave>(mKernel, mRecents);
     }
 }
 

--- a/Examples/Apps/Timer/Software/Libs/Header/Commands.hpp
+++ b/Examples/Apps/Timer/Software/Libs/Header/Commands.hpp
@@ -4,7 +4,6 @@
 #include "SDK/Messages/MessageBase.hpp"
 #include "SDK/Messages/MessageTypes.hpp"
 #include "SDK/Messages/CommandMessages.hpp"
-#include "SDK/Kernel/Kernel.hpp"
 
 #include "Timer.hpp"
 #include <vector>
@@ -38,6 +37,25 @@ namespace CustomMessage {
         Timer::Effect effect;
     };
 
+    /**
+     * @brief Copy up to kMaxRecents timers into a packed RecentEntry array.
+     * @return The number actually copied, for the message's count field.
+     *
+     * Shared by the two recents messages, which carry the same payload in
+     * opposite directions.
+     */
+    inline uint8_t packRecents(RecentEntry (&entries)[kMaxRecents],
+                               const std::vector<Timer>& list)
+    {
+        const uint8_t count = static_cast<uint8_t>(
+            list.size() < kMaxRecents ? list.size() : kMaxRecents);
+        for (uint8_t i = 0; i < count; ++i) {
+            entries[i].durationSec = list[i].durationSec;
+            entries[i].effect      = list[i].effect;
+        }
+        return count;
+    }
+
     /** @brief Sub-command carried by a TIMER_CONTROL message. */
     enum class TimerCmd : uint8_t {
         PAUSE,
@@ -58,6 +76,13 @@ namespace CustomMessage {
             , durationSec(0)
             , effect(Timer::EFFECT_BEEP_AND_VIBRO)
         {}
+
+        TimerStart(uint16_t durationSec, Timer::Effect effect)
+            : TimerStart()
+        {
+            this->durationSec = durationSec;
+            this->effect      = effect;
+        }
     };
 
     struct TimerControl : public SDK::MessageBase {
@@ -66,6 +91,12 @@ namespace CustomMessage {
             : SDK::MessageBase(TIMER_CONTROL)
             , cmd(TimerCmd::STOP)
         {}
+
+        explicit TimerControl(TimerCmd cmd)
+            : TimerControl()
+        {
+            this->cmd = cmd;
+        }
     };
 
     struct TimerRecentsSave : public SDK::MessageBase {
@@ -76,6 +107,12 @@ namespace CustomMessage {
             , entries{}
             , count(0)
         {}
+
+        explicit TimerRecentsSave(const std::vector<Timer>& list)
+            : TimerRecentsSave()
+        {
+            this->count = packRecents(this->entries, list);
+        }
     };
 
     // -- Service --> GUI ------------------------------------------------------
@@ -98,6 +135,17 @@ namespace CustomMessage {
             , durationSec(0)
             , effect(Timer::EFFECT_BEEP_AND_VIBRO)
         {}
+
+        TimerStateMsg(TimerState state, uint32_t endTick, uint32_t remainingMs,
+                      uint16_t durationSec, Timer::Effect effect)
+            : TimerStateMsg()
+        {
+            this->state       = static_cast<uint8_t>(state);
+            this->endTick     = endTick;
+            this->remainingMs = remainingMs;
+            this->durationSec = durationSec;
+            this->effect      = effect;
+        }
     };
 
     struct TimerFired : public SDK::MessageBase {
@@ -110,6 +158,14 @@ namespace CustomMessage {
             , effect(Timer::EFFECT_BEEP_AND_VIBRO)
             , background(false)
         {}
+
+        TimerFired(const Timer& timer, bool background)
+            : TimerFired()
+        {
+            this->durationSec = timer.durationSec;
+            this->effect      = timer.effect;
+            this->background  = background;
+        }
     };
 
     struct TimerRecents : public SDK::MessageBase {
@@ -120,122 +176,13 @@ namespace CustomMessage {
             , entries{}
             , count(0)
         {}
+
+        explicit TimerRecents(const std::vector<Timer>& list)
+            : TimerRecents()
+        {
+            this->count = packRecents(this->entries, list);
+        }
     };
-
-
-// Helper wrapper: constructs, sends and releases the pool message in one call.
-class Sender {
-public:
-    Sender(const SDK::Kernel &kernel) :
-            mKernel(kernel)
-    {
-    }
-    virtual ~Sender() = default;
-
-    // -- GUI --> Service --------------------------------------------------
-
-    bool start(uint16_t durationSec, Timer::Effect effect)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<TimerStart>();
-        if (msg) {
-            msg->durationSec = durationSec;
-            msg->effect      = effect;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool control(TimerCmd cmd)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<TimerControl>();
-        if (msg) {
-            msg->cmd = cmd;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool pause()  { return control(TimerCmd::PAUSE);  }
-    bool resume() { return control(TimerCmd::RESUME); }
-    bool reset()  { return control(TimerCmd::RESET);  }
-    bool stop()   { return control(TimerCmd::STOP);   }
-    bool repeat() { return control(TimerCmd::REPEAT); }
-    bool replayAlert() { return control(TimerCmd::REPLAY_ALERT); }
-
-    bool saveRecents(const std::vector<Timer>& list)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<TimerRecentsSave>();
-        if (msg) {
-            msg->count = static_cast<uint8_t>(
-                list.size() < kMaxRecents ? list.size() : kMaxRecents);
-            for (uint8_t i = 0; i < msg->count; ++i) {
-                msg->entries[i].durationSec = list[i].durationSec;
-                msg->entries[i].effect      = list[i].effect;
-            }
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    // -- Service --> GUI --------------------------------------------------
-
-    bool sendState(TimerState state, uint32_t endTick, uint32_t remainingMs,
-                   uint16_t durationSec, Timer::Effect effect)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<TimerStateMsg>();
-        if (msg) {
-            msg->state       = static_cast<uint8_t>(state);
-            msg->endTick     = endTick;
-            msg->remainingMs = remainingMs;
-            msg->durationSec = durationSec;
-            msg->effect      = effect;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool fired(const Timer& timer, bool background)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<TimerFired>();
-        if (msg) {
-            msg->durationSec = timer.durationSec;
-            msg->effect      = timer.effect;
-            msg->background  = background;
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-    bool sendRecents(const std::vector<Timer>& list)
-    {
-        bool status = false;
-        auto *msg = mKernel.comm.allocateMessage<TimerRecents>();
-        if (msg) {
-            msg->count = static_cast<uint8_t>(
-                list.size() < kMaxRecents ? list.size() : kMaxRecents);
-            for (uint8_t i = 0; i < msg->count; ++i) {
-                msg->entries[i].durationSec = list[i].durationSec;
-                msg->entries[i].effect      = list[i].effect;
-            }
-            status = mKernel.comm.sendMessage(msg);
-            mKernel.comm.releaseMessage(msg);
-        }
-        return status;
-    }
-
-private:
-    const SDK::Kernel &mKernel;
-};
 
 
 } // namespace CustomMessage

--- a/Examples/Apps/Timer/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Timer/Software/Libs/Header/Service.hpp
@@ -32,7 +32,6 @@ private:
 
     SDK::Kernel&          mKernel;
     bool                  mGuiStarted;
-    CustomMessage::Sender mGuiSender;
     TimerManager          mTimerManager;
     SDK::HomeWidget       mWidget;
 

--- a/Examples/Apps/Timer/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Timer/Software/Libs/Sources/Service.cpp
@@ -23,7 +23,6 @@ static constexpr uint32_t kFiredDeliveryTimeoutMs = 10000;
 Service::Service(SDK::Kernel &kernel)
         : mKernel(kernel)
         , mGuiStarted(false)
-        , mGuiSender(kernel)
         , mTimerManager(kernel)
         , mWidget(kernel)
 {
@@ -137,13 +136,14 @@ void Service::onStartGUI()
     // routes straight to the Fired screen. A state update sent before it would
     // route the blank Startup screen to Main, flashing it before Fired takes over.
     if (mPendingFired) {
-        mGuiSender.fired(mPendingTimer, true);   // GUI was closed -> background fire
+        // GUI was closed -> background fire
+        SDK::send_msg<CustomMessage::TimerFired>(mKernel, mPendingTimer, true);
         mPendingFired = false;
     }
 
     // Bring the GUI up to date: current countdown, then recents.
     sendStateToGui();
-    mGuiSender.sendRecents(mTimerManager.getRecents());
+    SDK::send_msg<CustomMessage::TimerRecents>(mKernel, mTimerManager.getRecents());
 }
 
 void Service::onStopGUI()
@@ -211,7 +211,8 @@ void Service::sendStateToGui()
         return;
     }
     TimerManager::State s = mTimerManager.getState();
-    mGuiSender.sendState(s.state, s.endTick, s.remainingMs, s.durationSec, s.effect);
+    SDK::send_msg<CustomMessage::TimerStateMsg>(mKernel, s.state, s.endTick, s.remainingMs,
+                                                s.durationSec, s.effect);
 }
 
 void Service::pumpWidget(uint32_t now, uint32_t& sleepTime)
@@ -358,7 +359,8 @@ void Service::onFired(const Timer& timer)
     playEffect(timer.effect);
 
     if (mGuiStarted) {
-        mGuiSender.fired(timer, false);   // GUI is up -> fired in-app
+        // GUI is up -> fired in-app
+        SDK::send_msg<CustomMessage::TimerFired>(mKernel, timer, false);
     } else {
         // Launch the GUI, then deliver the fire once it signals it is running.
         auto *msg = mKernel.comm.allocateMessage<SDK::Message::RequestAppRunGui>();
@@ -375,6 +377,6 @@ void Service::onFired(const Timer& timer)
 void Service::onRecentsChanged(const std::vector<Timer>& list)
 {
     if (mGuiStarted) {
-        mGuiSender.sendRecents(list);
+        SDK::send_msg<CustomMessage::TimerRecents>(mKernel, list);
     }
 }

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(una-sdk-host-tests
     support/KernelTestDoubles_test.cpp
     apps/Stopwatch/Stopwatch_test.cpp
     apps/Timer/TimerManager_test.cpp
+    apps/Timer/Commands_test.cpp
     "${UNA_SDK_ROOT}/Examples/Apps/Timer/Software/Libs/Sources/TimerManager.cpp"
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/SettingsSerializer.cpp"
     "${UNA_SDK_ROOT}/Examples/Apps/Running/Software/Libs/Sources/ActivityWriter.cpp"

--- a/Tests/Host/apps/Timer/Commands_test.cpp
+++ b/Tests/Host/apps/Timer/Commands_test.cpp
@@ -1,0 +1,141 @@
+// Pins the field-filling constructors of the Timer service<->GUI messages.
+//
+// These constructors are the whole send path now that SDK::send_msg forwards
+// straight into them: a field left unset here is a field silently dropped on
+// the wire, with nothing else to catch it.
+
+#include <gtest/gtest.h>
+
+// Spelled out, not "Commands.hpp": Stopwatch ships a Commands.hpp too and both
+// app header dirs are on the test include path, so the bare name resolves to
+// whichever CMake happens to list first.
+#include "../../../../Examples/Apps/Timer/Software/Libs/Header/Commands.hpp"
+
+#include <vector>
+
+namespace {
+
+using namespace CustomMessage;
+
+std::vector<Timer> makeTimers(size_t n)
+{
+    std::vector<Timer> list;
+    for (size_t i = 0; i < n; ++i) {
+        list.push_back(Timer{ static_cast<uint16_t>(60 * (i + 1)),
+                              static_cast<Timer::Effect>(i % Timer::EFFECT_COUNT) });
+    }
+    return list;
+}
+
+// -- Type ids ---------------------------------------------------------------
+
+TEST(TimerCommands, EveryMessageCarriesItsOwnType)
+{
+    EXPECT_EQ(TimerStart{}.getType(),       TIMER_START);
+    EXPECT_EQ(TimerControl{}.getType(),     TIMER_CONTROL);
+    EXPECT_EQ(TimerRecentsSave{}.getType(), TIMER_RECENTS_SAVE);
+    EXPECT_EQ(TimerStateMsg{}.getType(),    TIMER_STATE);
+    EXPECT_EQ(TimerFired{}.getType(),       TIMER_FIRED);
+    EXPECT_EQ(TimerRecents{}.getType(),     TIMER_RECENTS);
+}
+
+// The field-filling constructors delegate to the default one, so a type set
+// only there would be lost if the delegation were ever dropped.
+TEST(TimerCommands, FilledMessagesKeepTheirType)
+{
+    EXPECT_EQ(TimerStart(300, Timer::EFFECT_VIBRO).getType(), TIMER_START);
+    EXPECT_EQ(TimerControl(TimerCmd::PAUSE).getType(),        TIMER_CONTROL);
+    EXPECT_EQ(TimerRecentsSave(makeTimers(1)).getType(),      TIMER_RECENTS_SAVE);
+    EXPECT_EQ(TimerFired(Timer{ 60, Timer::EFFECT_BEEP }, true).getType(), TIMER_FIRED);
+    EXPECT_EQ(TimerRecents(makeTimers(1)).getType(),          TIMER_RECENTS);
+    EXPECT_EQ(TimerStateMsg(TimerState::RUNNING, 1, 2, 3, Timer::EFFECT_BEEP).getType(),
+              TIMER_STATE);
+}
+
+// -- GUI --> Service --------------------------------------------------------
+
+TEST(TimerCommands, StartCarriesDurationAndEffect)
+{
+    const TimerStart msg(1234, Timer::EFFECT_VIBRO);
+
+    EXPECT_EQ(msg.durationSec, 1234);
+    EXPECT_EQ(msg.effect,      Timer::EFFECT_VIBRO);
+}
+
+TEST(TimerCommands, ControlCarriesTheSubCommand)
+{
+    EXPECT_EQ(TimerControl(TimerCmd::PAUSE).cmd,        TimerCmd::PAUSE);
+    EXPECT_EQ(TimerControl(TimerCmd::REPLAY_ALERT).cmd, TimerCmd::REPLAY_ALERT);
+}
+
+// -- Service --> GUI --------------------------------------------------------
+
+TEST(TimerCommands, StateCarriesTheWholeSnapshot)
+{
+    const TimerStateMsg msg(TimerState::PAUSED, 111u, 222u, 333, Timer::EFFECT_BEEP);
+
+    EXPECT_EQ(msg.state,       static_cast<uint8_t>(TimerState::PAUSED));
+    EXPECT_EQ(msg.endTick,     111u);
+    EXPECT_EQ(msg.remainingMs, 222u);
+    EXPECT_EQ(msg.durationSec, 333);
+    EXPECT_EQ(msg.effect,      Timer::EFFECT_BEEP);
+}
+
+TEST(TimerCommands, FiredCarriesTheTimerAndTheBackgroundFlag)
+{
+    const Timer timer{ 90, Timer::EFFECT_BEEP };
+
+    const TimerFired inApp(timer, false);
+    EXPECT_EQ(inApp.durationSec, 90);
+    EXPECT_EQ(inApp.effect,      Timer::EFFECT_BEEP);
+    EXPECT_FALSE(inApp.background);
+
+    EXPECT_TRUE(TimerFired(timer, true).background);
+}
+
+// -- Recents ----------------------------------------------------------------
+
+TEST(TimerCommands, RecentsCarryEveryEntryInOrder)
+{
+    const std::vector<Timer> list = makeTimers(kMaxRecents);
+    const TimerRecents       msg(list);
+
+    ASSERT_EQ(msg.count, kMaxRecents);
+    for (uint8_t i = 0; i < msg.count; ++i) {
+        EXPECT_EQ(msg.entries[i].durationSec, list[i].durationSec) << "at " << int(i);
+        EXPECT_EQ(msg.entries[i].effect,      list[i].effect)      << "at " << int(i);
+    }
+}
+
+// The array is fixed so the message stays in the pool; an over-long list must
+// be truncated rather than written past the end.
+TEST(TimerCommands, RecentsTruncateToTheArrayCapacity)
+{
+    const std::vector<Timer> list = makeTimers(kMaxRecents + 5);
+
+    EXPECT_EQ(TimerRecents(list).count,     kMaxRecents);
+    EXPECT_EQ(TimerRecentsSave(list).count, kMaxRecents);
+}
+
+TEST(TimerCommands, EmptyRecentsSendAnEmptyList)
+{
+    const TimerRecentsSave msg{ std::vector<Timer>{} };
+
+    EXPECT_EQ(msg.count, 0);
+}
+
+// Both directions carry the same payload; they must pack it the same way.
+TEST(TimerCommands, BothRecentsDirectionsPackIdentically)
+{
+    const std::vector<Timer> list = makeTimers(2);
+    const TimerRecents       toGui(list);
+    const TimerRecentsSave   toService(list);
+
+    ASSERT_EQ(toGui.count, toService.count);
+    for (uint8_t i = 0; i < toGui.count; ++i) {
+        EXPECT_EQ(toGui.entries[i].durationSec, toService.entries[i].durationSec);
+        EXPECT_EQ(toGui.entries[i].effect,      toService.entries[i].effect);
+    }
+}
+
+} // namespace


### PR DESCRIPTION
Hopefully close this loop, `Timer` was in flight while #219 swept the per-app senders, so it merged with the old idiom.

Same treatment as the rest: each message type gains a field-filling constructor delegating to its default, and the send sites become `SDK::send_msg`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added convenient constructors for timer commands, status updates, firing notifications, and recent-timer messages.
  * Improved recent-timer handling, including ordering, empty lists, and capacity limits.
  * Streamlined communication between the timer service and GUI.

* **Documentation**
  * Updated timer architecture examples to reflect direct message communication and available message constructors.

* **Tests**
  * Added comprehensive coverage for timer messages, state updates, fired events, and recent-timer handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->