### PR TITLE
fix(simulator): match the watch on muted alerts and empty melodies

### DIFF
--- a/Libs/Header/SDK/Simulator/App/KernelMessageDispatcher.hpp
+++ b/Libs/Header/SDK/Simulator/App/KernelMessageDispatcher.hpp
@@ -211,7 +211,11 @@ private:
             }
         };
 
-        bool alertMutedFlag = false;                ///< Global flag to mute all alerts temporarily.
+        /// Mute alerts the watch raises at the user -- phone notifications,
+        /// calls and low battery -- across sound, vibration and the backlight.
+        /// Feedback an app requests during a session it owns (e.g. interval
+        /// phase cues) is deliberately not affected.
+        bool alertMutedFlag = false;
         Notification vibro;                         ///< Vibration notification settings.
         Notification sound;                         ///< Sound notification settings.
         GpsPowerMode gpsPowerMode = GPS_PM_BALANCED;    ///< GPS power consumption mode setting.

--- a/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
+++ b/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
@@ -169,28 +169,37 @@ void KernelMessageDispatcher::appMsgHandler(SDK::MessageBase* msg)
             mMessageMgr.signalCompletion(msg, SDK::MessageResult::SUCCESS);
         } break;
 
+        // Not gated on alertMutedFlag: muting covers alerts the watch raises at
+        // the user (phone notifications, calls, low battery), not feedback an
+        // app produces during a session the user started -- interval phase cues
+        // in Running/Treadmill being the motivating case. Mirrors the kernel.
         case SDK::MessageType::REQUEST_BUZZER_PLAY: {
             LOG_DEBUG("Requests buzzer\n");
 
-            if (!mLocalSettings.alertMutedFlag) {
-                //Alerts from GUI
-                    auto* buzzMsg = static_cast<SDK::Message::RequestBuzzerPlay*>(msg);
+            auto* buzzMsg = static_cast<SDK::Message::RequestBuzzerPlay*>(msg);
 
-                if (buzzMsg->notesCount) {
-                    auto melody = std::make_unique<Interface::IBuzzer::Note[]>(buzzMsg->notesCount);
-                    for (uint8_t i = 0; i < buzzMsg->notesCount; i++) {
-                        melody[i].level = (buzzMsg->notes[i].volume / 33);
-                        melody[i].time = buzzMsg->notes[i].time;
-                    }
-                    mBuzzer.play(melody.get(), buzzMsg->notesCount);
-                }
-                else {
-                    mBuzzer.play();
-                }
+            // notesCount arrives from the app unchecked; the message only
+            // carries skMaxNotes entries. Bounded as the kernel does.
+            // Not std::min: skMaxNotes is static const, so binding it to a
+            // const& odr-uses it and there is no definition to link against.
+            uint32_t count = buzzMsg->notesCount;
+            if (count > SDK::Message::RequestBuzzerPlay::skMaxNotes) {
+                LOG_WARNING("buzzer notesCount %lu > %lu, clamped\n",
+                            static_cast<unsigned long>(count),
+                            static_cast<unsigned long>(SDK::Message::RequestBuzzerPlay::skMaxNotes));
+                count = SDK::Message::RequestBuzzerPlay::skMaxNotes;
             }
-            else {
-                LOG_DEBUG("Ignore. Alerts muted\n");
+
+            // An empty melody is passed straight through, as on device. It used
+            // to fall back to mBuzzer.play(), i.e. a default beep -- but apps
+            // send an empty melody to STOP (Alarm's stopRinging()), so the
+            // simulator made a noise where the watch makes none.
+            auto melody = std::make_unique<Interface::IBuzzer::Note[]>(count);
+            for (uint32_t i = 0; i < count; i++) {
+                melody[i].level = (buzzMsg->notes[i].volume / 33);
+                melody[i].time = buzzMsg->notes[i].time;
             }
+            mBuzzer.play(melody.get(), count);
 
             mMessageMgr.signalCompletion(msg, SDK::MessageResult::SUCCESS);
         } break;
@@ -198,26 +207,24 @@ void KernelMessageDispatcher::appMsgHandler(SDK::MessageBase* msg)
         case SDK::MessageType::REQUEST_VIBRO_PLAY: {
             LOG_DEBUG("Requests vibro\n");
 
-            if (!mLocalSettings.alertMutedFlag) {
-                //Alerts from GUI
-                    auto* vibroMsg = static_cast<SDK::Message::RequestVibroPlay*>(msg);
+            auto* vibroMsg = static_cast<SDK::Message::RequestVibroPlay*>(msg);
 
-                if (vibroMsg->notesCount) {
-                    auto melody = std::make_unique<Interface::IVibro::Note[]>(vibroMsg->notesCount);
+            // Bounded like the buzzer above.
+            uint32_t count = vibroMsg->notesCount;
+            if (count > SDK::Message::RequestVibroPlay::skMaxNotes) {
+                LOG_WARNING("vibro notesCount %lu > %lu, clamped\n",
+                            static_cast<unsigned long>(count),
+                            static_cast<unsigned long>(SDK::Message::RequestVibroPlay::skMaxNotes));
+                count = SDK::Message::RequestVibroPlay::skMaxNotes;
+            }
 
-                    for (uint8_t i = 0; i < vibroMsg->notesCount; i++) {
-                        melody[i].effect = vibroMsg->notes[i].effect;
-                        melody[i].loop = 0;
-                        melody[i].pause = vibroMsg->notes[i].pause;
-                    }
-                    mVibro.play(melody.get(), vibroMsg->notesCount);
-			    } else {
-                    mVibro.play();
-                }
+            auto melody = std::make_unique<Interface::IVibro::Note[]>(count);
+            for (uint32_t i = 0; i < count; i++) {
+                melody[i].effect = vibroMsg->notes[i].effect;
+                melody[i].loop = 0;
+                melody[i].pause = vibroMsg->notes[i].pause;
             }
-            else {
-                LOG_DEBUG("Ignore. Alerts muted\n");
-            }
+            mVibro.play(melody.get(), count);
 
             mMessageMgr.signalCompletion(msg, SDK::MessageResult::SUCCESS);
         } break;


### PR DESCRIPTION
Brings the simulator's buzzer/vibro handling in line with the watch. Three behaviours differed, so an app could act differently on a developer's machine than on hardware — the worst kind of simulator bug, because it teaches the wrong lesson.

Pairs with UNAWatch/una-kernel#260, which settles what "Alerts Muted" means on device.

## 1. Muting silenced app-requested alerts

The kernel no longer does this. Mute covers alerts the watch raises **at** the user — phone notifications, calls, low battery — and leaves feedback an app produces during a session the user started. Interval phase cues in Running and Treadmill are the motivating case: they are the point of the workout.

The simulator still gated `REQUEST_BUZZER_PLAY` / `REQUEST_VIBRO_PLAY` on `alertMutedFlag`, so an app developer testing interval cues with mute enabled saw them suppressed here and working on the watch.

## 2. An empty melody played a default beep

`notesCount == 0` fell through to `mBuzzer.play()` / `mVibro.play()` — the no-argument overloads, i.e. a default beep and a default effect.

But an empty melody is the **only stop signal apps have**: there is no `REQUEST_BUZZER_STOP` / `REQUEST_VIBRO_STOP` in the SDK, and `Alarm::stopRinging()` sends a default-constructed request of each type precisely to stop. So *stopping* an alarm made a noise in the simulator. Empty melodies are now passed straight through, as the kernel does.

Worth knowing while you are in this area (not changed here, and true on device): a zero-count request reliably stops the **vibro** only. `Vibro::play()` calls `DRV2625::stop()` before programming, whereas `Buzzer::play()` queues notes and starts, so buzzer notes already queued play on. Apps that want silence promptly should stop re-issuing rather than rely on the empty melody.

## 3. `notesCount` was unbounded

The message carries only `skMaxNotes` entries, but the loop counter was `uint8_t` against a `uint32_t` bound — so a count above 255 never terminated, and 11–255 read past `notes[]`. Bounded and logged, mirroring the same fix in the kernel.

## Also

The doc comment on `alertMutedFlag` described the old "mute everything" meaning; rewritten to match actual behaviour.

`mLocalSettings` is now unread. Left in place rather than deleted, on the assumption it is wanted for other settings the simulator may honour later — happy to remove it if you would rather not carry a dead member.

## Testing

The edited translation unit compiles clean:

```
g++ -fsyntax-only -std=c++17 -DSIMULATOR -I Libs/Header \
    Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
```

I validated that check against a deliberately broken copy first, confirming it errors on the edited lines rather than passing vacuously. The full simulator build runs in CI.

Behavioural check for a reviewer with an app simulator to hand: enable mute, run a Running or Treadmill interval session, and confirm phase transitions still beep and buzz; then stop a ringing alarm and confirm it goes quiet instead of beeping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - App-requested sound and vibration feedback now works during an active session, even when watch-generated alerts are muted.
  - Audio and vibration requests with excessive note counts are safely limited to supported sizes.
  - Empty feedback requests are handled reliably and complete successfully.

- **Documentation**
  - Clarified that muted alerts affect watch-generated sound, vibration, and backlight, but not feedback explicitly requested by an app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->