### PR TITLE
ci(apps): gate the release on reproducible-build, and cover all four prefixes

### DIFF
--- a/.github/workflows/apps-ci.yml
+++ b/.github/workflows/apps-ci.yml
@@ -175,6 +175,9 @@ jobs:
           for root in /tmp/one /tmp/a/rather/deeper/two; do
             mkdir -p "$root"
             cp -a "$GITHUB_WORKSPACE/Examples/Apps/$APP" "$root/"
+            # Spelled for Workout's layout: several apps use Software/App instead,
+            # so changing APP means revisiting these two paths. Both writes are
+            # redirections, so a wrong layout fails here rather than later.
             apps="$root/$APP/Software/Apps"
             # touchgfx.cmake globs gui/src, so the GUI probe needs no edit.
             printf '%s\n' "$probe" > "$apps/TouchGFX-GUI/gui/src/UnaPrefixMapProbe.cpp"
@@ -196,11 +199,15 @@ jobs:
         run: |
           one=/tmp/one/$APP/Software/Apps/$APP-CMake/build
           two=/tmp/a/rather/deeper/two/$APP/Software/Apps/$APP-CMake/build
-          found=$(find "$one" "$two" -maxdepth 1 -name '*.uapp' | wc -l)
-          if [ "$found" -ne 2 ]; then
-            echo "::error::expected one .uapp from each build, found $found -- the checks below would have passed vacuously"
-            exit 1
-          fi
+          # Per directory, not two-across: a 2/0 split also totals two, and would
+          # reach cmp with one empty operand and report it as differing bytes.
+          for dir in "$one" "$two"; do
+            found=$(find "$dir" -maxdepth 1 -name '*.uapp' | wc -l)
+            if [ "$found" -ne 1 ]; then
+              echo "::error::expected exactly one .uapp in $dir, found $found -- the checks below would not have compared what they claim to"
+              exit 1
+            fi
+          done
           a=$(find "$one" -maxdepth 1 -name '*.uapp')
           b=$(find "$two" -maxdepth 1 -name '*.uapp')
           if ! cmp "$a" "$b"; then
@@ -224,12 +231,16 @@ jobs:
             fi
           done
           # /una-app and /una-app-gui reach only the probe objects, never the .elf.
+          # Both roots, not just the first: they are injected identically today, so
+          # one would do, but nothing here enforces that they stay identical.
           for want in /una-app/UnaPrefixMapProbe.cpp /una-app-gui/gui/src/UnaPrefixMapProbe.cpp; do
-            hits=$(find "$one" \( -name '*.o' -o -name '*.obj' \) -exec grep -laF -e "$want" {} + | wc -l)
-            if [ "$hits" -eq 0 ]; then
-              echo "::error::no object holds '$want' -- either that prefix stopped matching, or the probe was not compiled (check the sed anchor and the gui/src glob)"
-              exit 1
-            fi
+            for dir in "$one" "$two"; do
+              hits=$(find "$dir" \( -name '*.o' -o -name '*.obj' \) -exec grep -laF -e "$want" {} + | wc -l)
+              if [ "$hits" -eq 0 ]; then
+                echo "::error::no object under $dir holds '$want' -- either that prefix stopped matching, or the probe was not compiled (check the sed anchor and the gui/src glob)"
+                exit 1
+              fi
+            done
           done
 
   release:

--- a/.github/workflows/apps-ci.yml
+++ b/.github/workflows/apps-ci.yml
@@ -131,7 +131,8 @@ jobs:
     container: xanderhendriks/stm32cubeide:16.0
     env:
       # Workout asserts in its own Libs sources and has a GUI, so one build
-      # exercises the SDK, LIBS_PATH and TOUCHGFX_PATH prefixes together.
+      # exercises the SDK and LIBS_PATH prefixes. The other two need a probe
+      # source injected below -- see the note on that step.
       APP: Workout
     steps:
       - name: Setup GIT
@@ -157,20 +158,41 @@ jobs:
           chmod +x $(find /opt/st/stm32cubeide_* -type f -name arm-none-eabi-gcc | head -n 1)
           chmod +x $(find /opt/st/stm32cubeide_* -type f -name arm-none-eabi-g++ | head -n 1)
           export UNA_SDK=$GITHUB_WORKSPACE
