### PR TITLE
fix(cycling): show the real ascent on the summary "ELEV. GAIN" stat

### DIFF
--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/tracksummary_screen/TrackSummaryView.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/tracksummary_screen/TrackSummaryView.cpp
@@ -42,9 +42,14 @@ void TrackSummaryView::setSummary(const ActivitySummary& s, bool isImperial, boo
         return isImperial ? SDK::Utils::kmToMiles(kmPerHour) : kmPerHour;
     };
 
+    auto elevationConv = [isImperial](float metres) -> float {
+        return isImperial ? SDK::Utils::metersToFeet(metres) : metres;
+    };
+
     const float dist = distConv(s.distance);
     summaryFaceMap.setDistance(dist, isImperial);
     summaryFaceOverview.setDistance(dist, isImperial);
+    summaryFaceOverview.setElevation(elevationConv(s.elevation), isImperial);
     summaryFaceOverview.setAvgSpeed(speedConv(s.speedAvg), isImperial);
     summaryFaceOverview.setTimer(s.time);
     summaryFaceHeartRate.setMaxHR(s.hrMax);


### PR DESCRIPTION
Cycling's summary showed **"ELEV. GAIN 735 m" for every activity** — reported on a 0.56 km ride on flat ground in 1.4.0-rc2.

## Cause

`735` is a **TouchGFX Designer mock-up value**, not a computed one:

```cpp
// generated/gui_generated/src/containers/SummaryFaceOverviewBase.cpp:49
Unicode::snprintf(elevationValueBuffer, ELEVATIONVALUE_SIZE, "%s",
                  touchgfx::TypedText(T___SINGLEUSE_ZJSJ).getText());
```
```cpp
// generated/texts/src/LanguageGb.cpp:150
637, // T___SINGLEUSE_ZJSJ: "735"
```

`TrackSummaryView::setSummary()` set distance, avg speed, timer, HR and laps — but never called `summaryFaceOverview.setElevation()`. So the placeholder was never overwritten and the widget rendered a constant. `SummaryFaceOverview::setElevation()` itself was already correct; it was simply unreachable.

This is also **why the two previous fixes appeared to do nothing on the watch**. #1b876802 and #4f39ee05 both corrected which value `ActivitySummary::elevation` *carries* (`getAscent()` rather than `getCurrent()` / `ascent - descent`), and both were right — but nothing in Cycling ever read that field into the widget, so the displayed number never came from the data path at all. Hiking's summary view *does* make the call, which is why only Cycling showed a frozen value.

## Fix

One call, using the same metres→feet conversion as the sibling call sites (`TrackView`, Hiking's `TrackSummaryView`). The stat now renders `mSummary.elevation`, i.e. `DeltaCounter::getAscent()`, which `buildPartialSummary()` populates on both the mid-activity and post-activity paths. `SummaryFaceOverview` is embedded only by `TrackSummaryViewBase`, so this covers every screen that shows the stat.

## Verification

Cycling simulator, 30 s ride: the face previously read a fixed `735 m`; it now reads `5 m`, tracking the simulated barometer. Swept every other `T___SINGLEUSE_*` placeholder in Cycling's generated containers — all their setters are called, so this was the only orphan.

## Two follow-ups this exposes (not fixed here)

Now that the number is finally real, two pre-existing issues in `SDK::Metric::DeltaCounter` become visible. Both are in shared code used by all four activity apps, so I've left them out of a targeted rc fix rather than bundle them:

1. **`resume()` does not rebase the threshold baseline.** `add()` updates `mCurrent` and then returns early while paused, leaving `mLastValue` at its pre-pause value. The first post-resume sample therefore credits the *entire* altitude change that occurred during the pause as ascent — exactly what pausing was supposed to exclude. Cycling has just gained GPS-speed auto-pause (#524ecc3d), so this will now fire on every stop at a junction, and a long pause (or a drive home with the activity paused) could add a lot. Fix is ~2 lines: rebase `mLastValue`/`mLapLastValue` to `mCurrent` in `resume()`.

2. **The deadband is a ratchet, not a hysteresis.** With `minChange = 2.0 m`, symmetric barometer noise crossing the band adds to ascent *and* descent, so on flat ground both creep upward forever while net delta stays ~0. The simulator (σ = 0.3 hPa ≈ 2.5 m, deliberately noisy) accumulated 5 m in 30 s this way. Real hardware noise is much lower, so I can't predict the on-device rate from that — but it's worth watching the new number on a real flat ride now that it's observable.

There are no `DeltaCounter` host tests today (`Tests/Host/metrics/` covers MonotonicCounter, VariableCounter and SpeedSmoother), so item 1 would be worth landing with one.

Happy to do either or both as a separate PR — say the word.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Elevation summaries now display in feet for users using imperial units.
  * Metric users continue to see elevation values in metres.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->