### PR TITLE
docs(ble): publish BLE File Transfer Service protocol + services overview

### DIFF
--- a/Docs/BLE-File-Transfer-Service.md
+++ b/Docs/BLE-File-Transfer-Service.md
@@ -29,6 +29,10 @@ the classic (version 4) protocol interoperates unchanged.
 | Version | `ADAF0001-4669-6C65-5472-616E73666572` | Read |
 | Raw Transfer | `ADAF0002-4669-6C65-5472-616E73666572` | Write Without Response, Notify |
 
+> **Note.** The characteristic 16-bit IDs are UNA-specific (`ADAF0001` /
+> `ADAF0002`) and differ from Adafruit's upstream (`ADAF0100` / `ADAF0200`). Use
+> the UUIDs exactly as listed above — they are what the watch exposes.
+
 All operations are a request written to **Raw Transfer** and one or more
 responses delivered as **notifications** on the same characteristic. Enable
 notifications (write the CCCD) before issuing commands.
@@ -82,7 +86,7 @@ A GATT notification cannot carry more than the negotiated **ATT payload = MTU �
 3** bytes. Every FTS response has a fixed header, so the usable *data* per
 notification is smaller still. For `READ_DATA` (16-byte header) at MTU 220:
 
-```
+```text
 data per notification ≤ (MTU − 3) − 16 = 201 bytes
 ```
 
@@ -184,8 +188,9 @@ currentTime(8)}` + path; response `{command, status, reserved(6),
 truncatedTime(8)}`.
 
 **LISTDIR `0x50`** → `0x51`: request `{command, reserved, pathLength}` + path
-(must be a directory ending in `/`). One `0x51` notification per entry, then a
-terminating entry with `entryNumber == totalEntries` and `pathLength == 0`:
+(an absolute directory path, starting with `/`). One `0x51` notification per
+entry, then a terminating entry with `entryNumber == totalEntries` and
+`pathLength == 0`:
 
 | Off | Size | Field | Notes |
 |---|---|---|---|
@@ -200,7 +205,8 @@ terminating entry with `entryNumber == totalEntries` and `pathLength == 0`:
 | 28 | pathLength | name | entry name (not full path) |
 
 **MOVE `0x60`** → `0x61`: request `{command, reserved, oldPathLength(2),
-newPathLength(2)}` + oldPath + newPath; response `{command, status}`.
+newPathLength(2)}` + oldPath + **one separator byte** + newPath; response
+`{command, status}`. Both paths are absolute (start with `/`).
 
 ---
 
@@ -234,7 +240,8 @@ Stream `WRITE_DATA` without waiting per-chunk, bounded by a credit window.
 
 - Keep at most `WRITE_WINDOW` bytes unacked: send back-to-back while
   `bytesSent − bytesAcked < WRITE_WINDOW`; otherwise wait for an ACK.
-- **`freeSpace` is a contiguous high-water-mark.** `bytesAcked = totalSize −
+- **`freeSpace` is a contiguous high-water-mark** (an intentional v5 refinement
+  of the classic ACK — it makes loss detectable). `bytesAcked = totalSize −
   freeSpace` is the number of bytes held **with no gap** from the write's start;
   it never advances past a missing chunk. The terminal ACK (`freeSpace == 0`) is
   therefore only ever sent for a **hole-free** file.