+          # Two of the four prefixes cover no source in this repo: no app keeps a
+          # .cpp beside its CMakeLists.txt, and the GUI's only __FILE__ strings come
+          # from SDK headers, so /una-app and /una-app-gui are absent from every
+          # app we build. Give each of those roots a translation unit that
+          # materialises __FILE__, in the throwaway copy only, so a dead prefix
+          # becomes observable. The probe is unreferenced, so --gc-sections drops it
+          # before it reaches the .elf -- the check step reads the objects instead.
+          #
+          # A function, not `const char probe[] = __FILE__`: at file scope in C++
+          # that array is const and so has internal linkage, and an unreferenced
+          # static is discarded before it ever reaches the object file.
+          probe='const char* unaPrefixMapProbe() { return __FILE__; }'
           # The two roots differ in depth and in length, so a path that survives
           # into the binary changes its bytes rather than just its contents.
           for root in /tmp/one /tmp/a/rather/deeper/two; do
             mkdir -p "$root"
             cp -a "$GITHUB_WORKSPACE/Examples/Apps/$APP" "$root/"
+            apps="$root/$APP/Software/Apps"
+            # touchgfx.cmake globs gui/src, so the GUI probe needs no edit.
+            printf '%s\n' "$probe" > "$apps/TouchGFX-GUI/gui/src/UnaPrefixMapProbe.cpp"
+            # Nothing globs the project dir, so name that one in SERVICE_SOURCES.
+            printf '%s\n' "$probe" > "$apps/$APP-CMake/UnaPrefixMapProbe.cpp"
+            sed -i 's|^set(SERVICE_SOURCES|set(SERVICE_SOURCES\n    ${CMAKE_CURRENT_SOURCE_DIR}/UnaPrefixMapProbe.cpp|' \
+              "$apps/$APP-CMake/CMakeLists.txt"
             cd "$root/$APP/Software/Apps/$APP-CMake"
             mkdir -p build
             cd build
+            # No CMAKE_BUILD_TYPE on purpose: Release would define NDEBUG, and
+            # every assert path this job looks for would vanish with it.
             cmake ..
             make -j$(nproc)
           done
 
       # Steps in this container run under `sh -e`, not bash, so keep this POSIX.
-      - name: Require identical bytes and no build path in the app
+      - name: Require identical bytes, no build path, and every prefix still live
         run: |
           one=/tmp/one/$APP/Software/Apps/$APP-CMake/build
           two=/tmp/a/rather/deeper/two/$APP/Software/Apps/$APP-CMake/build
@@ -191,17 +213,38 @@ jobs:
               exit 1
             fi
           done
+          # Absence of a host path is only evidence if there was a path to rewrite.
+          # NDEBUG, a folded assert or a respelled prefix can empty the binary of
+          # __FILE__ entirely, and then everything above passes while proving
+          # nothing. So require each rewritten root to still be present.
+          for want in /una-sdk/ /una-app-libs/; do
+            if ! grep -qaF -e "$want" "$a"; then
+              echo "::error::no '$want' string in $APP -- that prefix covers nothing now, so the comparison above proves nothing"
+              exit 1
+            fi
+          done
+          # /una-app and /una-app-gui reach only the probe objects, never the .elf.
+          for want in /una-app/UnaPrefixMapProbe.cpp /una-app-gui/gui/src/UnaPrefixMapProbe.cpp; do
+            hits=$(find "$one" \( -name '*.o' -o -name '*.obj' \) -exec grep -laF -e "$want" {} + | wc -l)
+            if [ "$hits" -eq 0 ]; then
+              echo "::error::no object holds '$want' -- either that prefix stopped matching, or the probe was not compiled (check the sed anchor and the gui/src glob)"
+              exit 1
+            fi
+          done
 
   release:
     runs-on: ubuntu-latest
-    needs: [cmake-build, pack-variants]
+    needs: [cmake-build, pack-variants, reproducible-build]
     # pack-variants is skipped when no variants exist; that must not skip the
     # release with it (skipped needs propagate by default), so spell out the
-    # acceptable results instead.
+    # acceptable results instead. reproducible-build has no matrix and no `if`,
+    # so it always runs and success is the only acceptable result: a published
+    # .uapp that cannot be rebuilt from its source is the thing we are avoiding.
     if: >-
       startsWith(github.ref, 'refs/tags/apps-v') &&
       !cancelled() &&
       needs.cmake-build.result == 'success' &&
+      needs.reproducible-build.result == 'success' &&
       (needs.pack-variants.result == 'success' || needs.pack-variants.result == 'skipped')
     permissions:
       contents: write

