### PR TITLE
fix(metrics): stop DeltaCounter crediting the pause window, and cover it with tests

### DIFF
--- a/Libs/Header/SDK/Metrics/DeltaCounter.hpp
+++ b/Libs/Header/SDK/Metrics/DeltaCounter.hpp
@@ -116,7 +116,8 @@ public:
     void pause();
 
     /**
-     * @brief Resume tracking after pause.
+     * @brief Resume tracking after pause. Rebases the ascent/descent thresholds onto
+     *        the current value, so the change during the pause is not accumulated.
      */
     void resume();
 
@@ -237,6 +238,9 @@ inline void DeltaCounter::add(float currentValue)
         return;
     }
 
+    /* Re-arm after resetLap(); mLapStartValue stays at the lap boundary */
+    mHasLapData = true;
+
     if (mIsPaused) {
         return;
     }
@@ -291,6 +295,13 @@ inline void DeltaCounter::resume()
     if (!mIsInitialized || !mIsPaused) {
         return;
     }
+
+    /* Rebase the thresholds; the change during the pause must not accumulate */
+    if (mHasData) {
+        mLastValue    = mCurrent;
+        mLapLastValue = mCurrent;
+    }
+
     mIsPaused = false;
 }
 

--- a/Libs/Header/SDK/Simulator/Components/Simulator/PressureSimulator.hpp
+++ b/Libs/Header/SDK/Simulator/Components/Simulator/PressureSimulator.hpp
@@ -54,7 +54,10 @@ namespace Simulator
             return static_cast<float>(mP0 + mNoise(mGenerator));
         }
       
