### PR TITLE
feat(cycling): implement GPS-speed auto-pause

### DIFF
--- a/Docs/FitFiles-Structure.md
+++ b/Docs/FitFiles-Structure.md
@@ -771,6 +771,15 @@ battery level/voltage on the battery record variants).
 - `timestamp`: Event time (FIT timestamp)
 - `event`: `Event::Timer` (0)
 - `event_type`: `EventType::Start` (0) or `EventType::Stop` (1)
+- `data` (optional): the profile's polymorphic field 3. When `event` is
+  `Event::Timer` a decoder resolves it to the `timer_trigger` subfield, so it
+  records *what* stopped or started the timer: `TimerTrigger::Manual` (0),
+  `TimerTrigger::Auto` (1) or `TimerTrigger::FitnessEquipment` (2).
+
+  Include it in `defineMessage` only if you write it. Apps without auto-pause
+  omit it and emit the three fields above; the Cycling app includes it so an
+  auto-pause stop/start can be told apart from one the user asked for. Either
+  shape is valid FIT — the definition message tells the decoder which it is.
 
 ### Activity Messages
 **Purpose**: Top-level activity metadata.
@@ -1243,6 +1252,8 @@ void ActivityWriter::start(const AppInfo& info)
     writeFieldDescription(DF_HR_EXTERNAL,     "hr_external",  "bpm", fit::BaseType::UInt8);
 
     // 5. Define the remaining message types up front.
+    //    Append fit::field::Event::Data here if the app reports timer_trigger
+    //    (see Event Messages above); the write below must then supply it too.
     mFit->defineMessage(L_EVENT, fit::mesgNum(fit::MesgNum::Event),
         {fit::field::Event::Timestamp, fit::field::Event::EventField,
          fit::field::Event::EventType});

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/CyclingGUI.touchgfx
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/CyclingGUI.touchgfx
@@ -439,6 +439,16 @@
             "Height": 240,
             "LockPosition": true,
             "CustomContainerDefinitionName": "TrackFaceTotal"
+          },
+          {
+            "Type": "CustomContainerInstance",
+            "Name": "pauseIndicator",
+            "Y": 200,
+            "Width": 240,
+            "Height": 34,
+            "Visible": false,
+            "LockPosition": true,
+            "CustomContainerDefinitionName": "PauseIndicator"
           }
         ],
         "Interactions": [

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/generated/gui_generated/include/gui_generated/track_screen/TrackViewBase.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/generated/gui_generated/include/gui_generated/track_screen/TrackViewBase.hpp
@@ -14,6 +14,7 @@
 #include <gui/containers/TrackFaceOverview.hpp>
 #include <gui/containers/TrackFaceStatus.hpp>
 #include <gui/containers/TrackFaceTotal.hpp>
+#include <gui/containers/PauseIndicator.hpp>
 
 class TrackViewBase : public touchgfx::View<TrackPresenter>
 {
@@ -38,6 +39,7 @@ protected:
     TrackFaceOverview trackFaceOverview;
     TrackFaceStatus trackFaceStatus;
     TrackFaceTotal trackFaceTotal;
+    PauseIndicator pauseIndicator;
 
 private:
 

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/generated/gui_generated/src/track_screen/TrackViewBase.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/generated/gui_generated/src/track_screen/TrackViewBase.cpp
@@ -33,6 +33,10 @@ TrackViewBase::TrackViewBase()
 
     trackFaceTotal.setXY(0, 0);
     add(trackFaceTotal);
+
+    pauseIndicator.setXY(0, 200);
+    pauseIndicator.setVisible(false);
+    add(pauseIndicator);
 }
 
 TrackViewBase::~TrackViewBase()
@@ -48,6 +52,7 @@ void TrackViewBase::setupScreen()
     trackFaceOverview.initialize();
     trackFaceStatus.initialize();
     trackFaceTotal.initialize();
+    pauseIndicator.initialize();
     transitionBegins();
 }
 

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsPresenter.hpp
@@ -31,6 +31,7 @@ public:
     virtual void onGpsFix(bool acquired) override;
     virtual void onAccessoryStatus(uint8_t state, const char* name) override;
 
+    void saveAutoPause(bool state);
     void savePhoneNotif(bool state);
 
 private:

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/menusettings_screen/MenuSettingsView.hpp
@@ -15,6 +15,7 @@ public:
 
     void setGpsFix(bool state);
     void setAccessoryStatus(uint8_t state, const char* name);
+    void setAutoPause(bool state);
     void setPhoneNotif(bool state);
     void setPositionId(uint16_t id);
     uint16_t getPositionId();
@@ -23,6 +24,7 @@ protected:
     using Menu = App::MenuNav::Root::Settings;
 
     bool mGpsFix     = false;
+    bool mAutoPause  = false;
     bool mPhoneNotif = false;
 
     touchgfx::Callback<MenuSettingsView, MainMenuItem&, int16_t>       mUpdateItemCb;

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/model/AppMenu.hpp
@@ -62,7 +62,7 @@ struct Root {
 
     struct Settings {
         enum Id {
-            ID_ALERTS = 0, ID_PHONE_NOTIF,
+            ID_ALERTS = 0, ID_AUTO_PAUSE, ID_PHONE_NOTIF,
             ID_COUNT, ID_DEFAULT = ID_ALERTS
         };
 

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/model/Model.hpp
@@ -98,6 +98,13 @@ public:
     void trackPause();
     void trackResume();
     bool isTrackPaused() const;
+    /// Seconds elapsed in the current pause, 0 when not paused.
+    ///
+    /// Lives here rather than in a presenter because presenters are recreated
+    /// on every screen transition, and because the Model keeps receiving the
+    /// 1 Hz clock regardless of which screen is up -- a pause that spans a
+    /// screen change must keep counting.
+    std::time_t getPausedSeconds() const;
     const Track::Data& getTrackData() const;
     void saveLap();
     void saveTrack();
@@ -151,6 +158,13 @@ private:
     Track::State           mTrackState      {};
     const ActivitySummary* mActivitySummary = nullptr;
     Track::Data            mTrackData       {};
+
+    /// Wall-clock seconds derived from the 1 Hz LOCAL_TIME message, and the
+    /// value it held when the current pause began. Differencing timestamps
+    /// rather than counting ticks keeps the pause duration honest if the
+    /// service coalesces a multi-second gap into one message.
+    std::time_t mNowSec        = 0;
+    std::time_t mPauseStartSec = 0;
 };
 
 #endif // MODEL_HPP

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackPresenter.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackPresenter.hpp
@@ -33,6 +33,7 @@ public:
     virtual void onLapChanged(uint8_t lapEnd) override;
     virtual void onGpsFix(bool acquired) override;
     virtual void onAccessoryStatus(uint8_t state, const char* name) override;
+    virtual void onTrackState(const Track::State& state) override;
 
     void saveLap();
 

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/track_screen/TrackView.hpp
@@ -24,6 +24,11 @@ public:
     void setGpsFix(bool state);
     void setAccessoryStatus(uint8_t state);
 
+    /// Show or hide the paused banner over the current track face.
+    void setPaused(bool paused);
+    /// Seconds spent in the current pause, rendered in the banner.
+    void setPausedTime(std::time_t seconds);
+
 protected:
 
     virtual void handleKeyEvent(uint8_t key) override;
@@ -39,6 +44,7 @@ protected:
     uint8_t  mHrThresholdCount = 0;
     uint8_t  mAccessoryState = 0;  // last SDK::Accessory::State (engaged?)
     uint8_t  mHrSource       = 0;  // last HR-sample source (steady vs flashing)
+    bool     mPaused         = false;
 };
 
 #endif // TRACKVIEW_HPP

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsPresenter.cpp
@@ -15,6 +15,7 @@ void MenuSettingsPresenter::activate()
 
     view.setGpsFix(model->hasGpsFix());
     view.setAccessoryStatus(model->getAccessoryState(), "");