--- a/.github/workflows/apps-ci.yml
+++ b/.github/workflows/apps-ci.yml
@@ -158,34 +158,49 @@ jobs:
           chmod +x $(find /opt/st/stm32cubeide_* -type f -name arm-none-eabi-gcc | head -n 1)
           chmod +x $(find /opt/st/stm32cubeide_* -type f -name arm-none-eabi-g++ | head -n 1)
           export UNA_SDK=$GITHUB_WORKSPACE
-          # Two of the four prefixes cover no source in this repo: no app keeps a
-          # .cpp beside its CMakeLists.txt, and the GUI's only __FILE__ strings come
-          # from SDK headers, so /una-app and /una-app-gui are absent from every
-          # app we build. Give each of those roots a translation unit that
-          # materialises __FILE__, in the throwaway copy only, so a dead prefix
-          # becomes observable. The probe is unreferenced, so --gc-sections drops it
-          # before it reaches the .elf -- the check step reads the objects instead.
+          # Three of the four prefixes are given a translation unit that materialises
+          # __FILE__, in the throwaway copy only, so that a dead prefix becomes
+          # observable rather than merely unwitnessed. /una-app and /una-app-gui have
+          # no witness at all otherwise -- no app keeps a .cpp beside its
+          # CMakeLists.txt, and the GUI's only __FILE__ strings come from SDK headers.
+          # /una-app-libs does have one, but only three discretionary asserts in this
+          # app's own Libs sources: refactoring those away would turn this job red on
+          # every PR and block releases, blaming the prefix for someone else's
+          # cleanup. A probe costs one line and removes the hostage.
           #
-          # A function, not `const char probe[] = __FILE__`: at file scope in C++
-          # that array is const and so has internal linkage, and an unreferenced
-          # static is discarded before it ever reaches the object file.
-          probe='const char* unaPrefixMapProbe() { return __FILE__; }'
+          # /una-sdk is left on incidental coverage: 14 contributors spread across SDK
+          # sources are not going to drain at once, and the SDK is not copied here, so
+          # probing it would mean editing the checkout the other jobs share.
+          #
+          # Each probe is unreferenced, so --gc-sections drops it before it reaches the
+          # .elf -- the check step reads the objects instead. Distinct names because
+          # the project-dir and Libs probes land in the same service .elf and would
+          # otherwise be a duplicate symbol. A function, not
+          # `const char probe[] = __FILE__`: at file scope in C++ that array is const
+          # and so has internal linkage, and an unreferenced static is discarded
+          # before it ever reaches the object file.
+          #
           # The two roots differ in depth and in length, so a path that survives
           # into the binary changes its bytes rather than just its contents.
           for root in /tmp/one /tmp/a/rather/deeper/two; do
             mkdir -p "$root"
             cp -a "$GITHUB_WORKSPACE/Examples/Apps/$APP" "$root/"
-            # Spelled for Workout's layout: several apps use Software/App instead,
-            # so changing APP means revisiting these two paths. Both writes are
-            # redirections, so a wrong layout fails here rather than later.
+            # Spelled for Workout's layout: several apps use Software/App instead, and
+            # not every app keeps its Libs sources in Libs/Sources, so changing APP
+            # means revisiting these paths. All three writes are redirections, so a
+            # wrong layout fails here rather than later.
             apps="$root/$APP/Software/Apps"
-            # touchgfx.cmake globs gui/src, so the GUI probe needs no edit.
-            printf '%s\n' "$probe" > "$apps/TouchGFX-GUI/gui/src/UnaPrefixMapProbe.cpp"
-            # Nothing globs the project dir, so name that one in SERVICE_SOURCES.
-            printf '%s\n' "$probe" > "$apps/$APP-CMake/UnaPrefixMapProbe.cpp"
+            # touchgfx.cmake globs gui/src and libs.cmake globs Libs/Sources, so only
+            # the project-dir probe needs naming in a source list.
+            printf 'const char* unaPrefixMapProbeGui() { return __FILE__; }\n' \
+              > "$apps/TouchGFX-GUI/gui/src/UnaPrefixMapProbe.cpp"
+            printf 'const char* unaPrefixMapProbeLibs() { return __FILE__; }\n' \
+              > "$root/$APP/Software/Libs/Sources/UnaPrefixMapProbe.cpp"
+            printf 'const char* unaPrefixMapProbeApp() { return __FILE__; }\n' \
+              > "$apps/$APP-CMake/UnaPrefixMapProbe.cpp"
             sed -i 's|^set(SERVICE_SOURCES|set(SERVICE_SOURCES\n    ${CMAKE_CURRENT_SOURCE_DIR}/UnaPrefixMapProbe.cpp|' \
               "$apps/$APP-CMake/CMakeLists.txt"