-        float mNoiseLevel = 0.3f;
+        /* 1 sigma, hPa. Altitude comes from the pressure ratio, so the old 0.3
+           was ~2.5 m of noise -- past the apps' 2 m ascent threshold, which made
+           flat rides accumulate gain. ~3 Pa matches a real MS5837. */
+        float mNoiseLevel = 0.03f;
         float mP0 = 1013.25f;
         std::default_random_engine mGenerator;
         std::normal_distribution<double> mNoise;

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(una-sdk-host-tests
     sensorlayer/GyroscopeParser_test.cpp
     sensorlayer/SensorConnection_test.cpp
     metrics/MonotonicCounter_test.cpp
+    metrics/DeltaCounter_test.cpp
     metrics/SpeedSmoother_test.cpp
     metrics/VariableCounter_test.cpp
     utils/ClockTime_test.cpp

--- a/Tests/Host/metrics/DeltaCounter_test.cpp
+++ b/Tests/Host/metrics/DeltaCounter_test.cpp
@@ -1,0 +1,219 @@
+/**
+ * @file DeltaCounter_test.cpp
+ * @brief Unit tests for SDK::Metric::DeltaCounter
+ *
+ * The accumulator behind every activity app's elevation gain, fed ~1 Hz filtered
+ * barometric altitude with a 2 m threshold.
+ */
+
+#include <gtest/gtest.h>
+
+#include "SDK/Metrics/DeltaCounter.hpp"
+
+namespace {
+
+constexpr float kMinChange = 2.0f;   // m, matches all four activity apps
+
+SDK::Metric::DeltaCounter makeCounter()
+{
+    SDK::Metric::DeltaCounter c;
+    EXPECT_TRUE(c.init(kMinChange));
+    return c;
+}
+
+}  // namespace
+
+TEST(DeltaCounter, InitRejectsNegativeThreshold)
+{
+    SDK::Metric::DeltaCounter c;
+    EXPECT_FALSE(c.init(-0.1f));
+    EXPECT_TRUE(c.init(0.0f));
+    EXPECT_TRUE(c.init(kMinChange));
+}
+
+TEST(DeltaCounter, AddIsIgnoredBeforeInit)
+{
+    SDK::Metric::DeltaCounter c;    // no init()
+    c.add(700.0f);
+    EXPECT_FALSE(c.isValid());
+    EXPECT_FLOAT_EQ(0.0f, c.getCurrent());
+}
+
+TEST(DeltaCounter, FirstSampleOnlySeedsTheBaseline)
+{
+    SDK::Metric::DeltaCounter c = makeCounter();
+    EXPECT_FALSE(c.isValid());
+
+    c.add(700.0f);   // switching on at 700 m is not a 700 m climb
+
+    EXPECT_TRUE(c.isValid());
+    EXPECT_FLOAT_EQ(700.0f, c.getCurrent());
+    EXPECT_FLOAT_EQ(0.0f, c.getAscent());
+    EXPECT_FLOAT_EQ(0.0f, c.getDescent());
+    EXPECT_FLOAT_EQ(0.0f, c.getDelta());
+}
+
+TEST(DeltaCounter, SubThresholdDriftIsHeldNotDiscarded)
+{
+    SDK::Metric::DeltaCounter c = makeCounter();
+    c.add(100.0f);
+
+    // A slow climb arrives in sub-threshold steps; it must be held, not dropped.
+    c.add(101.0f);
+    c.add(101.5f);
+    EXPECT_FLOAT_EQ(0.0f, c.getAscent());
+
+    c.add(102.0f);
+    EXPECT_FLOAT_EQ(2.0f, c.getAscent());
+    EXPECT_FLOAT_EQ(0.0f, c.getDescent());
+}
+
+TEST(DeltaCounter, SteadyClimbSumsToTheClimb)
+{
+    SDK::Metric::DeltaCounter c = makeCounter();
+    c.add(0.0f);
+    for (int i = 1; i <= 100; ++i) {
+        c.add(static_cast<float>(i));
+    }
+    EXPECT_NEAR(100.0f, c.getAscent(), 0.01f);
+    EXPECT_FLOAT_EQ(0.0f, c.getDescent());
+    EXPECT_NEAR(100.0f, c.getDelta(), 0.01f);
+}
+
+TEST(DeltaCounter, DescentIsReportedPositive)
+{
+    SDK::Metric::DeltaCounter c = makeCounter();
+    c.add(500.0f);
+    c.add(490.0f);
+
+    EXPECT_FLOAT_EQ(10.0f, c.getDescent());
+    EXPECT_FLOAT_EQ(0.0f, c.getAscent());
+    EXPECT_FLOAT_EQ(-10.0f, c.getDelta());
+}
+
+TEST(DeltaCounter, NoiseBelowThresholdNeverAccumulates)
+{
+    SDK::Metric::DeltaCounter c = makeCounter();
+    c.add(100.0f);
+
+    for (int i = 0; i < 500; ++i) {
+        c.add(100.0f + ((i % 2 == 0) ? 1.9f : -1.9f));
+    }
+    EXPECT_FLOAT_EQ(0.0f, c.getAscent());
+    EXPECT_FLOAT_EQ(0.0f, c.getDescent());
+}
+
+TEST(DeltaCounter, NoiseAboveThresholdDoesAccumulate)
+{
+    SDK::Metric::DeltaCounter c = makeCounter();
+    c.add(100.0f);
+
+    // Deliberate: past the threshold, noise is indistinguishable from terrain. No
+    // accumulator topology avoids this -- only filtering, or a higher threshold.
+    for (int i = 0; i < 10; ++i) {
+        c.add(100.0f + ((i % 2 == 0) ? 2.5f : -2.5f));
+    }
+    EXPECT_GT(c.getAscent(), 0.0f);
+    EXPECT_GT(c.getDescent(), 0.0f);
+    EXPECT_NEAR(0.0f, c.getDelta(), 2.6f);   // net stays ~zero, so delta is safe
+}
+
+TEST(DeltaCounter, PauseStopsAccumulation)
+{
+    SDK::Metric::DeltaCounter c = makeCounter();
+    c.add(100.0f);
+    c.add(110.0f);
+    EXPECT_FLOAT_EQ(10.0f, c.getAscent());
+
+    c.pause();
+    EXPECT_TRUE(c.isPaused());
+    c.add(120.0f);
+    c.add(130.0f);
+
+    EXPECT_FLOAT_EQ(10.0f, c.getAscent());
+    EXPECT_FLOAT_EQ(130.0f, c.getCurrent());
+    EXPECT_FLOAT_EQ(30.0f, c.getDelta());   // delta ignores pause by design
+}
+
+TEST(DeltaCounter, ResumeDoesNotCreditThePauseWindow)
+{
+    SDK::Metric::DeltaCounter c = makeCounter();
+    c.add(100.0f);
+
+    // Auto-paused at the foot of a hill, then carried up it before resuming.
+    c.pause();
+    c.add(150.0f);
+    c.resume();
+    c.add(150.0f);
+
+    EXPECT_FLOAT_EQ(0.0f, c.getAscent());   // read 50 before resume() rebased
+
+    c.add(153.0f);
+    EXPECT_FLOAT_EQ(3.0f, c.getAscent());
+}
+
+TEST(DeltaCounter, ResumeDoesNotCreditThePauseWindowToTheLap)
+{
+    SDK::Metric::DeltaCounter c = makeCounter();
+    c.add(100.0f);
+
+    c.pause();
+    c.add(150.0f);
+    c.resume();
+    c.add(150.0f);
+
+    EXPECT_FLOAT_EQ(0.0f, c.getLapAscent());
+    EXPECT_FLOAT_EQ(0.0f, c.getLapDescent());
+}
+
+TEST(DeltaCounter, ResumeWithoutDataIsHarmless)
+{
+    SDK::Metric::DeltaCounter c = makeCounter();
+    c.pause();
+    c.resume();
+
+    c.add(700.0f);
+    EXPECT_FLOAT_EQ(0.0f, c.getAscent());
+    c.add(702.0f);
+    EXPECT_FLOAT_EQ(2.0f, c.getAscent());
+}
+
+TEST(DeltaCounter, ResetLapKeepsTotalsAndRebasesTheLap)
+{
+    SDK::Metric::DeltaCounter c = makeCounter();
+    c.add(100.0f);
+    c.add(110.0f);
+    EXPECT_FLOAT_EQ(10.0f, c.getLapAscent());
+
+    c.resetLap();
+    EXPECT_FALSE(c.isLapValid());
+    EXPECT_FLOAT_EQ(10.0f, c.getAscent());
+    EXPECT_FLOAT_EQ(0.0f, c.getLapAscent());
+    EXPECT_FLOAT_EQ(0.0f, c.getLapDelta());
+
+    c.add(115.0f);
+    EXPECT_TRUE(c.isLapValid());              // stayed false from lap 2 onwards
+    EXPECT_FLOAT_EQ(15.0f, c.getAscent());
+    EXPECT_FLOAT_EQ(5.0f, c.getLapAscent());
+    EXPECT_FLOAT_EQ(5.0f, c.getLapDelta());
+}
+
+TEST(DeltaCounter, ResetClearsEverything)
+{
+    SDK::Metric::DeltaCounter c = makeCounter();
+    c.add(100.0f);
+    c.add(120.0f);
+    c.pause();
+
+    c.reset();
+
+    EXPECT_FALSE(c.isValid());
+    EXPECT_FALSE(c.isPaused());
+    EXPECT_FLOAT_EQ(0.0f, c.getAscent());
+    EXPECT_FLOAT_EQ(0.0f, c.getDescent());
+    EXPECT_FLOAT_EQ(0.0f, c.getDelta());
+    EXPECT_FLOAT_EQ(0.0f, c.getCurrent());
+
+    c.add(700.0f);
+    EXPECT_FLOAT_EQ(0.0f, c.getAscent());
+}


### PR DESCRIPTION
Follow-up to #268, which made Cycling's "ELEV. GAIN" show real data for the first time. This fixes the accumulator behind it, adds the tests it never had, and stops the simulator lying about elevation. Independent of #268 — disjoint files, either can merge first.

## 1. `resume()` credited the pause window as ascent

`add()` deliberately keeps updating `mCurrent` while paused but leaves `mLastValue` alone. So the first sample after resuming was compared against the **pre-pause** altitude, and the whole change that happened *during* the pause landed in ascent — precisely what pausing is meant to exclude.

```cpp
c.add(100.0f);
c.pause();
c.add(150.0f);   // carried up a hill / driven home while paused
c.resume();
c.add(150.0f);   // before: ascent == 50   after: ascent == 0
```

`resume()` now rebases `mLastValue`/`mLapLastValue` onto the value the pause ended at. `getDelta()` is untouched — it's documented as net start-to-current and as ignoring pause.

Cycling has just gained GPS-speed auto-pause (#524ecc3d), so this fires at every junction. It affects all four activity apps: they all configure the counter identically (`SimpleLPF(0.8f)`, `init(2.0f)`) and all four pause it.

## 2. Laps stopped being valid after the first one

Writing the tests surfaced this. `resetLap()` clears `mHasLapData`, but the only code that set it back was the first-sample branch in `add()`, which is gated on `!mHasData`. From the second lap onwards `mHasLapData` stayed false for the rest of the activity, so `isLapValid()` returned false and `getLapDelta()` was pinned at `0`.

`add()` now re-arms the lap on any sample. `mLapStartValue` is left alone so a lap still starts where the previous one ended rather than at its first sample. **Latent today** — no app reads `getLapDelta()` or `isLapValid()` — but it would bite the moment one did.

## 3. The simulator was manufacturing elevation gain

`PressureSimulator` injected **0.3 hPa** of noise per sample. Altitude comes from the pressure *ratio*, so that is ~2.5 m of altitude noise — comfortably past the 2 m threshold the apps configure, which is why a dead-flat simulated ride accumulated 5 m in 30 s. `0.03 hPa` (~3 Pa) is the order of a real MS5837 sample and puts altitude noise near 0.25 m, well inside the threshold.

## 4. Tests (14, where there were none)

They pin first-sample seeding, sub-threshold drift being held rather than discarded, descent sign, lap independence, `reset()`, and both fixes above. **Three fail on the previous code** — verified by reverting each fix and re-running, not assumed.

Two tests deliberately document the threshold's limits rather than a wish: noise below it never accumulates; noise above it accumulates on *both* sides and is indistinguishable from terrain.

## Correcting my earlier recommendation

In #268 I suggested the deadband should become a hysteresis. **Having worked it through, that would not have helped** and I'm not proposing it:

- On a ±(T+ε) oscillation, a peak-valley/zigzag accumulator commits one leg per confirmed reversal of about the same size the ratchet commits per band crossing. Both accumulate at a similar rate; the topology isn't what saves you.
- The current ratchet also has a property worth keeping: because `mLastValue` only advances on a commit, sub-threshold drift is *held*, so a genuinely slow climb is still counted in full rather than discarded sample by sample.
- What actually governs creep is noise amplitude versus threshold. With the corrected simulator noise the existing accumulator reports **0 m on a 0.55 km flat ride** (screenshot-verified) — the same distance as the field report that started this.

So the creep I measured was a simulator artefact, not a device defect. If a real flat ride still over-reports once #268 lands, the lever is the filter constant or the threshold, tuned against a real barometer trace — the `LOG_DEBUG("Altitude %.2f (Filtered %.2f) ...")` line in each Service prints exactly what's needed. Happy to do that with a syslog capture.

## Also checked: no other app has the #268 bug

I wrote a reachability audit (self-tested against the known Cycling bug, which it catches) over every `T___SINGLEUSE_*` Designer placeholder in all 15 apps: for each, does a *reachable* method write that buffer? After discarding false positives — calls through reference parameters (`LapListItem&` in scroll-list callbacks), pointer arrays (`ZoneInfo* rows[5]`) and internal-only call chains — **the Cycling elevation stat was the only genuine one**. Alarm's `RingingView` has an unwritten `"07:15"` placeholder but the widget is explicitly `setVisible(false)`, so it never shows.

One consistency observation, not fixed: Cycling's *live* track face renders `getCurrent()` (absolute altitude) under the label "Elevation", while the summary renders accumulated gain under "ELEV. GAIN". Both are defensible readings of their own labels, but Hiking exposes explicit total/lap ascent on a dedicated face, so the family isn't consistent. Worth a product decision rather than a patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ascent and descent tracking after pausing and resuming, excluding changes recorded during the pause.
  * Restored lap-data tracking correctly after resetting a lap while preserving the lap boundary.
  * Reduced pressure simulation noise for more stable readings.

* **Tests**
  * Added comprehensive coverage for metric initialization, thresholds, noise handling, pause/resume behavior, lap tracking, and resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->