+    view.setAutoPause(model->getSettings().autoPauseEn);
     view.setPhoneNotif(model->getSettings().phoneNotifEn);
 }
 
@@ -31,6 +32,13 @@ void MenuSettingsPresenter::onGpsFix(bool acquired)
 void MenuSettingsPresenter::onAccessoryStatus(uint8_t state, const char* name)
 {
     view.setAccessoryStatus(state, name);
+}
+
+void MenuSettingsPresenter::saveAutoPause(bool state)
+{
+    Settings sett = model->getSettings();
+    sett.autoPauseEn = state;
+    model->saveSettings(sett);
 }
 
 void MenuSettingsPresenter::savePhoneNotif(bool state)

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/menusettings_screen/MenuSettingsView.cpp
@@ -38,6 +38,12 @@ void MenuSettingsView::setAccessoryStatus(uint8_t state, const char* /*name*/)
     menuLayout.setHr(state);
 }
 
+void MenuSettingsView::setAutoPause(bool state)
+{
+    mAutoPause = state;
+    menuLayout.invalidate();
+}
+
 void MenuSettingsView::setPhoneNotif(bool state)
 {
     mPhoneNotif = state;
@@ -63,6 +69,13 @@ void MenuSettingsView::updateItem(MainMenuItem& item, int16_t index)
         cfg.style = MenuItemConfig::SIMPLE;
         cfg.msgId = T_TEXT_LAP_ALERTS;
         break;
+    case Menu::ID_AUTO_PAUSE:
+        cfg.style    = MenuItemConfig::TIP;
+        cfg.msgId    = T_TEXT_AUTO_PAUSE;
+        cfg.tipId    = mAutoPause ? T_TEXT_ON_UC : T_TEXT_OFF_UC;
+        cfg.tipColor = mAutoPause ? SDK::GUI::Color::YELLOW_DARK
+                                  : SDK::GUI::Color::TEAL;
+        break;
     case Menu::ID_PHONE_NOTIF:
         cfg.style    = MenuItemConfig::TIP;
         cfg.msgId    = T_TEXT_PHONE_NOTIF_DOT;
@@ -85,6 +98,12 @@ void MenuSettingsView::updateCenterItem(MainMenuCenterItem& item, int16_t index)
     case Menu::ID_ALERTS:
         cfg.style = MenuItemConfig::SIMPLE;
         cfg.msgId = T_TEXT_LAP_ALERTS;
+        break;
+    case Menu::ID_AUTO_PAUSE:
+        cfg.style       = MenuItemConfig::TOGGLE;
+        cfg.msgId       = T_TEXT_AUTO_BR_PAUSE;
+        cfg.msgIdType   = T_TMP_SEMIBOLD_25;
+        cfg.toggleState = mAutoPause;
         break;
     case Menu::ID_PHONE_NOTIF:
         cfg.style       = MenuItemConfig::TOGGLE;
@@ -115,6 +134,11 @@ void MenuSettingsView::handleKeyEvent(uint8_t key)
         switch (id) {
         case Menu::ID_ALERTS:
             application().gotoMenuAlertsScreenNoTransition();
+            break;
+        case Menu::ID_AUTO_PAUSE:
+            mAutoPause = !mAutoPause;
+            setAutoPause(mAutoPause);
+            presenter->saveAutoPause(mAutoPause);
             break;
         case Menu::ID_PHONE_NOTIF:
             mPhoneNotif = !mPhoneNotif;

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -184,7 +184,11 @@ bool Model::isTrackPaused() const
 
 std::time_t Model::getPausedSeconds() const
 {
-    if (mTrackState != Track::State::PAUSED || mNowSec < mPauseStartSec) {
+    // mPauseStartSec == 0 means the pause began before the clock was available
+    // and has not been adopted yet; report nothing rather than an epoch.
+    if (mTrackState != Track::State::PAUSED
+        || mPauseStartSec == 0
+        || mNowSec < mPauseStartSec) {
         return 0;
     }
     return mNowSec - mPauseStartSec;
@@ -314,6 +318,13 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             const std::time_t nowSec = std::mktime(&forEpoch);
             if (nowSec != static_cast<std::time_t>(-1)) {
                 mNowSec = nowSec;
+
+                // A pause that began before the clock arrived could not latch a
+                // start (see below); adopt the first real timestamp instead, so
+                // it counts from here rather than staying stuck at zero.
+                if (mTrackState == Track::State::PAUSED && mPauseStartSec == 0) {
+                    mPauseStartSec = mNowSec;
+                }
             }
 
             if (dateChanged) {
@@ -349,6 +360,10 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             if (mTrackState != msg->state) {
                 mTrackState = msg->state;
                 if (mTrackState == Track::State::PAUSED) {
+                    // mNowSec is 0 until the first LOCAL_TIME. Latching that and
+                    // then differencing it against a real epoch would report a
+                    // decades-long pause, so leave it unset (0) and let the
+                    // clock handler adopt the first real timestamp instead.
                     mPauseStartSec = mNowSec;
                 }
                 modelListener->onTrackState(mTrackState);

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/model/Model.cpp
@@ -182,6 +182,14 @@ bool Model::isTrackPaused() const
     return mTrackState == Track::State::PAUSED;
 }
 
+std::time_t Model::getPausedSeconds() const
+{
+    if (mTrackState != Track::State::PAUSED || mNowSec < mPauseStartSec) {
+        return 0;
+    }
+    return mNowSec - mPauseStartSec;
+}
+
 const Track::Data& Model::getTrackData() const
 {
     return mTrackData;
@@ -299,6 +307,15 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
                                      newTime.tm_sec   != mTime.tm_sec;
             mTime = newTime;
 
+            // Wall-clock seconds for pause-duration arithmetic. mktime()
+            // normalises a copy (it mutates its argument) and interprets the
+            // fields as local time, which is fine: only differences are used.
+            std::tm forEpoch = newTime;
+            const std::time_t nowSec = std::mktime(&forEpoch);
+            if (nowSec != static_cast<std::time_t>(-1)) {
+                mNowSec = nowSec;
+            }
+
             if (dateChanged) {
                 modelListener->onDate(mTime.tm_year + 1900, mTime.tm_mon + 1,
                                       mTime.tm_mday, mTime.tm_wday);
@@ -331,6 +348,9 @@ bool Model::customMessageHandler(SDK::MessageBase* message)
             auto* msg = static_cast<CustomMessage::TrackStateUpd*>(message);
             if (mTrackState != msg->state) {
                 mTrackState = msg->state;
+                if (mTrackState == Track::State::PAUSED) {
+                    mPauseStartSec = mNowSec;
+                }
                 modelListener->onTrackState(mTrackState);
             }
         } break;

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackPresenter.cpp
@@ -28,6 +28,13 @@ void TrackPresenter::activate()
     view.setBatteryLevel(model->getBatteryLevel());
     view.setGpsFix(model->hasGpsFix());
     view.setAccessoryStatus(model->getAccessoryState());
+
+    // The track can already be paused when this screen is entered -- auto-pause
+    // may have fired while another screen was up -- so adopt the current state
+    // and the pause duration the Model has been accumulating meanwhile, rather
+    // than assuming active and restarting the count.
+    view.setPaused(model->isTrackPaused());
+    view.setPausedTime(model->getPausedSeconds());
 }
 
 void TrackPresenter::deactivate()
@@ -48,6 +55,18 @@ void TrackPresenter::onBatteryLevel(uint8_t lvl)
 void TrackPresenter::onTime(uint8_t hour, uint8_t minute, uint8_t sec)
 {
     view.setTime(hour, minute);
+
+    // onTime() is the only 1 Hz tick the GUI still receives while paused: the
+    // activity timer is frozen, so TRACK_DATA_UPDATE carries a constant value.
+    if (model->isTrackPaused()) {
+        view.setPausedTime(model->getPausedSeconds());
+    }
+}
+
+void TrackPresenter::onTrackState(const Track::State& state)
+{
+    view.setPaused(state == Track::State::PAUSED);
+    view.setPausedTime(model->getPausedSeconds());
 }
 
 void TrackPresenter::onLapChanged(uint8_t lapEnd)

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -20,6 +20,10 @@ void TrackView::setupScreen()
 
     scrollIndicator.setConfig(ScrollIndicator::kSmall);
     scrollIndicator.setCount(FaceId::ID_COUNT);
+
+    // The banner is an overlay on whichever face is showing, so its visibility
+    // survives face changes and is driven only by the track state.
+    pauseIndicator.setVisible(mPaused);
 }
 
 void TrackView::tearDownScreen()
@@ -156,6 +160,25 @@ void TrackView::setAccessoryStatus(uint8_t state)
 {
     mAccessoryState = state;
     updateHrIcon();
+}
+
+void TrackView::setPaused(bool paused)
+{
+    if (mPaused == paused) {
+        return;
+    }
+    mPaused = paused;
+
+    pauseIndicator.setVisible(paused);
+    pauseIndicator.invalidate();
+}
+
+void TrackView::setPausedTime(std::time_t seconds)
+{
+    if (!mPaused) {
+        return;
+    }
+    pauseIndicator.setTime(seconds);
 }
 
 void TrackView::updateHrIcon()

--- a/Examples/Apps/Cycling/Software/Libs/Header/ActivityWriter.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/ActivityWriter.hpp
@@ -99,8 +99,11 @@ public:
     ActivityWriter(const SDK::Kernel& kernel, const char* pathToDir);
 
     void start(const AppInfo& info);
-    void pause(std::time_t timestamp);
-    void resume(std::time_t timestamp);
+    /// @param autoTrigger true when auto-pause drove the transition rather than
+    ///        the rider. Recorded as the timer event's timer_trigger subfield so
+    ///        a decoded activity can tell the two apart.
+    void pause(std::time_t timestamp, bool autoTrigger = false);
+    void resume(std::time_t timestamp, bool autoTrigger = false);
     void addRecord(const RecordData& record);
     void addLap(const LapData& lap);
     /// Finalize the current activity. The return value is the FIT-durability
@@ -161,7 +164,8 @@ private:
     void defineRecordMessages();
     void writeFieldDescription(uint8_t devFieldNum, const char* name,
                                const char* units, SDK::Fit::BaseType baseType);
-    void addMessageEvent(std::time_t t, SDK::Fit::EventType type);
+    void addMessageEvent(std::time_t t, SDK::Fit::EventType type,
+                         SDK::Fit::TimerTrigger trigger);
 
     bool createAndOpenFile(std::time_t utc);
     bool saveSummary(const TrackData& track);

--- a/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
@@ -43,6 +43,47 @@ private:
     /// fast enough to be useful.
     static constexpr std::size_t skPaceSmoothingTicks = 10;
 
+    // -- Auto-pause (GPS-speed driven) ----------------------------------------
+    //
+    // The thresholds are hysteretic: the track auto-pauses below
+    // skAutoPauseSpeedMps but only auto-resumes above skAutoResumeSpeedMps, so a
+    // rider hovering around a single threshold cannot flap between states.
+    //
+    // skAutoPauseSpeedMps mirrors the "genuinely moving" floor already used by
+    // mSpeedCounter.init() and by the kernel's grade estimator
+    // (GradeConfig::kMinWindowSpeedMps). Below it, speed is already excluded
+    // from the activity average, so pausing there agrees with what we record.
+    //
+    // skAutoResumeSpeedMps sits deliberately well below the slowest sustained
+    // pedalling (~1.4 m/s / 5 km/h): a rider pulling away up a hill from a
+    // standing start MUST resume, and silently dropping a climb is far worse
+    // than counting a few stopped seconds at a light. It is still ~2.7x above
+    // the stationary GPS noise peak measured on a bench with a fix (~0.33 m/s),
+    // which the dwell requirement then filters further.
+    //
+    // GPS speed arrives at 1 Hz (skSamplePeriod) and updateAutoPause() runs on
+    // the same 1 Hz track tick, so a dwell in seconds is also a dwell in
+    // samples. Three samples tolerates a single glitched or dropped reading.
+    //
+    // The detector reads the mGpsSpeed* latches rather than keeping its own
+    // copy of the sample: those already carry the isSpeedValid() gate it needs.
+    // It must not clear mGpsSpeedFresh -- processTrack() does that after
+    // feeding the pace smoother, so updateAutoPause() has to run before it.
+    //
+    // NOTE: the resume dwell is not free. MonotonicCounter rebases on resume, so
+    // the distance and time accrued while waiting out skAutoPauseDwellSec are
+    // dropped from the active totals rather than deferred -- roughly 3 m per
+    // stop at these values. Shorten the resume side first if that ever shows up
+    // in ride totals.
+    //
+    // These values are provisional: they are derived from bench noise plus
+    // cycling speed ranges, not yet from a logged ride. Every transition is
+    // logged at INFO so a serial capture can confirm or correct them.
+    static constexpr float   skAutoPauseSpeedMps  = 0.5f;  // pause below, m/s (1.8 km/h)
+    static constexpr float   skAutoResumeSpeedMps = 0.9f;  // resume above, m/s (3.2 km/h)
+    static constexpr uint8_t skAutoPauseDwellSec  = 3;     // sustained ticks either way
+    static constexpr uint8_t skAutoPauseStaleSec  = 5;     // hold state after this long with no valid speed
+
     // -- Infrastructure -------------------------------------------------------
 
     SDK::Kernel&          mKernel;
@@ -127,7 +168,53 @@ private:
         TIME,
     };
 
+    /**
+     * @brief Who owns the current pause.
+     *
+     * Auto-pause must never resume a pause the rider asked for: while they sit
+     * on the action overlay deciding whether to save or discard, movement of
+     * the wrist (or the bike being wheeled) must not restart recording.
+     */
+    enum class PauseSource {
+        NONE = 0,   ///< Not paused.
+        MANUAL,     ///< Rider opened the pause/action overlay.
+        AUTO,       ///< Auto-pause detected a stop.
+    };
+
+    /**
+     * @brief Auto-pause detector state, evaluated once per second.
+     *
+     * Kept separate from mSpeedCounter because the counter is deliberately
+     * paused along with the rest of the metrics, whereas the detector has to
+     * keep watching speed *while* paused in order to notice the rider moving
+     * off again.
+     */
+    struct AutoPauseState {
+        /// Ticks since the last valid speed sample. Starts (and resets)
+        /// SATURATED, so the detector treats speed as stale until a real sample
+        /// proves otherwise -- mGpsSpeedMs is an initialiser, not a measurement,
+        /// until then, and acting on it would auto-pause any ride started
+        /// before the first GPS fix.
+        uint8_t staleSec = skAutoPauseStaleSec;
+        uint8_t belowSec = 0;   ///< Consecutive samples under the pause threshold.
+        uint8_t aboveSec = 0;   ///< Consecutive samples over the resume threshold.
+
+        /// Clear the dwell counters only; freshness tracking is unaffected.
+        void resetDwell()
+        {
+            belowSec = 0;
+            aboveSec = 0;
+        }
+
+        void reset()
+        {
+            staleSec = skAutoPauseStaleSec;
+            resetDwell();
+        }
+    } mAutoPause{};
+
     LapDivSource mLapDivSource        = LapDivSource::OFF;
+    PauseSource  mPauseSource         = PauseSource::NONE;
     Track::State mTrackState          = Track::State::INACTIVE;
     bool         mPreviousGpsFixState = false;
     bool         mGpsInitialConnectFailed = false;  ///< GPS_LOCATION subscribe lost the startup ack race; the retry logs the recovery.
@@ -164,7 +251,8 @@ private:
     void processTrack();
     void saveLap(float autoLapDistanceM = 0.0f);
     void stopTrack(bool discard);
-    void pauseTrack(bool pause);
+    void pauseTrack(bool pause, PauseSource source);
+    void updateAutoPause();
     void buildPartialSummary();
     ActivityWriter::RecordData prepareRecordData();
     LapDivSource getLapDivSource();
@@ -176,6 +264,7 @@ private:
     void requestAccessoryRelease();
     void notifyFirstFix();
     void notifyLapEnd();
+    void notifyAutoPause(bool paused);
     void notifyNewActivity();
     void backlightOn(uint32_t timeoutMs = skBacklightTimeout);
     void playBuzzerPattern(uint16_t beepMs, uint8_t count = 1, uint16_t silenceMs = 100);

--- a/Examples/Apps/Cycling/Software/Libs/Header/Settings.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Settings.hpp
@@ -51,7 +51,7 @@ struct Settings {
     // Fields
     uint32_t version = kVersion;    ///< Settings version.
 
-    bool autoPauseEn = false; ///< Serialized only; not on settings wheel until auto-pause is implemented.
+    bool     autoPauseEn  = false;  ///< Flag to enable GPS-speed auto pause during activity track.
     bool     phoneNotifEn = true;   ///< Flag to enable receiving phone notification when app is run.
     Alerts::Distance::Id alertDistanceId = Alerts::Distance::ID_OFF;    ///< Distance alert option.
     Alerts::Time::Id     alertTimeId     = Alerts::Time::ID_OFF;        ///< Time alert option.

--- a/Examples/Apps/Cycling/Software/Libs/Header/SettingsSerializer.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/SettingsSerializer.hpp
@@ -11,7 +11,7 @@
  * @code{.json}
  * {
  *     "version":1,
- *     "auto_pause_en":false,  // persisted; no GUI toggle until feature is implemented
+ *     "auto_pause_en":false,
  *     "phone_notif_en":true,
  *     "alert_distance_id":0,
  *     "alert_time_id":0

--- a/Examples/Apps/Cycling/Software/Libs/Sources/ActivityWriter.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/ActivityWriter.cpp
@@ -90,7 +90,7 @@ void ActivityWriter::start(const AppInfo& info)
     // event
     mFit->defineMessage(L_EVENT, fit::mesgNum(fit::MesgNum::Event),
         {fit::field::Event::Timestamp, fit::field::Event::EventField,
-         fit::field::Event::EventType});
+         fit::field::Event::EventType, fit::field::Event::Data});
 
     defineRecordMessages();
 
@@ -115,7 +115,9 @@ void ActivityWriter::start(const AppInfo& info)
         {fit::field::Activity::Timestamp, fit::field::Activity::TotalTimerTime,
          fit::field::Activity::LocalTimestamp, fit::field::Activity::NumSessions});
 
-    addMessageEvent(info.timestamp, fit::EventType::Start);
+    // The rider started the activity, so this opening timer event is Manual
+    // regardless of whether auto-pause is enabled for the session.
+    addMessageEvent(info.timestamp, fit::EventType::Start, fit::TimerTrigger::Manual);
 
     // Header + all definitions are on disk: flush and drop the recovery marker.
     // getPosition() here is a clean record boundary, so a crash after this point
@@ -187,17 +189,21 @@ void ActivityWriter::writeFieldDescription(uint8_t devFieldNum, const char* name
         .write();
 }
 
-void ActivityWriter::pause(std::time_t timestamp)
+void ActivityWriter::pause(std::time_t timestamp, bool autoTrigger)
 {
     if (mFit) {
-        addMessageEvent(timestamp, fit::EventType::Stop);
+        addMessageEvent(timestamp, fit::EventType::Stop,
+                        autoTrigger ? fit::TimerTrigger::Auto
+                                    : fit::TimerTrigger::Manual);
     }
 }
 
-void ActivityWriter::resume(std::time_t timestamp)
+void ActivityWriter::resume(std::time_t timestamp, bool autoTrigger)
 {
     if (mFit) {
-        addMessageEvent(timestamp, fit::EventType::Start);
+        addMessageEvent(timestamp, fit::EventType::Start,
+                        autoTrigger ? fit::TimerTrigger::Auto
+                                    : fit::TimerTrigger::Manual);
     }
 }
 
@@ -361,12 +367,17 @@ void ActivityWriter::discard()
     mFile.reset();
 }
 
-void ActivityWriter::addMessageEvent(std::time_t t, fit::EventType type)
+void ActivityWriter::addMessageEvent(std::time_t t, fit::EventType type,
+                                     fit::TimerTrigger trigger)
 {
+    // Field order must match the L_EVENT definition. `data` is uint32 per the
+    // profile; decoders resolve it to the timer_trigger subfield because
+    // `event` is Timer.
     mFit->data(L_EVENT)
         .u32(unixToFitTimestamp(t))
         .u8(static_cast<uint8_t>(fit::Event::Timer))
         .u8(static_cast<uint8_t>(type))
+        .u32(static_cast<uint32_t>(trigger))
         .write();
 }
 

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -1020,6 +1020,12 @@ void Service::stopTrack(bool discard)
 
 void Service::pauseTrack(bool pause, PauseSource source)
 {
+    // Any pause/resume request invalidates the dwell evidence gathered for the
+    // opposite edge, including the requests rejected by the guards below: a
+    // blocked auto-resume must not leave its evidence banked for later. Done
+    // first so no early return can skip it.
+    mAutoPause.resetDwell();
+
     if (mTrackState == Track::State::INACTIVE) {
         return;
     }
@@ -1091,9 +1097,6 @@ void Service::pauseTrack(bool pause, PauseSource source)
                  static_cast<uint32_t>(mTimeCounter.getCurrent()));
         SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
     }