-            cd "$root/$APP/Software/Apps/$APP-CMake"
+            cd "$apps/$APP-CMake"
             mkdir -p build
             cd build
             # No CMAKE_BUILD_TYPE on purpose: Release would define NDEBUG, and
@@ -223,21 +238,31 @@ jobs:
           # Absence of a host path is only evidence if there was a path to rewrite.
           # NDEBUG, a folded assert or a respelled prefix can empty the binary of
           # __FILE__ entirely, and then everything above passes while proving
-          # nothing. So require each rewritten root to still be present.
-          for want in /una-sdk/ /una-app-libs/; do
+          # nothing. So require the rewritten root to still be present.
+          #
+          # This one is sound only *after* the host-path loop above, and only because
+          # of it: this repo is itself named una-sdk, so in CI the workspace is
+          # /__w/una-sdk/una-sdk and an entirely unrewritten SDK path still contains
+          # the substring "/una-sdk/". The preceding loop is what rules that out.
+          # Keep the two in this order, and don't lift this check out on its own.
+          for want in /una-sdk/; do
             if ! grep -qaF -e "$want" "$a"; then
               echo "::error::no '$want' string in $APP -- that prefix covers nothing now, so the comparison above proves nothing"
               exit 1
             fi
           done
-          # /una-app and /una-app-gui reach only the probe objects, never the .elf.
+          # The probed roots reach only the objects, never the .elf. *.obj never
+          # matches in this container -- the Makefile generator emits .o -- and is
+          # here so the same check runs unchanged against a local Ninja build.
           # Both roots, not just the first: they are injected identically today, so
           # one would do, but nothing here enforces that they stay identical.
-          for want in /una-app/UnaPrefixMapProbe.cpp /una-app-gui/gui/src/UnaPrefixMapProbe.cpp; do
+          for want in /una-app/UnaPrefixMapProbe.cpp \
+                      /una-app-libs/Sources/UnaPrefixMapProbe.cpp \
+                      /una-app-gui/gui/src/UnaPrefixMapProbe.cpp; do
             for dir in "$one" "$two"; do
               hits=$(find "$dir" \( -name '*.o' -o -name '*.obj' \) -exec grep -laF -e "$want" {} + | wc -l)
               if [ "$hits" -eq 0 ]; then
-                echo "::error::no object under $dir holds '$want' -- either that prefix stopped matching, or the probe was not compiled (check the sed anchor and the gui/src glob)"
+                echo "::error::no object under $dir holds '$want' -- either that prefix stopped matching, or the probe for it was not compiled (check the injection in the build step: the two globs and the sed anchor)"
                 exit 1
               fi
             done

--- a/cmake/una-app.cmake
+++ b/cmake/una-app.cmake
@@ -34,10 +34,15 @@ set(CMAKE_CXX_STANDARD 17)
 
 # Make the build independent of where the SDK and the app are checked out.
 #
-# __FILE__ reaches .rodata two ways: assert() (no NDEBUG anywhere, so newlib's
-# __assert_func keeps it) and UnaLogger's __FILENAME__, which trims to a basename
-# only at *runtime*. SDK and app sources both compile through absolute paths, so
-# the same source built elsewhere produces different bytes.
+# __FILE__ reaches .rodata two ways: assert() (nothing here defines NDEBUG, so
+# newlib's __assert_func keeps it) and UnaLogger's __FILENAME__, which trims to a
+# basename only at *runtime*. SDK and app sources both compile through absolute
+# paths, so the same source built elsewhere produces different bytes.
+#
+# Configuring -DCMAKE_BUILD_TYPE=Release would define NDEBUG and strip every one
+# of those strings. That costs the reproducible-build CI job most of what it
+# checks, so that job now also requires the rewritten prefixes to still be
+# present rather than only comparing bytes.
 #
 # -fmacro-prefix-map rewrites __FILE__ only: logged basenames are unchanged and
 # debug info keeps real paths, which -ffile-prefix-map would have broken.

--- a/cmake/una-app.cmake
+++ b/cmake/una-app.cmake
@@ -39,10 +39,14 @@ set(CMAKE_CXX_STANDARD 17)
 # basename only at *runtime*. SDK and app sources both compile through absolute
 # paths, so the same source built elsewhere produces different bytes.
 #