--- a/Docs/BLE-File-Transfer-Service.md
+++ b/Docs/BLE-File-Transfer-Service.md
@@ -1,0 +1,306 @@
+# UNA Watch — BLE File Transfer Service (FTS)
+
+This document is the wire protocol for reading and writing files on a UNA Watch
+over Bluetooth Low Energy. It is what a companion app or integration implements
+against; it does not describe the watch's internal implementation.
+
+The base protocol is the [Adafruit CircuitPython BLE File Transfer
+protocol](https://github.com/adafruit/Adafruit_CircuitPython_BLE_File_Transfer)
+(service `0xFEBB`). UNA implements that command set and adds a small set of
+backward-compatible **fast-transfer extensions** (protocol version 5): windowed
+reads and writes, a file digest query, and safe resume. A client that only knows
+the classic (version 4) protocol interoperates unchanged.
+
+## Conventions
+
+- All multi-byte integers are **little-endian**.
+- All request/response layouts below are **packed** (no padding beyond the
+  `reserved` bytes shown). Byte offsets are given for each field.
+- **Paths** are UTF-8, not NUL-terminated on the wire; their length is carried in
+  a `pathLength` field. Absolute paths, `/`-separated (e.g.
+  `/Apps/Workout/Activity/202607/activity_...fit`).
+- Times are **nanoseconds since the Unix epoch** (`uint64`).
+
+## Service and characteristics
+
+| Item | UUID | Properties |
+|---|---|---|
+| File Transfer Service | `0000FEBB-0000-1000-8000-00805F9B34FB` (`0xFEBB`) | — |
+| Version | `ADAF0001-4669-6C65-5472-616E73666572` | Read |
+| Raw Transfer | `ADAF0002-4669-6C65-5472-616E73666572` | Write Without Response, Notify |
+
+All operations are a request written to **Raw Transfer** and one or more
+responses delivered as **notifications** on the same characteristic. Enable
+notifications (write the CCCD) before issuing commands.
+
+**Security.** The watch requires a **bonded, encrypted connection** — pair with
+the watch before using FTS. Reads and writes on the characteristics are rejected
+on an unencrypted link.
+
+## Capability negotiation
+
+Read the **Version** characteristic — a single `uint32` (little-endian):
+
+- **4** — classic protocol only (Adafruit-compatible, stop-and-wait).
+- **≥ 5** — UNA fast-transfer extensions are available.
+
+Gating rules for a version-5 client:
+
+- **Read windowing** needs no gate — it degrades automatically against a v4
+  watch (see [Read windowing](#read-windowing-v5)).
+- **Write windowing** and **`DIGEST`** MUST be gated on version **≥ 5**.
+
+## Command summary
+
+| ID | Name | Direction |
+|---|---|---|
+| `0x10` | READ | request |
+| `0x11` | READ_DATA | response |
+| `0x12` | READ_PACING | request (more) |
+| `0x20` | WRITE | request |
+| `0x21` | WRITE_PACING | response |
+| `0x22` | WRITE_DATA | request (data) |
+| `0x30` / `0x31` | DELETE / status | request / response |
+| `0x40` / `0x41` | MKDIR / status | request / response |
+| `0x50` / `0x51` | LISTDIR / entry | request / response |
+| `0x60` / `0x61` | MOVE / status | request / response |
+| `0x70` / `0x71` | DIGEST / status | request / response **(UNA extension)** |
+
+Status codes (the `status` byte in responses):
+
+| Value | Meaning |
+|---|---|
+| `0x01` | OK |
+| `0x02` | ERROR (generic) |
+| `0x03` | ERROR_NO_FILE |
+| `0x04` | ERROR_PROTOCOL (malformed/wrong length) |
+| `0x05` | ERROR_READ_ONLY |
+
+## Notification sizing — read this first
+
+A GATT notification cannot carry more than the negotiated **ATT payload = MTU −
+3** bytes. Every FTS response has a fixed header, so the usable *data* per
+notification is smaller still. For `READ_DATA` (16-byte header) at MTU 220:
+
+```
+data per notification ≤ (MTU − 3) − 16 = 201 bytes
+```
+
+Do **not** assume one request maps to one notification of the size you asked for.
+A version-5 watch delivers a large read as multiple `READ_DATA` notifications (see
+below); each `READ_DATA` is self-describing (`chunkOffset`, `chunkLength`), so
+reassemble by offset and never trust a `chunkLength` beyond what the notification
+actually delivered.
+
+---
+
+# Classic operations (protocol version 4)
+
+## Read a file
+
+**READ `0x10`** (request):
+
+| Off | Size | Field | Notes |
+|---|---|---|---|
+| 0 | 1 | command = `0x10` | |
+| 1 | 1 | reserved | 0 |
+| 2 | 2 | pathLength | |
+| 4 | 4 | chunkOffset | file offset to start at |
+| 8 | 4 | chunkSize | bytes requested |
+| 12 | pathLength | path | UTF-8 |
+
+**READ_DATA `0x11`** (response, one or more notifications):
+
+| Off | Size | Field | Notes |
+|---|---|---|---|
+| 0 | 1 | command = `0x11` | |
+| 1 | 1 | status | |
+| 2 | 2 | reserved | |
+| 4 | 4 | chunkOffset | offset of this chunk |
+| 8 | 4 | totalLength | total file size |
+| 12 | 4 | chunkLength | bytes of data that follow |
+| 16 | chunkLength | data | |
+
+**READ_PACING `0x12`** (request more) — after consuming a chunk, ask for the next:
+
+| Off | Size | Field | Notes |
+|---|---|---|---|
+| 0 | 1 | command = `0x12` | |
+| 1 | 1 | status = `0x01` | |
+| 2 | 2 | reserved | |
+| 4 | 4 | chunkOffset | next offset = bytes received so far |
+| 8 | 4 | chunkSize | bytes requested |
+
+Classic flow: send `READ`, receive one `READ_DATA`, send `READ_PACING` for the
+next chunk, repeat until `chunkOffset + chunkLength == totalLength`.
+
+## Write a file
+
+**WRITE `0x20`** (request):
+
+| Off | Size | Field | Notes |
+|---|---|---|---|
+| 0 | 1 | command = `0x20` | |
+| 1 | 1 | reserved | 0 |
+| 2 | 2 | pathLength | |
+| 4 | 4 | offset | start offset (**0 for a fresh write**; see [Resume](#resume)) |
+| 8 | 8 | currentTime | ns since epoch (file mtime) |
+| 16 | 4 | totalSize | total bytes to be written |
+| 20 | pathLength | path | |
+
+**WRITE_PACING `0x21`** (response / ACK):
+
+| Off | Size | Field | Notes |
+|---|---|---|---|
+| 0 | 1 | command = `0x21` | |
+| 1 | 1 | status | |
+| 2 | 2 | reserved | |
+| 4 | 4 | offset | |
+| 8 | 8 | truncatedTime | mtime as stored |
+| 16 | 4 | freeSpace | bytes still expected (see below) |
+
+**WRITE_DATA `0x22`** (request, carries data):
+
+| Off | Size | Field | Notes |
+|---|---|---|---|
+| 0 | 1 | command = `0x22` | |
+| 1 | 1 | status = `0x01` | |
+| 2 | 2 | reserved | |
+| 4 | 4 | offset | offset of this chunk |
+| 8 | 4 | dataSize | bytes of data that follow |
+| 12 | dataSize | data | |
+
+Classic flow: `WRITE`, then send `WRITE_DATA` chunks in ascending order, waiting
+for a `WRITE_PACING` ACK after each. `freeSpace == 0` is the terminal ACK.
+`bytesAcked = totalSize − freeSpace`.
+
+## Delete / MkDir / List / Move
+
+**DELETE `0x30`** → `0x31`: request `{command, reserved, pathLength}` + path;
+response `{command, status}`.
+
+**MKDIR `0x40`** → `0x41`: request `{command, reserved, pathLength, reserved(4),
+currentTime(8)}` + path; response `{command, status, reserved(6),
+truncatedTime(8)}`.
+
+**LISTDIR `0x50`** → `0x51`: request `{command, reserved, pathLength}` + path
+(must be a directory ending in `/`). One `0x51` notification per entry, then a
+terminating entry with `entryNumber == totalEntries` and `pathLength == 0`:
+
+| Off | Size | Field | Notes |
+|---|---|---|---|
+| 0 | 1 | command = `0x51` | |
+| 1 | 1 | status | |
+| 2 | 2 | pathLength | name length that follows |
+| 4 | 4 | entryNumber | 0-based |
+| 8 | 4 | totalEntries | |
+| 12 | 4 | flags | bit 0 = directory |
+| 16 | 8 | modificationTime | ns since epoch |
+| 24 | 4 | fileSize | (ignore for directories) |
+| 28 | pathLength | name | entry name (not full path) |
+
+**MOVE `0x60`** → `0x61`: request `{command, reserved, oldPathLength(2),
+newPathLength(2)}` + oldPath + newPath; response `{command, status}`.
+
+---
+
+# Fast-transfer extensions (protocol version 5)
+
+All of these run on the **same** `ADAF0002` characteristic — no new services or
+characteristics.
+
+## Read windowing {#read-windowing-v5}
+
+Instead of one chunk per round-trip, request a **large `chunkSize`** (e.g. 4096).
+The watch answers a single `READ_PACING` with a **burst** of `READ_DATA`
+notifications totalling up to `chunkSize`, then waits for the next pacing request.
+
+- Each `READ_DATA` is self-describing — **reassemble by `chunkOffset`**, not
+  arrival order.
+- Pace on bytes actually received: the next `READ_PACING.chunkOffset` = total
+  bytes received so far.
+- Each notification is capped to the payload limit (see [Notification
+  sizing](#notification-sizing--read-this-first)); a large `chunkSize` simply
+  arrives as several notifications.
+
+**Auto-degrade:** a v4 watch answers a large `chunkSize` with a single packet, so
+a v5 client falls back to classic pacing automatically — no version gate needed.
+
+**Recommended window: 4096 bytes.** Larger adds little (reads are round-trip
+bound).
+
+## Write windowing (credit-based, with recovery)
+
+Stream `WRITE_DATA` without waiting per-chunk, bounded by a credit window.
+
+- Keep at most `WRITE_WINDOW` bytes unacked: send back-to-back while
+  `bytesSent − bytesAcked < WRITE_WINDOW`; otherwise wait for an ACK.
+- **`freeSpace` is a contiguous high-water-mark.** `bytesAcked = totalSize −
+  freeSpace` is the number of bytes held **with no gap** from the write's start;
+  it never advances past a missing chunk. The terminal ACK (`freeSpace == 0`) is
+  therefore only ever sent for a **hole-free** file.
+- **Send `WRITE_DATA` in ascending offset order.**
+- **Loss recovery (go-back-N).** If `bytesAcked` stops advancing while bytes are
+  unacked — the window drains to `bytesAcked` with no terminal ACK — a chunk was
+  lost. **Rewind `bytesSent = bytesAcked` and resume**; retransmits overwrite the
+  gap. Arm a short "no ACK progress" timeout to trigger the rewind.
+- **Recommended `WRITE_WINDOW`: 2048 bytes** (~10 chunks at MTU 220). Larger
+  windows can *reduce* throughput (more drops → more retransmits) and don't help
+  — writes are round-trip bound. Raise only with digest-verified testing.
+
+Recommended integrity check: after a windowed write, `DIGEST` the file and
+compare (below).
+
+## DIGEST — integrity without read-back (UNA extension)
+
+Verify a file's contents without transferring it back over BLE.
+
+**DIGEST `0x70`** (request): `{command, reserved, pathLength}` + path.
+
+**DIGEST_STATUS `0x71`** (response, 12 bytes):
+
+| Off | Size | Field | Notes |
+|---|---|---|---|
+| 0 | 1 | command = `0x71` | |
+| 1 | 1 | status | OK / ERROR_NO_FILE / ERROR |
+| 2 | 2 | reserved | |
+| 4 | 4 | fileSize | total bytes hashed |
+| 8 | 4 | crc32 | see below |
+
+`crc32` is **standard CRC-32** (IEEE 802.3 / zlib: reflected poly `0xEDB88320`,
+init `0xFFFFFFFF`, final XOR `0xFFFFFFFF`) over the whole file — identical to
+Java `java.util.zip.CRC32` and Python `zlib.crc32`. Compute the expected value
+with a stock library and compare `crc32` + `fileSize`.
+
+## Resume {#resume}
+
+A `WRITE` with `offset > 0` **preserves the existing file head** `[0, offset)` and
+overwrites only from `offset` onward. So after a disconnect mid-write you may
+reconnect and continue with `WRITE offset = bytesAcked` — no need to restart from
+0. A fresh `WRITE offset = 0` truncates (so a full re-upload also works).
+
+**`bytesAcked` durability.** ACKs can lead the watch's flush to storage. On a
+**clean disconnect** the watch flushes before you reconnect, so `[0, bytesAcked)`
+is committed and you can resume at raw `bytesAcked`. If the watch instead
+**reset / lost power** mid-write, only data up to its last internal flush is
+guaranteed — on reconnect, confirm the committed size (`LISTDIR` or `DIGEST`'s
+`fileSize`) before resuming, and a `DIGEST` after any resumed transfer is cheap
+insurance.
+
+**Lost terminal ACK.** If the final `WRITE_PACING` is lost, your normal
+stall→rewind resends the tail and the watch re-acknowledges the completed file
+(`freeSpace == 0`) — the same loop concludes "done." After concluding done, drain
+any leftover `WRITE_PACING` notifications before issuing the next command so a
+stale one isn't mistaken for the next command's response.
+
+## Compatibility matrix
+
+| Client \ Watch | v4 watch | v5 watch |
+|---|---|---|
+| v4 client | classic | classic (v5 features simply unused) |
+| v5 client | classic (windowing auto-degrades; gate writes/DIGEST off) | full fast transfer |
+
+---
+
+*Base protocol © Adafruit Industries (MIT), extended by UNA. Report protocol
+issues on this repository.*

--- a/Docs/BLE-File-Transfer-Service.md
+++ b/Docs/BLE-File-Transfer-Service.md
@@ -132,7 +132,7 @@ actually delivered.
 | 0 | 1 | command = `0x12` | |
 | 1 | 1 | status = `0x01` | |
 | 2 | 2 | reserved | |
-| 4 | 4 | chunkOffset | next offset = bytes received so far |
+| 4 | 4 | chunkOffset | next offset = contiguous end (first byte not yet received) |
 | 8 | 4 | chunkSize | bytes requested |
 
 Classic flow: send `READ`, receive one `READ_DATA`, send `READ_PACING` for the
@@ -223,8 +223,10 @@ notifications totalling up to `chunkSize`, then waits for the next pacing reques
 
 - Each `READ_DATA` is self-describing — **reassemble by `chunkOffset`**, not
   arrival order.
-- Pace on bytes actually received: the next `READ_PACING.chunkOffset` = total
-  bytes received so far.
+- Pace from the **contiguous end**: the next `READ_PACING.chunkOffset` = the
+  first byte you don't yet have (`initialOffset + contiguous bytes received`), so
+  a dropped notification is re-requested rather than skipped — not the raw count
+  of bytes received.
 - Each notification is capped to the payload limit (see *Notification sizing*
   above); a large `chunkSize` simply arrives as several notifications.
 

--- a/Docs/BLE-File-Transfer-Service.md
+++ b/Docs/BLE-File-Transfer-Service.md
@@ -47,7 +47,7 @@ Read the **Version** characteristic — a single `uint32` (little-endian):
 Gating rules for a version-5 client:
 
 - **Read windowing** needs no gate — it degrades automatically against a v4
-  watch (see [Read windowing](#read-windowing-v5)).
+  watch (see *Read windowing* under the version-5 extensions below).
 - **Write windowing** and **`DIGEST`** MUST be gated on version **≥ 5**.
 
 ## Command summary
@@ -143,7 +143,7 @@ next chunk, repeat until `chunkOffset + chunkLength == totalLength`.
 | 0 | 1 | command = `0x20` | |
 | 1 | 1 | reserved | 0 |
 | 2 | 2 | pathLength | |
-| 4 | 4 | offset | start offset (**0 for a fresh write**; see [Resume](#resume)) |
+| 4 | 4 | offset | start offset (**0 for a fresh write**; see *Resume* below) |
 | 8 | 8 | currentTime | ns since epoch (file mtime) |
 | 16 | 4 | totalSize | total bytes to be written |
 | 20 | pathLength | path | |
@@ -209,7 +209,7 @@ newPathLength(2)}` + oldPath + newPath; response `{command, status}`.
 All of these run on the **same** `ADAF0002` characteristic — no new services or
 characteristics.
 
-## Read windowing {#read-windowing-v5}
+## Read windowing
 
 Instead of one chunk per round-trip, request a **large `chunkSize`** (e.g. 4096).
 The watch answers a single `READ_PACING` with a **burst** of `READ_DATA`
@@ -219,9 +219,8 @@ notifications totalling up to `chunkSize`, then waits for the next pacing reques
   arrival order.
 - Pace on bytes actually received: the next `READ_PACING.chunkOffset` = total
   bytes received so far.
-- Each notification is capped to the payload limit (see [Notification
-  sizing](#notification-sizing--read-this-first)); a large `chunkSize` simply
-  arrives as several notifications.
+- Each notification is capped to the payload limit (see *Notification sizing*
+  above); a large `chunkSize` simply arrives as several notifications.
 
 **Auto-degrade:** a v4 watch answers a large `chunkSize` with a single packet, so
 a v5 client falls back to classic pacing automatically — no version gate needed.
@@ -272,7 +271,7 @@ init `0xFFFFFFFF`, final XOR `0xFFFFFFFF`) over the whole file — identical to
 Java `java.util.zip.CRC32` and Python `zlib.crc32`. Compute the expected value
 with a stock library and compare `crc32` + `fileSize`.
 
-## Resume {#resume}
+## Resume
 
 A `WRITE` with `offset > 0` **preserves the existing file head** `[0, offset)` and
 overwrites only from `offset` onward. So after a disconnect mid-write you may

--- a/Docs/BLE-Services-Overview.md
+++ b/Docs/BLE-Services-Overview.md
@@ -1,0 +1,59 @@
+# UNA Watch — BLE Services Overview
+
+This is the map of the GATT services a UNA Watch exposes over Bluetooth Low
+Energy. Most are **standard Bluetooth SIG or vendor services** — any BLE tool
+recognizes them. The File Transfer Service has its own reference:
+[BLE-File-Transfer-Service.md](./BLE-File-Transfer-Service.md).
+
+**Security.** The watch requires a **bonded, encrypted connection**. Pair with
+the watch before reading or writing any characteristic.
+
+## Standard services
+
+These follow their published specifications exactly — refer to the Bluetooth SIG
+(or Nordic) documents for field formats.
+
+| Service | UUID | Source | Purpose |
+|---|---|---|---|
+| Device Information | `0x180A` | Bluetooth SIG | Manufacturer, model, serial, firmware/hardware revisions |
+| Current Time | `0x1805` | Bluetooth SIG | Time sync from the phone |
+| Battery | `0x180F` | Bluetooth SIG | Battery level |
+| File Transfer | `0xFEBB` | Adafruit | File read/write, OTA — see its own reference |
+| Nordic UART | `6E400001-B5A3-F393-E0A9-E50E24DCCA9E` | Nordic | Serial-style data channel |
+
+### Device Information (`0x180A`)
+
+| Characteristic | UUID |
+|---|---|
+| Manufacturer Name | `0x2A29` |
+| Model Number | `0x2A24` |
+| Serial Number | `0x2A25` |
+| Firmware Revision | `0x2A26` |
+| Hardware Revision | `0x2A27` |
+
+Reading `0x2A26` is the supported way to discover the watch's firmware version.
+
+### Current Time (`0x1805`)
+
+| Characteristic | UUID |
+|---|---|
+| Current Time | `0x2A2B` |
+| Local Time Information | `0x2A0F` |
+
+### Battery (`0x180F`)
+
+| Characteristic | UUID |
+|---|---|
+| Battery Level | `0x2A19` |
+
+Standard `uint8` percentage; subscribe for notifications on level change.
+
+### Nordic UART (`6E400001-…`)
+
+A standard Nordic UART Service (serial-style channel). Characteristics:
+`6E400002-…` and `6E400003-…` (one write, one notify).
+
+---
+
+*Bluetooth SIG service/characteristic formats are defined by the Bluetooth SIG;
+the File Transfer Service is based on the Adafruit protocol (see its reference).*

--- a/Docs/BLE-Services-Overview.md
+++ b/Docs/BLE-Services-Overview.md
@@ -8,10 +8,11 @@ recognizes them. The File Transfer Service has its own reference:
 **Security.** The watch requires a **bonded, encrypted connection**. Pair with
 the watch before reading or writing any characteristic.
 
-## Standard services
+## Services
 
-These follow their published specifications exactly — refer to the Bluetooth SIG
-(or Nordic) documents for field formats.
+The standard Bluetooth SIG and Nordic services follow their published
+specifications — refer to those documents for field formats. The File Transfer
+Service is UNA's (Adafruit-based); see its own reference.
 
 | Service | UUID | Source | Purpose |
 |---|---|---|---|
@@ -48,10 +49,15 @@ Reading `0x2A26` is the supported way to discover the watch's firmware version.
 
 Standard `uint8` percentage; subscribe for notifications on level change.
 
-### Nordic UART (`6E400001-…`)
+### Nordic UART (`6E400001-B5A3-F393-E0A9-E50E24DCCA9E`)
 
-A standard Nordic UART Service (serial-style channel). Characteristics:
-`6E400002-…` and `6E400003-…` (one write, one notify).
+A Nordic UART Service (serial-style channel). Note the two data characteristics
+are **swapped relative to Nordic's usual convention**:
+
+| Characteristic | UUID | Direction |
+|---|---|---|
+| Watch → client | `6E400002-B5A3-F393-E0A9-E50E24DCCA9E` | Notify |
+| Client → watch | `6E400003-B5A3-F393-E0A9-E50E24DCCA9E` | Write / Write Without Response |
 
 ---
 

--- a/Docs/index.rst
+++ b/Docs/index.rst
@@ -72,6 +72,14 @@ Next steps:
 
 .. toctree::
    :maxdepth: 4
+   :caption: 📡 BLE Interface
+   :hidden:
+
+   BLE-File-Transfer-Service
+   BLE-Services-Overview
+
+.. toctree::
+   :maxdepth: 4
    :caption: 🎋 Apps Sharing
    :hidden:
 


### PR DESCRIPTION
## What

The first public documentation of the UNA Watch BLE interface — two client-facing references for companion-app and third-party integrators:

- **`Docs/BLE-File-Transfer-Service.md`** — the FTS wire protocol. Documents the Adafruit `0xFEBB` base (classic v4) and UNA's backward-compatible **v5 fast-transfer extensions**: read/write windowing, credit-based writes with go-back-N recovery, the `DIGEST` integrity query, and safe resume. Every command has a byte-offset wire table.
- **`Docs/BLE-Services-Overview.md`** — the standard GATT service map (Device Information, Current Time, Battery, File Transfer, Nordic UART).

## Why

External clients have been implementing against this interface black-box (e.g. #272), re-deriving details like the per-notification size ceiling. These docs are the wire contracts they need — **wire contract only, no firmware internals.**

## Notes

- The **"Notification sizing — read this first"** section documents the `MTU − 3` per-notification ceiling behind #272 (fixed in firmware; documented here so clients don't recompute it wrong).
- **Nordic UART** is described at the service level (its two characteristics noted as one write / one notify).
- Both files are new; nothing else changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a complete BLE File Transfer Service protocol specification, including commands, security, file operations, notifications, and advanced transfer capabilities.
  * Added an overview of the watch’s BLE services, connection requirements, standard characteristics, firmware discovery, battery notifications, and related references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->