-
-    // Either edge invalidates the dwell evidence gathered for the opposite one.
-    mAutoPause.resetDwell();
 }
 
 void Service::updateAutoPause()

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -312,6 +312,10 @@ void Service::handleSensorsData(uint16_t handle, SDK::Sensor::DataBatch& data)
     } else if (mSensorGpsSpeed.matchesDriver(handle)) {
         SDK::SensorDataParser::GpsSpeed parser(data[0]);
         if (parser.isDataValid()) {
+            // These three latches also feed auto-pause (see updateAutoPause),
+            // which needs the same isSpeedValid() gate: a dead-reckoned speed is
+            // extrapolated, so in a tunnel it would otherwise fake the movement
+            // that triggers an auto-resume.
             mGpsSpeedMs    = parser.getSpeed();  // raw instantaneous speed
             mGpsSpeedValid = parser.isSpeedValid();  // already excludes dead reckoning
             mGpsSpeedFresh = true;   // consumed by the pace smoother each tick
@@ -433,12 +437,12 @@ void Service::handleEvent(const CustomMessage::SettingsSave& event)
 
 void Service::handleEvent(const CustomMessage::TrackPause& /*event*/)
 {
-    pauseTrack(true);
+    pauseTrack(true, PauseSource::MANUAL);
 }
 
 void Service::handleEvent(const CustomMessage::TrackResume& /*event*/)
 {
-    pauseTrack(false);
+    pauseTrack(false, PauseSource::MANUAL);
 }
 
 void Service::handleEvent(const CustomMessage::ManualLap& /*event*/)
@@ -494,6 +498,18 @@ void Service::notifyLapEnd()
     backlightOn();
     playBuzzerPattern(150, 3);
     playVibroPattern(SDK::Message::RequestVibroPlay::Effect::ALERT_750MS_100);
+}
+
+void Service::notifyAutoPause(bool paused)
+{
+    // Vibro only, and no forced backlight. Unlike a first fix or a lap end,
+    // auto-pause fires at every traffic light, so a buzzer or a 5 s backlight
+    // pulse each time would be both irritating and a needless battery cost.
+    // The on-screen paused indicator carries the state; this is just the cue to
+    // look. One pulse on pause, two on resume, so they are distinguishable
+    // without looking.
+    playVibroPattern(SDK::Message::RequestVibroPlay::Effect::STRONG_CLICK_100,
+                     paused ? 1 : 2);
 }
 
 void Service::notifyNewActivity()
@@ -679,6 +695,9 @@ void Service::startTrack(std::time_t utc)
     mSessionNotEmpty = false;
     mLapNotEmpty = false;
 
+    mPauseSource = PauseSource::NONE;
+    mAutoPause.reset();
+
     mSummary = ActivitySummary{};
     mSummary.laps.reserve(10);
 
@@ -715,6 +734,11 @@ void Service::processTrack()
     // (processTrack) so it never re-powers sensors after the track ends.
     connectSensors();
 
+    // Evaluate auto-pause before anything else this tick, so that a transition
+    // takes effect on the map point, the FIT record and the auto-lap tests
+    // below rather than one second late.
+    updateAutoPause();
+
     // Creating map
     SDK::TrackMapBuilder::GpsPoint newPoint{ mGps.latitude, mGps.longitude };
     if (mGps.fix && mTrackState == Track::State::ACTIVE) {
@@ -741,11 +765,23 @@ void Service::processTrack()
     // VariableCounter::add() latches its current value before its own pause
     // check, so the old readout went on tracking the raw speed of a standing
     // rider while the activity was paused.
-    if (mTrackState == Track::State::ACTIVE) {
+    const bool moving = (mTrackState == Track::State::ACTIVE);
+    if (moving) {
         mSpeedSmoother.tick(mGpsSpeedMs, mGpsSpeedValid && mGpsSpeedFresh);
-        mGpsSpeedFresh = false;
     }
-    mTrackData.speed       = mSpeedSmoother.getSpeed();
+    // Consumed every tick, NOT only while active: updateAutoPause() reads this
+    // latch to tell a tick that brought a sample from one that did not, and it
+    // has to keep doing so while paused in order to notice the rider moving off
+    // again. Left set through a pause it would pin the detector to "always
+    // fresh", so a fix lost while stopped would auto-resume off a frozen speed.
+    mGpsSpeedFresh = false;
+
+    // A paused rider is, by definition, not moving. The smoother deliberately
+    // freezes while paused (see above), which was invisible when a pause always
+    // meant the action overlay was up -- but auto-pause leaves the track face on
+    // screen, where a frozen "20.0 km/h" next to the paused banner reads as a
+    // bug. Report zero instead; the averages and maxima are untouched.
+    mTrackData.speed       = moving ? mSpeedSmoother.getSpeed() : 0.0f;
     mTrackData.avgSpeed    = speedFromTotals(mTrackData.distance, mTrackData.totalTime);
     mTrackData.maxSpeed    = mSpeedCounter.getMaximum();
     mTrackData.avgLapSpeed = speedFromTotals(mTrackData.lapDistance, mTrackData.lapTime);
@@ -753,7 +789,7 @@ void Service::processTrack()
 
     // Pace, s/m
     const float kMinSpeed = mSpeedCounter.getMinValid();
-    mTrackData.pace    = mSpeedSmoother.getPace();
+    mTrackData.pace    = moving ? mSpeedSmoother.getPace() : 0.0f;  // 0 = "--" while paused
     mTrackData.lapPace = getPace(mTrackData.avgLapSpeed, kMinSpeed);
 
     // HR
@@ -913,7 +949,11 @@ void Service::stopTrack(bool discard)
     if (!discard && mSessionNotEmpty) {
 
         if (mTrackState != Track::State::PAUSED) {
-            mActivityWriter.pause(mTimeCounter.getCurrent());
+            // Ending the ride is always the rider's doing, so this closing stop
+            // is Manual even when auto-pause was enabled for the session. Passed
+            // explicitly rather than left to the default: this is the one
+            // pause() caller that does not carry a PauseSource of its own.
+            mActivityWriter.pause(mTimeCounter.getCurrent(), /*autoTrigger=*/false);
         }
 
         if (mLapNotEmpty) {
@@ -963,7 +1003,9 @@ void Service::stopTrack(bool discard)
         mActivityWriter.discard();
     }
 
-    mTrackState = Track::State::INACTIVE;
+    mTrackState  = Track::State::INACTIVE;
+    mPauseSource = PauseSource::NONE;
+    mAutoPause.reset();
     LOG_INFO("Track stopped. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
     LOG_INFO("Time: %u / %u s\n", static_cast<uint32_t>(mTimeCounter.getValueActive()), static_cast<uint32_t>(mTimeCounter.getValueTotal()));
     LOG_INFO("Distance: %.3f m\n", mDistanceCounter.getValueActive());
@@ -976,28 +1018,60 @@ void Service::stopTrack(bool discard)
     disconnect();
 }
 
-void Service::pauseTrack(bool pause)
+void Service::pauseTrack(bool pause, PauseSource source)
 {
     if (mTrackState == Track::State::INACTIVE) {
         return;
     }
 
-    if (pause && mTrackState == Track::State::ACTIVE) {
-        mTimeCounter.pause();
-        mDistanceCounter.pause();
-        mSpeedCounter.pause();
-        mHrCounter.pause();
-        mAltitudeCounter.pause();
+    if (pause) {
+        if (mTrackState == Track::State::ACTIVE) {
+            mTimeCounter.pause();
+            mDistanceCounter.pause();
+            mSpeedCounter.pause();
+            mHrCounter.pause();
+            mAltitudeCounter.pause();
 
-        mActivityWriter.pause(mTimeCounter.getCurrent());
+            // Pausing the counters also freezes the auto-lap sources: the lap
+            // distance and lap time that processTrack() tests against the alert
+            // targets are the *active* values, so a long wait at a light can no
+            // longer trip a lap on its own.
+            mActivityWriter.pause(mTimeCounter.getCurrent(),
+                                  source == PauseSource::AUTO);
 
-        mTrackState = Track::State::PAUSED;
-        LOG_INFO("Track paused. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
-        SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
+            mTrackState  = Track::State::PAUSED;
+            mPauseSource = source;
+            LOG_INFO("Track paused (%s). UTC: %u\n",
+                     source == PauseSource::AUTO ? "auto" : "manual",
+                     static_cast<uint32_t>(mTimeCounter.getCurrent()));
+            SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
+        } else if (source == PauseSource::MANUAL && mPauseSource == PauseSource::AUTO) {
+            // The rider opened the pause overlay while auto-pause was holding
+            // the track. Hand ownership to them, so moving off again cannot
+            // auto-resume recording underneath the save/discard menu.
+            mPauseSource = PauseSource::MANUAL;
+            LOG_INFO("Auto-pause taken over manually. UTC: %u\n",
+                     static_cast<uint32_t>(mTimeCounter.getCurrent()));
+        }
 
-        buildPartialSummary();
-        SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
-    } else if (!pause && mTrackState == Track::State::PAUSED) {
+        // Only the manual path can reach a screen that shows the summary, and
+        // nothing accumulates while paused, so building it on manual requests
+        // alone keeps it fresh wherever it is visible without paying for it at
+        // every traffic light.
+        if (source == PauseSource::MANUAL) {
+            buildPartialSummary();
+            SDK::send_msg<CustomMessage::Summary>(mKernel, &mSummary);
+        }
+    } else {
+        if (mTrackState != Track::State::PAUSED) {
+            return;
+        }
+
+        // An auto-resume must never lift a pause the rider asked for.
+        if (source == PauseSource::AUTO && mPauseSource != PauseSource::AUTO) {
+            return;
+        }
+
         mTimeCounter.resume();
         mDistanceCounter.resume();
         mSpeedCounter.resume();
@@ -1007,11 +1081,98 @@ void Service::pauseTrack(bool pause)
         mHrCounter.resume();
         mAltitudeCounter.resume();
 
-        mActivityWriter.resume(mTimeCounter.getCurrent());
+        mActivityWriter.resume(mTimeCounter.getCurrent(),
+                               source == PauseSource::AUTO);
 
-        mTrackState = Track::State::ACTIVE;
-        LOG_INFO("Track resumed. UTC: %u\n", static_cast<uint32_t>(mTimeCounter.getCurrent()));
+        mTrackState  = Track::State::ACTIVE;
+        mPauseSource = PauseSource::NONE;
+        LOG_INFO("Track resumed (%s). UTC: %u\n",
+                 source == PauseSource::AUTO ? "auto" : "manual",
+                 static_cast<uint32_t>(mTimeCounter.getCurrent()));
         SDK::send_msg<CustomMessage::TrackStateUpd>(mKernel, mTrackState);
+    }
+
+    // Either edge invalidates the dwell evidence gathered for the opposite one.
+    mAutoPause.resetDwell();
+}
+
+void Service::updateAutoPause()
+{
+    if (!mSettings.autoPauseEn) {
+        // Switched off mid-activity while it was holding the track: give the
+        // rider back an active track rather than stranding them paused.
+        if (mTrackState == Track::State::PAUSED && mPauseSource == PauseSource::AUTO) {
+            LOG_INFO("Auto-pause disabled while paused -- resuming\n");
+            // MANUAL: the rider caused this by turning the setting off, so the
+            // FIT records a rider-triggered resume. It also clears the AUTO
+            // guard in pauseTrack() rather than depending on it.
+            pauseTrack(false, PauseSource::MANUAL);
+        }
+        mAutoPause.reset();
+        return;
+    }
+
+    // Freshness: this runs on the 1 Hz track tick and GPS speed arrives at the
+    // same rate, but the two are not phase-locked, so a given tick may see zero
+    // or two samples. Counting ticks-since-a-sample rather than demanding one
+    // per tick tolerates that jitter.
+    // Read the shared latches; do NOT clear mGpsSpeedFresh -- processTrack()
+    // consumes it for the pace smoother after this runs.
+    const bool fresh = mGpsSpeedFresh && mGpsSpeedValid;
+    if (fresh) {
+        mAutoPause.staleSec = 0;
+    } else if (mAutoPause.staleSec < skAutoPauseStaleSec) {
+        ++mAutoPause.staleSec;
+    }
+
+    // No trustworthy speed: hold whatever state we are in. Auto-pausing on a
+    // lost fix would punish riding into a tunnel, and auto-resuming on one
+    // would punish stopping in it.
+    //
+    // staleSec starts saturated (see AutoPauseState), so a track begun before
+    // the first fix -- the rider hits Start in a car park and pedals off while
+    // the GNSS is still acquiring -- holds here instead of acting on
+    // mGpsSpeedMs, which at that point is an initialiser rather than a
+    // measurement. Without that, the detector would read a never-measured
+    // 0 m/s and auto-pause 3 s into every such ride.
+    if (mAutoPause.staleSec >= skAutoPauseStaleSec) {
+        mAutoPause.resetDwell();
+        return;
+    }
+
+    // The dwell counts SAMPLES, not ticks. Advancing it on a tick that brought
+    // no new sample would let one reading plus two dropouts satisfy a
+    // three-sample threshold -- the inverse of the tolerance intended, and
+    // reachable in the field because one obstruction (bridge, underpass) tends
+    // to produce both the bad sample and the dropout that follows it. A gap
+    // tick holds the evidence: it neither advances nor discards it.
+    if (!fresh) {
+        return;
+    }
+
+    if (mTrackState == Track::State::ACTIVE && mPauseSource == PauseSource::NONE) {
+        mAutoPause.aboveSec = 0;
+        if (mGpsSpeedMs < skAutoPauseSpeedMps) {
+            if (++mAutoPause.belowSec >= skAutoPauseDwellSec) {
+                pauseTrack(true, PauseSource::AUTO);
+                notifyAutoPause(true);
+            }
+        } else {
+            mAutoPause.belowSec = 0;
+        }
+    } else if (mTrackState == Track::State::PAUSED && mPauseSource == PauseSource::AUTO) {
+        mAutoPause.belowSec = 0;
+        if (mGpsSpeedMs > skAutoResumeSpeedMps) {
+            if (++mAutoPause.aboveSec >= skAutoPauseDwellSec) {
+                pauseTrack(false, PauseSource::AUTO);
+                notifyAutoPause(false);
+            }
+        } else {
+            mAutoPause.aboveSec = 0;
+        }
+    } else {
+        // Manually paused: the detector stays quiet until the rider resumes.
+        mAutoPause.resetDwell();
     }
 }
 

--- a/Libs/Header/SDK/Fit/FitProfile.hpp
+++ b/Libs/Header/SDK/Fit/FitProfile.hpp
@@ -49,6 +49,9 @@ enum class SubSport : uint8_t { Generic = 0, Treadmill = 1, Street = 2, Trail = 
                                 Track = 4, IndoorCycling = 6 };
 enum class Event : uint8_t { Timer = 0 };
 enum class EventType : uint8_t { Start = 0, Stop = 1 };
+/// event.data subfield when event == Timer: what caused the timer transition.
+/// Lets a decoder tell an auto-pause stop/start from one the user asked for.
+enum class TimerTrigger : uint8_t { Manual = 0, Auto = 1, FitnessEquipment = 2 };
 enum class ActivityType : uint8_t { Manual = 0, AutoMultiSport = 1 };
 enum class Intensity : uint8_t { Active = 0, Rest = 1, Warmup = 2, Cooldown = 3, Invalid = 0xFF };
 // 255 (Development) is the reserved value for apps without an allocated
@@ -87,6 +90,11 @@ namespace Event {
     constexpr FitWriter::Field Timestamp{253, BaseType::UInt32};  // date_time, s
     constexpr FitWriter::Field EventField{0, BaseType::Enum};     // event
     constexpr FitWriter::Field EventType{1, BaseType::Enum};      // event_type
+    // The profile's `data` field. Its meaning is chosen by a subfield keyed on
+    // `event`; for event == Timer it resolves to timer_trigger (see
+    // TimerTrigger). Base type is uint32 per the profile even though every
+    // subfield value we write is a small enum.
+    constexpr FitWriter::Field Data{3, BaseType::UInt32};         // data
 }
 
 namespace Record {


### PR DESCRIPTION
Implements GPS-speed auto-pause for the Cycling app and restores its settings toggle.

`auto_pause_en` has been persisted but dormant since 74682e42 hid the toggle to avoid exposing a non-functional control. Nothing read it, and only manual pause existed. This makes it real — **for Cycling only**.

## Why Cycling only

Running and Treadmill drive their interval phases off elapsed time, so auto-pause needs a defined interaction there before it can be enabled. Cycling and Hiking have no intervals; Hiking is left dormant since auto-pause matters far less at walking speed. The other apps' behaviour and FIT output are unchanged.

## Detection

| | Threshold | Rationale |
|---|---|---|
| Pause below | 0.5 m/s (1.8 km/h) | Reuses the "genuinely moving" floor already used by `mSpeedCounter` and the kernel grade estimator — below it, speed is *already* excluded from the activity average |
| Resume above | 0.9 m/s (3.2 km/h) | ~2.7× the measured stationary GPS noise peak, but well under the slowest sustained pedalling (~1.4 m/s) so a hill start from a standstill resumes |
| Dwell | 3 samples each way | GPS speed is 1 Hz; three samples tolerates one glitched reading |

The 0.5–0.9 m/s band is a dead zone where state holds, so a rider hovering at one threshold cannot flap.

The resume threshold is the one worth scrutinising. Set too high (Garmin's published default is nearer 6.5 km/h), a rider pulling away up a hill from a red light stays paused and silently loses the climb — much worse than counting a few stopped seconds.

Other properties:

- Gated on `GpsSpeed::isSpeedValid()`, which excludes acquiring, fix-loss and dead-reckoning samples. A dead-reckoned speed is extrapolated, so in a tunnel it would otherwise fake movement.
- Staleness starts **saturated**, so a ride begun before the first fix holds rather than acting on an initialiser that was never a measurement.
- The dwell counts **samples, not ticks** — a tick with no new sample holds the evidence rather than advancing it, so one reading plus two dropouts cannot satisfy a three-sample threshold.
- `PauseSource` tracks pause ownership. Auto-resume never lifts a manual pause, and opening the action overlay upgrades an auto-pause to manual, so moving off cannot restart recording under the save/discard menu.
- Pausing freezes the auto-lap sources, so a long wait at a light cannot trip a distance or time lap.

## FIT

Timer events now carry `timer_trigger` (`event.data`, field 3), so an auto-pause stop/start is distinguishable from a rider-requested one. Activity start, rider pause/resume and end-of-ride remain `Manual`.

Adds `Event::Data` and the `TimerTrigger` enum to the shared FIT profile — **definition only**; apps that don't write the field produce byte-identical output.

This isn't cosmetic: it means threshold tuning can come from any normally-recorded ride pulled off a watch, rather than requiring a tethered serial capture.

## UI

- **Settings wheel**: Auto Pause restored between Lap Alerts and Phone Notif, **default off**. No text regeneration needed — `T_TEXT_AUTO_PAUSE` / `T_TEXT_AUTO_BR_PAUSE` survived the hide commit.
- **Paused banner** on the Track screen, reusing the existing `PauseIndicator` container so it matches TrackAction. Without it an auto-pause silently freezes the timer, which reads as a crash. Its duration lives in the Model (not a presenter, which TouchGFX recreates per screen transition) and is derived from timestamps, so it survives screen changes and can't undercount if a clock message coalesces.
- **Vibro only** — one pulse on pause, two on resume. No buzzer or forced backlight: unlike a lap end, this fires at every traffic light.

## Interaction with the pace SpeedSmoother

The smoother landed while this was in progress; the rebase surfaced two things:

- `mGpsSpeedFresh` is now consumed on **every** track tick rather than only while ACTIVE. Left set through a pause it pinned the detector to "always fresh", so a fix lost while stopped could auto-resume off a frozen speed.
- The live speed/pace readout now reports **zero while paused**. The smoother deliberately freezes during a pause, which was invisible when a pause always meant the action overlay was up — but auto-pause leaves the track face on screen, where a frozen "20.0 km/h" beside the paused banner reads as a bug. Averages and maxima are untouched. Flagging explicitly in case the smoother's author prefers a different treatment.

## Verification

All in the TouchGFX simulator (GPS stop/go injected via a temporary sim change, reverted before commit):

- Toggle renders and persists to `settings.json`.
- Full pause/resume cycles with distance and the activity timer correctly frozen, and the banner clearing on resume.
- **Ride started before GPS fix no longer auto-pauses.** A/B confirmed: with the guard removed the track pauses at 3 s while the display reads 25 km/h; with it, the timer runs on normally. The app's own "Start before signal acquired?" prompt makes this a first-class flow, not an edge case.
- Banner duration survives a screen change (00:09 → 00:18 across a round trip, 9 s elapsed).
- A recorded activity decoded with `fitdecode`:

```
12:25:21  timer  start  timer_trigger=manual
12:25:49  timer  stop   timer_trigger=auto
12:26:03  timer  start  timer_trigger=auto
12:26:28  timer  stop   timer_trigger=auto
12:26:43  timer  start  timer_trigger=auto
12:27:09  timer  stop   timer_trigger=auto
```

Active intervals 28 + 25 + 26 = **79 s**, exactly matching `total_timer_time = 79.0` against `total_elapsed_time = 189.0`. Auto-paused time is correctly excluded from moving time, and ending while auto-paused produced no duplicate stop event.

## Follow-ups, not in this PR

- **Thresholds are provisional** — derived from bench GPS noise plus cycling speed ranges, not a logged ride. Every transition logs at INFO, and `timer_trigger` is now in the FIT, so one real ride can confirm or correct them.
- **No host test for the 4-field event encode.** `FitWriter::emitData()` validates total payload size only, so a same-size field reorder would corrupt silently with no CI signal. There is no Cycling `ActivityWriter` test target today (only Running, which pins the old 3-field shape).
- **Windows simulator writes undecodable FITs** — unrelated and pre-existing (a Hiking file from July has it too). `FileSystem.cpp` uses `std::ios::app` for a non-truncating write open on Windows, and `app` ignores seek, so `FitWriter`'s header back-patch appends instead of overwriting and `data_size` stays 0. The POSIX branch was already fixed with a comment naming this exact hazard. Device builds (FatFs) and Linux CI are unaffected; only local Windows FIT verification is, which is why the decode above needed the header patched first.
- Pressing Resume can flash the banner at 00:00 for a frame before the service's state update round-trips. Cosmetic and self-healing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPS-based Auto Pause and Auto Resume with configurable speed thresholds.
  * Added an Auto Pause option in cycling settings.
  * Added a pause indicator showing paused status and elapsed pause time.
  * Paused activities now display zero speed and pace while preserving ongoing tracking behavior.
  * Auto-pause notifications use vibration feedback.

* **Documentation**
  * Documented FIT event timer-trigger details for manual, automatic, and equipment-triggered events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->