-# Configuring -DCMAKE_BUILD_TYPE=Release would define NDEBUG and strip every one
-# of those strings. That costs the reproducible-build CI job most of what it
-# checks, so that job now also requires the rewritten prefixes to still be
-# present rather than only comparing bytes.
+# Configuring -DCMAKE_BUILD_TYPE=Release would define NDEBUG, which takes the
+# assert channel and only that one -- __FILENAME__ is gated on LOG_LEVEL. It
+# happens to empty a built app of these strings anyway, because assert is today
+# the only channel that contributes any: no translation unit that leaves
+# LOG_MODULE_PRX at its __FILENAME__ default goes on to call LOG_*. That is a
+# coincidence of the current sources, not a property of the flag, so the
+# reproducible-build CI job requires the rewritten prefixes to still be present
+# rather than trusting either channel to stay non-empty.
 #
 # -fmacro-prefix-map rewrites __FILE__ only: logged basenames are unchanged and
 # debug info keeps real paths, which -ffile-prefix-map would have broken.


### PR DESCRIPTION
Follow-up to #234, addressing the two points I left open there plus one I got wrong.

### 1. The release did not depend on the check

`reproducible-build` was absent from `release.needs`, so an `apps-v*` tag could publish a `.uapp` with the check red — the exact artifact the check exists to protect. It has no matrix and no `if`, so it always runs and `success` is the only acceptable result. Added to both `needs` and the explicit `if`, since that job spells out per-need results to stop a skipped `pack-variants` propagating.

### 2. Two of the four prefixes covered nothing — including one I claimed was covered

**Correction to my review of #234:** I said `/una-app-gui` was exercised via `generated/fonts/src/FontCache.cpp:87`'s `assert`. It isn't. That assert compares two compile-time constants, so it folds away before it can bake a path.

Measured on a `Workout` build configured the way CI configures it:

| prefix | strings in the `.uapp` |
|---|---|
| `/una-sdk/` | 14 |
| `/una-app-libs/` | 3 |
| `/una-app/` | **0** |
| `/una-app-gui/` | **0** |

No app in this repo keeps a `.cpp` beside its `CMakeLists.txt`, and the GUI's only `__FILE__` strings come from SDK headers under `$UNA_SDK`. So both of those prefixes could die unnoticed.

Each now gets a probe translation unit, **in the throwaway `/tmp` copy only, never in the app itself**:

- the GUI probe is picked up by the existing `gui/src` glob in `touchgfx.cmake`, so it needs no edit;
- nothing globs the project dir, so that one is named in `SERVICE_SOURCES` via an anchored `sed`.

`--gc-sections` drops the unreferenced probe before it reaches the `.elf`, so the assertions read the **object files**. That is the right level anyway — `-fmacro-prefix-map` is a preprocessor property.

The probe is a function rather than `const char probe[] = __FILE__;`: at file scope in C++ that array is `const` and therefore has internal linkage, and an unreferenced static is discarded before it reaches the object. I shipped the array form first and the new assertion caught it, which is a reasonable sign the assertion earns its place.

### 3. The checks could pass vacuously

"No host path in the binary" is only evidence if there was a path to rewrite. Configuring `-DCMAKE_BUILD_TYPE=Release` defines `NDEBUG` and empties the binary of every one of these strings — verified, 0 occurrences of all four roots — and then `cmp` compares two identically path-free binaries and proves nothing. A folded assert or a respelled prefix does the same thing more quietly.

The job now requires each rewritten root to still be present, and `una-app.cmake`'s "no NDEBUG anywhere" is corrected to say so, since as written it reads as a property of the code rather than of how CI happens to configure it.

### Verification

Replayed the job locally against both roots (Ninja instead of make, same injection and same assertions):

```
PASS: identical bytes from both roots
PASS: no host path in the .uapp
PASS: '/una-sdk/' present (14 hits)
PASS: '/una-app-libs/' present (3 hits)
PASS: '/una-app/UnaPrefixMapProbe.cpp' in 1 object(s)
PASS: '/una-app-gui/gui/src/UnaPrefixMapProbe.cpp' in 1 object(s)
```

Negative case: disabling the `TOUCHGFX_PATH` map alone makes the GUI probe object hold the raw `C:/t1/...` path and fails the job. That case is invisible to the pre-existing `.uapp` grep, which the probe never reaches — so the object-level check is doing real work rather than duplicating it.

Both `run` blocks pass `sh -n`, since steps in that container run under `sh -e`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved build verification to detect missing source-path rewrites and incomplete build artifacts.
  - Release publishing now proceeds only after reproducible-build checks pass.

- **Documentation**
  - Expanded build documentation covering assertion and logging behavior across release configurations.
  - Clarified requirements for verifying rewritten paths during continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->