### PR TITLE
fix(variant): never adopt an identity reached by a truncated path

### DIFF
--- a/Docs/unit-testing.md
+++ b/Docs/unit-testing.md
@@ -94,7 +94,9 @@ Worth knowing:
   `IDirectory::create()` does not, matching the simulator's non-recursive
   `::mkdir`. `remove()` on a directory refuses unless it is empty.
 - **A name from a listing is openable as `"/" + name`**, and a listing never
-  reports the same name twice.
+  reports the same name twice — for every name short enough to survive
+  `ObjectInfo::name`. Both guarantees stop at that boundary; see the
+  name-length divergence below.
 - Opening a directory that does not exist fails, so assert on `open()`.
 
 ### Prove the scan is live
@@ -116,14 +118,33 @@ All deliberate. Check these before writing a test that leans on one:
 - **Leading and trailing slashes are not significant.** `/a.txt`, `a.txt` and
   `a.txt/` are one object, at every depth, for lookup as well as enumeration.
   This is what lets a test seed `/App.uapp` and have code that scans `/` find
-  it, but a real filesystem would keep them apart.
+  it, but a real filesystem would keep them apart. Repeated *interior*
+  separators are not a divergence: `a//b` and `a/b` are one object here as
+  they are on POSIX and FatFs.
+- **A file may be created under a directory that does not exist.** Writing
+  `a/b/c.txt` implies `a` and `a/b` rather than failing with `ENOENT` — the
+  flip side of implied directories. `mkdir()` the parents first if a test
+  needs the `ENOENT` branch.
 - **No `.` / `..` resolution.** Both are ordinary path segments, so `a/b` and
   `a/./b` are different places.
 - **Directory rename is not modelled** — it returns false. The simulator's
   does work, so do not read that false as device behaviour.
+- **No hidden/system attributes of their own.** `isHidden` is derived from a
+  leading `.` in the name, as the POSIX simulator does; `isSystem` is always
+  false.
 - **A name longer than `ObjectInfo::name` cannot round-trip**; it comes back
   clipped, as the simulator's `safe_strcpy` would clip it. Real backends cap
-  a single name well below that.
+  a single name well below that. Names are deduplicated *before* clipping, so
+  two names differing only past that capacity come back as two identical
+  entries — the one case where a listing repeats a name.
+
+What the fake refuses, so a test cannot build a state the device cannot
+reach: one name is never both a file and a directory (`mkdir()`,
+`IDirectory::create()`, a write-`open()` and `seedFile()` all enforce this);
+`rename()`/`copy()` will not take a removed path as their source, nor a
+destination that is the root, an existing directory, or under a file; and
+`close()` on a handle that is not open fails, so `EXPECT_TRUE(h->close())` is
+a real assertion.
 
 ## Troubleshooting
 

--- a/Docs/unit-testing.md
+++ b/Docs/unit-testing.md
@@ -56,6 +56,75 @@ Use `SDK::TestSupport::KernelFixture`:
 - Instantiate serializer with `SettingsSerializer(fixture.kernel, "settings.json")`.
 - Verify load/save behavior without device firmware or simulator runtime.
 
+## Testing Code That Scans A Directory
+
+`InMemoryFileSystem` enumerates what you seed, so code that walks a directory
+(`kernel.fs.dir(path)` then `readNext()`) can be tested directly. Seeding a
+file is enough — the directories along its path are implied, with no `mkdir`
+needed:
+
+```cpp
+KernelFixture fixture;
+fixture.fileSystem.seedFile("Activity/morning.fit", contents);
+fixture.fileSystem.seedFile("Activity/archive/old.fit", contents);
+
+auto dir = fixture.kernel.fs.dir("Activity");
+ASSERT_TRUE(dir->open());
+SDK::Interface::IFileSystem::ObjectInfo item{};
+while (dir->readNext(item)) {
+    // "archive" (isDir true), then "morning.fit" (isDir false)
+}
+dir->close();
+```
+
+Worth knowing:
+
+- **Direct children only.** `Activity/archive/old.fit` shows up as the
+  directory `archive` when listing `Activity`, not as a file — the same shape
+  a real backend reports.
+- **`isDir` is real**, so an `if (item.isDir) continue;` guard is actually
+  exercised rather than silently dead.
+- **Enumeration is sorted by name**, so tests are reproducible. The device
+  enumerates in directory-entry order, so do not write tests that depend on
+  alphabetical order *meaning* anything — only on it being stable.
+- **A snapshot is taken at `open()`.** Files seeded mid-scan do not appear
+  until an explicit `readNext(item, /*reset=*/true)`, which rewinds without
+  reading an entry (and re-snapshots, as POSIX `rewinddir` does).
+- **`mkdir()` creates parents** and succeeds if the directory already exists;
+  `IDirectory::create()` does not, matching the simulator's non-recursive
+  `::mkdir`. `remove()` on a directory refuses unless it is empty.
+- **A name from a listing is openable as `"/" + name`**, and a listing never
+  reports the same name twice.
+- Opening a directory that does not exist fails, so assert on `open()`.
+
+### Prove the scan is live
+
+A test whose expectation is "nothing was found" cannot tell a correct
+decision from a scan that never ran — seed a path the fake resolves
+differently than you assumed and it still passes. Where the expected outcome
+is a negative, assert first that the directory really enumerates what you
+seeded, or pair the test with a positive control that differs in exactly the
+one property under test.
+
+### Divergences from a real backend
+
+All deliberate. Check these before writing a test that leans on one:
+
+- **An implied directory is only as durable as its contents.** A directory
+  that exists solely because a file lives under it stops existing when that
+  file is removed. Call `mkdir()` if a test needs it to outlive its children.
+- **Leading and trailing slashes are not significant.** `/a.txt`, `a.txt` and
+  `a.txt/` are one object, at every depth, for lookup as well as enumeration.
+  This is what lets a test seed `/App.uapp` and have code that scans `/` find
+  it, but a real filesystem would keep them apart.
+- **No `.` / `..` resolution.** Both are ordinary path segments, so `a/b` and
+  `a/./b` are different places.
+- **Directory rename is not modelled** — it returns false. The simulator's
+  does work, so do not read that false as device behaviour.
+- **A name longer than `ObjectInfo::name` cannot round-trip**; it comes back
+  clipped, as the simulator's `safe_strcpy` would clip it. Real backends cap
+  a single name well below that.
+
 ## Troubleshooting
 
 - If `core_json.h` is missing, confirm include path:

--- a/Libs/Header/SDK/Interfaces/IFileSystem.hpp
+++ b/Libs/Header/SDK/Interfaces/IFileSystem.hpp
@@ -40,7 +40,11 @@ public:
      * @brief   Structure to store directory item information.
      */
     struct ObjectInfo {
-        char name[skMaxPathLen];   ///< Name of the item.
+        /// Leaf name of the item, not a path. Note this is as wide as a whole
+        /// path, so a maximal name cannot be joined onto a directory and still
+        /// fit in skMaxPathLen: code that builds a path from an enumerated
+        /// name must check the join for truncation rather than assume it fits.
+        char name[skMaxPathLen];
         bool isDir;       ///< 'true' if the item is a directory.
         bool isHidden;    ///< 'true' if the item is hidden.
         bool isSystem;    ///< 'true' if the item is a system file.

--- a/Libs/Source/Variant/VariantConfig.cpp
+++ b/Libs/Source/Variant/VariantConfig.cpp
@@ -54,8 +54,8 @@ bool readFlags(const SDK::Kernel &kernel, const char *path, uint32_t &flags)
 
 Config::Config(const SDK::Kernel &kernel)
 {
-    // Pick the same file the kernel's scan picked (mixed-dir determinism,
-    // design doc section 3.4): any real (non-alias) .uapp in the sandbox
+    // Pick the same file the kernel's scan picked (the mixed-directory
+    // determinism rules): any real (non-alias) .uapp in the sandbox
     // root means the app runs as its classic self; otherwise the first
     // alias-flagged .uapp is this variant's identity. An unreadable
     // candidate counts as a real app, mirroring the kernel's routing.
@@ -66,16 +66,37 @@ Config::Config(const SDK::Kernel &kernel)
             return;
         }
 
-        char candidate[SDK::Interface::IFileSystem::skMaxPathLen] {};
         SDK::Interface::IFileSystem::ObjectInfo item {};
         bool realAppSeen = false;
         while (dir->readNext(item)) {
             if (item.isDir || !hasUappExtension(item.name)) {
                 continue;
             }
-            snprintf(candidate, sizeof(candidate), "/%s", item.name);
+            // Per iteration and zero-initialised, so an entry whose path is
+            // declined below names nothing at all rather than inheriting what
+            // the last one left here.
+            char candidate[SDK::Interface::IFileSystem::skMaxPathLen] {};
+
+            // ObjectInfo::name is as wide as a whole path, so "/" + name need
+            // not fit in one. A name too long to form a path is as unreadable
+            // as one whose flags will not load, and takes the same
+            // conservative branch: a truncated path would name some other
+            // file, and opening the wrong .uapp is worse than opening none.
+            //
+            // Measuring first, rather than recovering the length from
+            // snprintf, is what keeps the path free of anything to truncate --
+            // and with it the -Wformat-truncation that a "/%s" whose source is
+            // as wide as its destination earns at the -Os -Wall app builds use.
+            const size_t nameLen = strlen(item.name);
+            // The path is '/' + name + '\0', so nameLen + 2 bytes.
+            const bool nameFits = nameLen + 2 <= sizeof(candidate);
+            if (nameFits) {
+                candidate[0] = '/';
+                memcpy(&candidate[1], item.name, nameLen + 1); // includes the NUL
+            }
+
             uint32_t flags = 0;
-            if (!readFlags(kernel, candidate, flags) ||
+            if (!nameFits || !readFlags(kernel, candidate, flags) ||
                     (flags & kFlagVariantAlias) == 0) {
                 realAppSeen = true;
                 break;
@@ -168,6 +189,11 @@ Config::Config(const SDK::Kernel &kernel)
     const char *name = nullptr;
     size_t nameLen = 0;
     if (reader.get("name", name, nameLen)) {
+        // Clipping is the right answer here, unlike for the candidate path
+        // above: mName is a display label, so a too-long one shows shortened
+        // rather than failing the launch. snprintf always NUL-terminates.
+        // -Wformat-truncation=2 flags this, which is the intended behaviour
+        // and not a level app builds enable.
         snprintf(mName, sizeof(mName), "%.*s", static_cast<int>(nameLen), name);
     }
 

--- a/Tests/Host/CMakeLists.txt
+++ b/Tests/Host/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(una-sdk-host-tests
     utils/ClockTime_test.cpp
     utils/Utils_test.cpp
     utils/CopyUtf8_test.cpp
+    variant/VariantConfig_test.cpp
     support/KernelTestDoubles_test.cpp
     apps/Stopwatch/Stopwatch_test.cpp
     apps/Timer/TimerManager_test.cpp
@@ -78,6 +79,7 @@ add_executable(una-sdk-host-tests
     "${UNA_SDK_ROOT}/Libs/Source/SensorLayer/SensorConnection.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/AppConfig/AppConfig.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/JSON/JsonStreamReader.cpp"
+    "${UNA_SDK_ROOT}/Libs/Source/Variant/VariantConfig.cpp"
     "${UNA_SDK_ROOT}/Libs/Source/JSON/JsonStreamWriter.cpp"
     "${COREJSON_DIR}/core_json.c"
     "${UNA_SDK_ROOT}/Libs/Source/Simulator/Kernel/Mock/FileSystem.cpp"

--- a/Tests/Host/support/KernelTestDoubles.cpp
+++ b/Tests/Host/support/KernelTestDoubles.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <map>
 #include <new>
 
 #include "SDK/Messages/MessageBase.hpp"
@@ -101,18 +102,22 @@ void* StubAppComm::allocateMessage(size_t size)
 
 InMemoryFileSystem::InMemoryFile::InMemoryFile(InMemoryFileSystem& fs, std::string path)
     : mFs(fs)
-    , mPath(std::move(path))
+    , mGivenPath(std::move(path))
+    , mPath(canonicalPath(mGivenPath))
 {
 }
 
 void InMemoryFileSystem::InMemoryFile::setPath(const char* path)
 {
-    mPath = path != nullptr ? path : "";
+    mGivenPath = path != nullptr ? path : "";
+    mPath = canonicalPath(mGivenPath);
 }
 
 const char* InMemoryFileSystem::InMemoryFile::getPath() const
 {
-    return mPath.c_str();
+    // The path as the caller spelled it, matching the simulator's File, which
+    // hands back exactly what setPath() was given.
+    return mGivenPath.c_str();
 }
 
 bool InMemoryFileSystem::InMemoryFile::exist() const
@@ -132,11 +137,13 @@ bool InMemoryFileSystem::InMemoryFile::rename(const char* newPath)
     // Keep the open-handle instrumentation keyed by the handle's current path:
     // without the migration a rename-while-open leaves the old bucket nonzero
     // forever and the eventual close() would drain the wrong (new) bucket.
+    const std::string newCanonical = canonicalPath(newPath);
     if (mOpen) {
         --mFs.openHandles[mPath];
-        ++mFs.openHandles[newPath];
+        ++mFs.openHandles[newCanonical];
     }
-    mPath = newPath;
+    mGivenPath = newPath;
+    mPath = newCanonical;
     return true;
 }
 
@@ -293,64 +300,213 @@ size_t InMemoryFileSystem::InMemoryFile::getPosition() const
     return mPos;
 }
 
-InMemoryFileSystem::EmptyDirectory::EmptyDirectory(std::string path)
-    : mPath(std::move(path))
+// -- Path helpers -----------------------------------------------------------
+//
+// Purely lexical: the backing store is a flat map of canonical paths, so
+// "parent" and "base name" are defined by the last '/' and nothing else. No
+// "." or ".." resolution, no case folding.
+
+std::string InMemoryFileSystem::canonicalPath(const std::string& path)
+{
+    size_t begin = 0;
+    while (begin < path.size() && path[begin] == '/') {
+        ++begin;
+    }
+    size_t end = path.size();
+    while (end > begin && path[end - 1] == '/') {
+        --end;
+    }
+    return path.substr(begin, end - begin);
+}
+
+std::string InMemoryFileSystem::parentOf(const std::string& path)
+{
+    const size_t slash = path.find_last_of('/');
+    if (slash == std::string::npos) {
+        return {}; // a direct child of the root
+    }
+    return path.substr(0, slash);
+}
+
+std::string InMemoryFileSystem::baseNameOf(const std::string& path)
+{
+    const size_t slash = path.find_last_of('/');
+    return slash == std::string::npos ? path : path.substr(slash + 1);
+}
+
+bool InMemoryFileSystem::fileExistsAt(const std::string& canonical) const
+{
+    auto it = files.find(canonical);
+    return it != files.end() && it->second.exists;
+}
+
+bool InMemoryFileSystem::directoryExists(const std::string& path) const
+{
+    const std::string dir = canonicalPath(path);
+    if (dir.empty()) {
+        return true; // the root always exists
+    }
+    if (directories.count(dir) != 0) {
+        return true;
+    }
+    // Otherwise it exists if some file lives under it. Asking that directly
+    // short-circuits on the first hit; materialising every directory in the
+    // tree just to answer one question makes every exist() miss cost a walk
+    // of the whole store.
+    const std::string prefix = dir + "/";
+    for (const auto& kv : files) {
+        if (kv.second.exists && kv.first.compare(0, prefix.size(), prefix) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// -- InMemoryDirectory ------------------------------------------------------
+
+InMemoryFileSystem::InMemoryDirectory::InMemoryDirectory(InMemoryFileSystem& fs, std::string path)
+    : mFs(fs), mGivenPath(std::move(path)), mPath(canonicalPath(mGivenPath))
 {
 }
 
-void InMemoryFileSystem::EmptyDirectory::setPath(const char* path)
+void InMemoryFileSystem::InMemoryDirectory::setPath(const char* path)
 {
-    mPath = path != nullptr ? path : "";
+    mGivenPath = path != nullptr ? path : "";
+    mPath = canonicalPath(mGivenPath);
+    // Repointing the handle invalidates any scan in progress: continuing to
+    // hand out the previous directory's entries under the new path is a
+    // combination no real backend can show. The caller must open() again.
+    mOpen = false;
+    mEntries.clear();
+    mCursor = 0;
 }
 
-const char* InMemoryFileSystem::EmptyDirectory::getPath() const
+const char* InMemoryFileSystem::InMemoryDirectory::getPath() const
 {
-    return mPath.c_str();
+    // The path as the caller spelled it, matching the simulator's Directory.
+    return mGivenPath.c_str();
 }
 
-bool InMemoryFileSystem::EmptyDirectory::exist() const
+bool InMemoryFileSystem::InMemoryDirectory::exist() const
 {
-    return true;
+    return mFs.directoryExists(mPath);
 }
 
-bool InMemoryFileSystem::EmptyDirectory::rename(const char* newPath)
+bool InMemoryFileSystem::InMemoryDirectory::rename(const char* newPath)
 {
-    if (newPath == nullptr) {
+    // Renaming a directory would have to rewrite every descendant's key in
+    // the flat map. Nothing needs it, and a rename that silently moved the
+    // handle without moving the contents would be worse than an honest
+    // failure -- so this fails rather than lies.
+    (void)newPath;
+    return false;
+}
+
+bool InMemoryFileSystem::InMemoryDirectory::remove()
+{
+    return mFs.remove(mPath.c_str());
+}
+
+bool InMemoryFileSystem::InMemoryDirectory::create()
+{
+    // Deliberately not mkdir(): the simulator's Directory::create() is a
+    // single non-recursive ::mkdir that fails with ENOENT when the parent is
+    // missing, and a fake that quietly conjures the parents would hide that.
+    const std::string parent = parentOf(mPath);
+    if (mPath.empty() || mFs.fileExistsAt(mPath) || !mFs.directoryExists(parent)) {
         return false;
     }
-    mPath = newPath;
+    mFs.directories.insert(mPath);
     return true;
 }
 
-bool InMemoryFileSystem::EmptyDirectory::remove()
+void InMemoryFileSystem::InMemoryDirectory::snapshot()
 {
-    return true;
+    mEntries.clear();
+    mCursor = 0;
+
+    // Collected by name so a listing can never report the same name twice,
+    // however many stored paths or implied directories map onto it.
+    std::map<std::string, Entry> byName;
+    const std::string prefix = mPath.empty() ? std::string() : mPath + "/";
+
+    for (const auto& kv : mFs.files) {
+        if (!kv.second.exists || kv.first.compare(0, prefix.size(), prefix) != 0) {
+            continue;
+        }
+        const std::string rest = kv.first.substr(prefix.size());
+        if (rest.empty()) {
+            continue;
+        }
+        const size_t slash = rest.find('/');
+        if (slash == std::string::npos) {
+            byName[rest] = Entry{ rest, false, kv.second.content.size() };
+        } else {
+            // A file deeper down: what this directory holds is the segment
+            // just below it, reported as a subdirectory.
+            const std::string child = rest.substr(0, slash);
+            byName.emplace(child, Entry{ child, true, 0 });
+        }
+    }
+
+    for (const std::string& dir : mFs.directories) {
+        if (parentOf(dir) != mPath || dir.empty()) {
+            continue;
+        }
+        const std::string child = baseNameOf(dir);
+        byName.emplace(child, Entry{ child, true, 0 });
+    }
+
+    // std::map is already ordered by name, which is the reproducible
+    // enumeration order the class comment promises.
+    mEntries.reserve(byName.size());
+    for (auto& kv : byName) {
+        mEntries.push_back(std::move(kv.second));
+    }
 }
 
-bool InMemoryFileSystem::EmptyDirectory::create()
+bool InMemoryFileSystem::InMemoryDirectory::open()
 {
-    return true;
-}
-
-bool InMemoryFileSystem::EmptyDirectory::open()
-{
+    if (!mFs.directoryExists(mPath)) {
+        return false; // opening a directory that isn't there fails, as on device
+    }
     mOpen = true;
+    snapshot();
     return true;
 }
 
-bool InMemoryFileSystem::EmptyDirectory::isOpen() const
+bool InMemoryFileSystem::InMemoryDirectory::isOpen() const
 {
     return mOpen;
 }
 
-bool InMemoryFileSystem::EmptyDirectory::readNext(SDK::Interface::IFileSystem::ObjectInfo& item, bool reset)
+bool InMemoryFileSystem::InMemoryDirectory::readNext(SDK::Interface::IFileSystem::ObjectInfo& item, bool reset)
 {
-    (void)item;
-    (void)reset;
-    return false;
+    if (!mOpen) {
+        return false;
+    }
+    if (reset) {
+        snapshot();
+        return true; // Rewind only -- item is left unmodified, per the interface doc comment.
+    }
+    if (mCursor >= mEntries.size()) {
+        return false;
+    }
+
+    const Entry& entry = mEntries[mCursor++];
+    // Clipped exactly as the simulator's safe_strcpy would clip it; see the
+    // note on name length in the class comment.
+    std::strncpy(item.name, entry.name.c_str(), sizeof(item.name) - 1);
+    item.name[sizeof(item.name) - 1] = '\0';
+    item.isDir    = entry.isDir;
+    item.isHidden = entry.name[0] == '.'; // as the POSIX simulator derives it
+    item.isSystem = false;
+    item.size     = entry.size;
+    item.utc      = 0; // Matches InMemoryFileSystem::objectInfo()'s existing convention.
+    return true;
 }
 
-bool InMemoryFileSystem::EmptyDirectory::close()
+bool InMemoryFileSystem::InMemoryDirectory::close()
 {
     mOpen = false;
     return true;
@@ -358,7 +514,26 @@ bool InMemoryFileSystem::EmptyDirectory::close()
 
 bool InMemoryFileSystem::mkdir(const char* path)
 {
-    (void)path;
+    if (path == nullptr) {
+        return false;
+    }
+    // A file anywhere along the chain makes the directory impossible, as on
+    // device -- otherwise the fake would hold one name as both a file and an
+    // openable directory at once. Checked over the whole chain before
+    // anything is recorded, so a rejected mkdir() leaves no half-built path.
+    const std::string requested = canonicalPath(path);
+    for (std::string dir = requested; !dir.empty(); dir = parentOf(dir)) {
+        if (fileExistsAt(dir)) {
+            return false;
+        }
+    }
+    // Creates parents too, and succeeds when the directory already exists --
+    // both per IFileSystem::mkdir's contract.
+    for (std::string dir = requested; !dir.empty(); dir = parentOf(dir)) {
+        if (!directories.insert(dir).second) {
+            break; // already recorded, so its ancestors are too
+        }
+    }
     return true;
 }
 
@@ -372,16 +547,26 @@ std::unique_ptr<SDK::Interface::IFile> InMemoryFileSystem::file(const char* path
 
 std::unique_ptr<SDK::Interface::IDirectory> InMemoryFileSystem::dir(const char* path)
 {
-    return std::make_unique<EmptyDirectory>(path != nullptr ? path : "");
+    if (path == nullptr) {
+        return {}; // as file() does: a null path yields no handle
+    }
+    return std::make_unique<InMemoryDirectory>(*this, path);
 }
 
 bool InMemoryFileSystem::exist(const char* path) const
 {
-    if (path == nullptr) {
+    // An empty path names nothing, as stat("") does not. "/" is the root and
+    // does exist, and canonicalPath() maps both to "", so separate them here.
+    if (path == nullptr || path[0] == '\0') {
         return false;
     }
-    auto it = files.find(path);
-    return it != files.end() && it->second.exists;
+    auto it = files.find(canonicalPath(path));
+    if (it != files.end() && it->second.exists) {
+        return true;
+    }
+    // A directory exists too -- IFileSystem::exist() is about filesystem
+    // objects, not files specifically.
+    return directoryExists(path);
 }
 
 bool InMemoryFileSystem::remove(const char* path)
@@ -389,13 +574,31 @@ bool InMemoryFileSystem::remove(const char* path)
     if (path == nullptr) {
         return false;
     }
-    auto it = files.find(path);
-    if (it == files.end()) {
+    const std::string target = canonicalPath(path);
+    auto it = files.find(target);
+    if (it != files.end() && it->second.exists) {
+        it->second.exists = false;
+        it->second.content.clear();
+        return true;
+    }
+
+    // Removing a directory: only an existing, empty one, mirroring FatFs
+    // f_unlink, which refuses to remove a directory that still has children.
+    if (target.empty() || !directoryExists(target)) {
         return false;
     }
-    it->second.exists = false;
-    it->second.content.clear();
-    return true;
+    const std::string prefix = target + "/";
+    for (const auto& kv : files) {
+        if (kv.second.exists && kv.first.compare(0, prefix.size(), prefix) == 0) {
+            return false;
+        }
+    }
+    for (const std::string& other : directories) {
+        if (other.compare(0, prefix.size(), prefix) == 0) {
+            return false;
+        }
+    }
+    return directories.erase(target) != 0;
 }
 
 bool InMemoryFileSystem::rename(const char* oldPath, const char* newPath)
@@ -403,11 +606,11 @@ bool InMemoryFileSystem::rename(const char* oldPath, const char* newPath)
     if (oldPath == nullptr || newPath == nullptr) {
         return false;
     }
-    auto it = files.find(oldPath);
+    auto it = files.find(canonicalPath(oldPath));
     if (it == files.end()) {
         return false;
     }
-    files[newPath] = std::move(it->second);
+    files[canonicalPath(newPath)] = std::move(it->second);
     files.erase(it);
     return true;
 }
@@ -417,41 +620,56 @@ bool InMemoryFileSystem::copy(const char* oldPath, const char* newPath)
     if (oldPath == nullptr || newPath == nullptr) {
         return false;
     }
-    auto it = files.find(oldPath);
+    auto it = files.find(canonicalPath(oldPath));
     if (it == files.end()) {
         return false;
     }
-    files[newPath] = it->second;
+    files[canonicalPath(newPath)] = it->second;
     return true;
 }
 
 bool InMemoryFileSystem::objectInfo(const char* path, ObjectInfo& item) const
 {
-    if (path == nullptr) {
+    // As with exist(): an empty path is not an object, the root is.
+    if (path == nullptr || path[0] == '\0') {
         return false;
     }
-    auto it = files.find(path);
-    if (it == files.end() || !it->second.exists) {
+    const std::string target = canonicalPath(path);
+
+    // The leaf name, not the path handed in -- the convention the simulator's
+    // objectInfo() follows, and the one every readNext() already used.
+    const std::string name = baseNameOf(target);
+    const auto populate = [&item, &name](bool isDir, size_t size) {
+        std::strncpy(item.name, name.c_str(), sizeof(item.name) - 1);
+        item.name[sizeof(item.name) - 1] = '\0';
+        item.isDir = isDir;
+        item.isHidden = !name.empty() && name[0] == '.';
+        item.isSystem = false;
+        item.size = size;
+        item.utc = 0;
+    };
+
+    auto it = files.find(target);
+    if (it != files.end() && it->second.exists) {
+        populate(false, it->second.content.size());
+        return true;
+    }
+
+    if (!directoryExists(target)) {
         return false;
     }
-    std::strncpy(item.name, path, sizeof(item.name) - 1);
-    item.name[sizeof(item.name) - 1] = '\0';
-    item.isDir = false;
-    item.isHidden = false;
-    item.isSystem = false;
-    item.size = it->second.content.size();
-    item.utc = 0;
+    populate(true, 0);
     return true;
 }
 
 void InMemoryFileSystem::seedFile(const std::string& path, std::string content)
 {
-    files[path] = InMemoryFileEntry{ std::move(content), true };
+    files[canonicalPath(path)] = InMemoryFileEntry{ std::move(content), true };
 }
 
 std::string InMemoryFileSystem::readFile(const std::string& path) const
 {
-    auto it = files.find(path);
+    auto it = files.find(canonicalPath(path));
     if (it == files.end() || !it->second.exists) {
         return {};
     }

--- a/Tests/Host/support/KernelTestDoubles.cpp
+++ b/Tests/Host/support/KernelTestDoubles.cpp
@@ -109,6 +109,18 @@ InMemoryFileSystem::InMemoryFile::InMemoryFile(InMemoryFileSystem& fs, std::stri
 
 void InMemoryFileSystem::InMemoryFile::setPath(const char* path)
 {
+    // Repointing closes any open handle, as IDirectory::setPath does. The new
+    // path is a different file, so an open handle's count cannot follow it the
+    // way rename()'s does: it is released here, against the path that earned
+    // it. A handle left open across the change would write to the new path
+    // where the real File keeps writing through the descriptor it opened, and
+    // its close() would decrement a bucket it never incremented.
+    if (mOpen) {
+        --mFs.openHandles[mPath];
+    }
+    mOpen = false;
+    mWriteMode = false;
+    mPos = 0;
     mGivenPath = path != nullptr ? path : "";
     mPath = canonicalPath(mGivenPath);
 }
@@ -163,6 +175,15 @@ size_t InMemoryFileSystem::InMemoryFile::size() const
 
 bool InMemoryFileSystem::InMemoryFile::open(bool wMode, bool override)
 {
+    // A write-open cannot conjure a file where the name is already a directory
+    // (EISDIR), nor under a path whose ancestor is a file (ENOTDIR). Without
+    // this the fake would hold one name as both a file and an openable
+    // directory at once -- the state IFileSystem::mkdir() already refuses to
+    // create from the other direction.
+    if (wMode && !mFs.canHoldFileAt(mPath)) {
+        return false;
+    }
+
     // Injected, file-kind-scoped storage failure: refuse to open a matching path
     // for writing without touching the entry (e.g. the auxiliary ".json" summary
     // fails while the ".fit" is already durable).
@@ -203,14 +224,17 @@ bool InMemoryFileSystem::InMemoryFile::isOpen() const
 
 bool InMemoryFileSystem::InMemoryFile::close()
 {
-    // Injected close failure (FatFs f_close semantics: a sync failure keeps
-    // the FIL valid and its lock-table entry held): the handle stays open.
-    if (mOpen && mFs.closeGate && !mFs.closeGate(mPath)) {
+    // Closing what is not open fails, as the simulator's File::close() does,
+    // so EXPECT_TRUE(f->close()) is an assertion with a failing mode.
+    if (!mOpen) {
         return false;
     }
-    if (mOpen) {
-        --mFs.openHandles[mPath];
+    // Injected close failure (FatFs f_close semantics: a sync failure keeps
+    // the FIL valid and its lock-table entry held): the handle stays open.
+    if (mFs.closeGate && !mFs.closeGate(mPath)) {
+        return false;
     }
+    --mFs.openHandles[mPath];
     mOpen = false;
     return true;
 }
@@ -308,15 +332,23 @@ size_t InMemoryFileSystem::InMemoryFile::getPosition() const
 
 std::string InMemoryFileSystem::canonicalPath(const std::string& path)
 {
-    size_t begin = 0;
-    while (begin < path.size() && path[begin] == '/') {
-        ++begin;
+    // Runs of '/' collapse to one, leading and trailing runs to none, so
+    // "a//b" and "a/b" name one object as they do on POSIX and FatFs. That
+    // keeps a stray separator from splitting a path into an empty segment,
+    // which would enumerate as an entry with no name -- something no backend
+    // can show, and which no caller could join back onto its parent.
+    std::string out;
+    out.reserve(path.size());
+    for (const char c : path) {
+        if (c == '/' && (out.empty() || out.back() == '/')) {
+            continue;
+        }
+        out.push_back(c);
     }
-    size_t end = path.size();
-    while (end > begin && path[end - 1] == '/') {
-        --end;
+    while (!out.empty() && out.back() == '/') {
+        out.pop_back();
     }
-    return path.substr(begin, end - begin);
+    return out;
 }
 
 std::string InMemoryFileSystem::parentOf(const std::string& path)
@@ -338,6 +370,27 @@ bool InMemoryFileSystem::fileExistsAt(const std::string& canonical) const
 {
     auto it = files.find(canonical);
     return it != files.end() && it->second.exists;
+}
+
+bool InMemoryFileSystem::canHoldFileAt(const std::string& canonical) const
+{
+    // The root is a directory, so no file can live *at* it.
+    if (canonical.empty()) {
+        return false;
+    }
+    // A directory already holding the name rules out a file there (EISDIR),
+    // and a file anywhere along the chain rules out anything below it
+    // (ENOTDIR). The mirror of IFileSystem::mkdir()'s chain walk, so the two
+    // agree on which names are already spoken for.
+    if (directoryExists(canonical)) {
+        return false;
+    }
+    for (std::string dir = parentOf(canonical); !dir.empty(); dir = parentOf(dir)) {
+        if (fileExistsAt(dir)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 bool InMemoryFileSystem::directoryExists(const std::string& path) const
@@ -412,8 +465,13 @@ bool InMemoryFileSystem::InMemoryDirectory::create()
     // Deliberately not mkdir(): the simulator's Directory::create() is a
     // single non-recursive ::mkdir that fails with ENOENT when the parent is
     // missing, and a fake that quietly conjures the parents would hide that.
+    if (mPath.empty()) {
+        // The root. ::mkdir gives EEXIST, which the simulator reports as
+        // success once it confirms the target really is a directory.
+        return true;
+    }
     const std::string parent = parentOf(mPath);
-    if (mPath.empty() || mFs.fileExistsAt(mPath) || !mFs.directoryExists(parent)) {
+    if (mFs.fileExistsAt(mPath) || !mFs.directoryExists(parent)) {
         return false;
     }
     mFs.directories.insert(mPath);
@@ -508,7 +566,13 @@ bool InMemoryFileSystem::InMemoryDirectory::readNext(SDK::Interface::IFileSystem
 
 bool InMemoryFileSystem::InMemoryDirectory::close()
 {
+    // As the simulator's Directory::close(): closing what is not open fails.
+    if (!mOpen) {
+        return false;
+    }
     mOpen = false;
+    mEntries.clear();
+    mCursor = 0;
     return true;
 }
 
@@ -555,8 +619,11 @@ std::unique_ptr<SDK::Interface::IDirectory> InMemoryFileSystem::dir(const char* 
 
 bool InMemoryFileSystem::exist(const char* path) const
 {
-    // An empty path names nothing, as stat("") does not. "/" is the root and
-    // does exist, and canonicalPath() maps both to "", so separate them here.
+    // An empty path names nothing, as FatFs f_stat("") is FR_INVALID_NAME on
+    // device. Note the simulator answers TRUE here -- it prepends a sandbox
+    // root, so "" stats that directory -- and the device is the behaviour
+    // worth modelling. "/" is the root and does exist, and canonicalPath()
+    // maps both to "", so separate them here.
     if (path == nullptr || path[0] == '\0') {
         return false;
     }
@@ -606,12 +673,30 @@ bool InMemoryFileSystem::rename(const char* oldPath, const char* newPath)
     if (oldPath == nullptr || newPath == nullptr) {
         return false;
     }
-    auto it = files.find(canonicalPath(oldPath));
-    if (it == files.end()) {
+    // A removed path lingers in the map as a tombstone -- present, with its
+    // `exists` flag cleared -- and is not a source. Moving one would report
+    // success for work not done, and would carry the tombstone onto the
+    // destination, destroying whatever lives there. remove() reads the flag
+    // for the same reason.
+    const std::string source = canonicalPath(oldPath);
+    auto it = files.find(source);
+    if (it == files.end() || !it->second.exists) {
         return false;
     }
-    files[canonicalPath(newPath)] = std::move(it->second);
-    files.erase(it);
+    const std::string target = canonicalPath(newPath);
+    if (!canHoldFileAt(target)) {
+        return false; // the root, an existing directory, or under a file
+    }
+    // One object under two spellings ("a.txt" and "/a.txt") is the same key,
+    // and moving an entry onto itself would leave it unspecified and then
+    // erase it. std::rename succeeds and leaves the file alone; so does this.
+    if (source == target) {
+        return true;
+    }
+    // Erased by key rather than by iterator: inserting the destination can
+    // rehash, and a rehash invalidates every iterator into the map.
+    files[target] = std::move(it->second);
+    files.erase(source);
     return true;
 }
 
@@ -620,11 +705,26 @@ bool InMemoryFileSystem::copy(const char* oldPath, const char* newPath)
     if (oldPath == nullptr || newPath == nullptr) {
         return false;
     }
-    auto it = files.find(canonicalPath(oldPath));
-    if (it == files.end()) {
+    const std::string source = canonicalPath(oldPath);
+    auto it = files.find(source);
+    if (it == files.end() || !it->second.exists) {
+        return false; // a removed source is not a source; see rename()
+    }
+    const std::string target = canonicalPath(newPath);
+    if (!canHoldFileAt(target)) {
         return false;
     }
-    files[canonicalPath(newPath)] = it->second;
+    // Copying an object onto itself leaves it as it was. The simulator, which
+    // opens the destination for truncation before reading the source, empties
+    // the file instead; that is worth not reproducing.
+    if (source == target) {
+        return true;
+    }
+    // Read into a local before the insert: growing the map can rehash, and
+    // reaching back through `it` afterwards would be reaching through an
+    // invalidated iterator.
+    InMemoryFileEntry entry = it->second;
+    files[target] = std::move(entry);
     return true;
 }
 
@@ -662,9 +762,18 @@ bool InMemoryFileSystem::objectInfo(const char* path, ObjectInfo& item) const
     return true;
 }
 
-void InMemoryFileSystem::seedFile(const std::string& path, std::string content)
+bool InMemoryFileSystem::seedFile(const std::string& path, std::string content)
 {
-    files[canonicalPath(path)] = InMemoryFileEntry{ std::move(content), true };
+    // Seeding is subject to the same rule a write-open is: a name already held
+    // by a directory, or living under a file, cannot also be a file. Without
+    // this a test could seed the fake into a state the device cannot reach and
+    // then write assertions against it.
+    const std::string target = canonicalPath(path);
+    if (!canHoldFileAt(target)) {
+        return false;
+    }
+    files[target] = InMemoryFileEntry{ std::move(content), true };
+    return true;
 }
 
 std::string InMemoryFileSystem::readFile(const std::string& path) const

--- a/Tests/Host/support/KernelTestDoubles.hpp
+++ b/Tests/Host/support/KernelTestDoubles.hpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <functional>
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -87,23 +88,85 @@ public:
 
     private:
         InMemoryFileSystem& mFs;
-        std::string mPath;
+        std::string mGivenPath; ///< As handed to the ctor/setPath, for getPath().
+        std::string mPath;      ///< Canonical form, used for lookups.
         bool mOpen = false;
         bool mWriteMode = false;
         size_t mPos = 0;
     };
 
-    class EmptyDirectory : public SDK::Interface::IDirectory {
+    /**
+     * @brief Enumerating directory over the flat `files` map plus any
+     *        explicitly created directories.
+     *
+     * A path's parent is everything before its last '/', so "Activity/a.fit"
+     * is a child of "Activity" and "a.fit" is a child of the root. Directories
+     * are those created through mkdir()/create() *and* those implied by a
+     * file's path: seeding "a/b/c.txt" makes "a" and "a/b" enumerable
+     * without any mkdir call. Both files and subdirectories are reported,
+     * with @c isDir set accordingly.
+     *
+     * Enumeration order is **sorted by name**, and deliberately so: the
+     * backing store is an unordered_map, so anything depending on
+     * enumeration order (picking the "first" matching entry, say) would
+     * otherwise be a coin flip from run to run. Real FAT enumerates in
+     * directory-entry order, so do not read this ordering as a guarantee
+     * the device makes -- it is a guarantee the *fake* makes, so that tests
+     * are reproducible.
+     *
+     * A listing never reports the same name twice, whatever mix of spellings
+     * and implied/explicit directories produced it.
+     *
+     * readNext() is a cursor over a snapshot taken at open() (and re-taken
+     * on an explicit reset=true, matching POSIX rewinddir, which refreshes
+     * the stream to the directory's current state). Entries added mid-scan
+     * do not retroactively appear until such a rewind.
+     *
+     * Known divergences from a real backend, all of them deliberate. Check
+     * these before writing a test that leans on one:
+     *
+     *  - **An implied directory is only as durable as its contents.** A
+     *    directory that exists solely because a file lives under it stops
+     *    existing when that file is removed; a real filesystem would keep
+     *    the now-empty directory. mkdir() it if a test needs it to outlive
+     *    its children.
+     *  - **Leading and trailing slashes are not significant.** "/a.txt",
+     *    "a.txt" and "a.txt/" all name one object, at every depth, for
+     *    enumeration *and* for lookup alike. This is what lets a test seed
+     *    "/App.uapp" and have code that scans "/" and opens "/" + name find
+     *    it. A real filesystem would treat a trailing slash as requiring a
+     *    directory.
+     *  - **No "." / ".." resolution.** Both are ordinary path segments, so
+     *    "a/b" and "a/./b" are different places.
+     *  - **Directory rename is not modelled** -- it returns false rather
+     *    than pretending to succeed. The simulator's Directory::rename()
+     *    does work, so do not read a false here as device behaviour.
+     *  - **No hidden/system attributes of their own.** isHidden is derived
+     *    from a leading '.' in the name, as the POSIX simulator does;
+     *    isSystem is always false.
+     *  - **A name longer than ObjectInfo::name cannot round-trip.** It is
+     *    reported clipped, exactly as the simulator's safe_strcpy would clip
+     *    it. Real backends cap a single name well below that, so seeding one
+     *    that long is a test-authoring mistake rather than a case to model.
+     */
+    class InMemoryDirectory : public SDK::Interface::IDirectory {
     public:
-        explicit EmptyDirectory(std::string path);
-        ~EmptyDirectory() override = default;
+        InMemoryDirectory(InMemoryFileSystem& fs, std::string path);
+        ~InMemoryDirectory() override = default;
 
+        /// Repoints the handle. Any scan in progress is invalidated: the
+        /// handle closes and must be open()ed again before readNext().
         void setPath(const char* path) override;
         const char* getPath() const override;
         bool exist() const override;
+        /// Always false: directory rename is not modelled by this fake.
         bool rename(const char* newPath) override;
         bool remove() override;
 
+        /// Creates this one directory, and fails when its parent is missing
+        /// or a file already occupies the name -- as the simulator's
+        /// non-recursive ::mkdir does. Use IFileSystem::mkdir() for the
+        /// parents-too behaviour.
         bool create() override;
         bool open() override;
         bool isOpen() const override;
@@ -111,23 +174,76 @@ public:
         bool close() override;
 
     private:
-        std::string mPath;
-        bool mOpen = false;
+        struct Entry {
+            std::string name;
+            bool        isDir = false;
+            size_t      size  = 0;
+        };
+
+        InMemoryFileSystem& mFs;
+        std::string         mGivenPath; ///< As handed to the ctor/setPath, for getPath().
+        std::string         mPath;      ///< Canonical form, used for lookups.
+        bool                mOpen = false;
+        std::vector<Entry>  mEntries; // sorted, snapshotted at open()/reset
+        size_t              mCursor = 0;
+
+        void snapshot();
     };
 
+    /// Creates the directory and any missing parents; true if it already
+    /// existed, per IFileSystem::mkdir. False for a null path, and false when
+    /// a file already occupies the name.
     bool mkdir(const char* path) override;
     std::unique_ptr<SDK::Interface::IFile> file(const char* path) override;
     std::unique_ptr<SDK::Interface::IDirectory> dir(const char* path) override;
+    /// True for an existing file OR directory: IFileSystem::exist() asks
+    /// about filesystem objects, not files specifically. An empty path names
+    /// nothing and is false, as stat("") is; "/" is the root and is true.
     bool exist(const char* path) const override;
+    /// Removes an existing file, or an existing and empty directory.
+    ///
+    /// Returns false when there is nothing there to remove, a path removed
+    /// earlier included: such an entry lingers in the backing map with its
+    /// `exists` flag cleared, and reporting success for work not done is a
+    /// bad thing to write assertions against.
     bool remove(const char* path) override;
     bool rename(const char* oldPath, const char* newPath) override;
     bool copy(const char* oldPath, const char* newPath) override;
+    /// Populates @p item for an existing file or directory. @c name receives
+    /// the leaf name, not the path handed in -- the same convention the
+    /// simulator's objectInfo() and every readNext() follow.
     bool objectInfo(const char* path, ObjectInfo& item) const override;
 
     void seedFile(const std::string& path, std::string content);
     std::string readFile(const std::string& path) const;
 
+    /// Canonical lookup key for @p path: leading and trailing '/' stripped,
+    /// so "/a/b", "a/b" and "a/b/" are one object and the root is "". This is
+    /// applied at every entry point, which is what makes a name returned by a
+    /// listing openable as "/" + name. No "." / ".." resolution.
+    static std::string canonicalPath(const std::string& path);
+    /// Directory of a canonical @p path: everything before its last '/', or
+    /// "" (the root) when it has none.
+    static std::string parentOf(const std::string& path);
+    /// Final path segment of @p path.
+    static std::string baseNameOf(const std::string& path);
+
+    /// True when an existing file sits at @p canonical (already canonicalised).
+    bool fileExistsAt(const std::string& canonical) const;
+    /// True when @p path is the root, was created via mkdir(), or is implied
+    /// by an existing file living under it.
+    bool directoryExists(const std::string& path) const;
+
+    /// Keyed by canonicalPath(); seedFile() and every IFileSystem entry point
+    /// canonicalise before touching this, so a test that reaches in directly
+    /// must use the canonical spelling ("d/a.txt", never "/d/a.txt").
     std::unordered_map<std::string, InMemoryFileEntry> files;
+
+    /// Directories created explicitly through mkdir()/IDirectory::create(),
+    /// canonicalised and without the root. Directories implied by a file's
+    /// path are NOT stored here -- see directoryExists(), which considers
+    /// both.
+    std::set<std::string> directories;
 
     // -- Test instrumentation -------------------------------------------------
     /// Number of successful flush() calls, keyed by file path.

--- a/Tests/Host/support/KernelTestDoubles.hpp
+++ b/Tests/Host/support/KernelTestDoubles.hpp
@@ -69,6 +69,9 @@ public:
         InMemoryFile(InMemoryFileSystem& fs, std::string path);
         ~InMemoryFile() override = default;
 
+        /// Repoints the handle. Any open file is closed first: the new path is
+        /// a different file, so an open handle's bookkeeping cannot follow it
+        /// the way rename()'s does.
         void setPath(const char* path) override;
         const char* getPath() const override;
         bool exist() const override;
@@ -115,7 +118,10 @@ public:
      * are reproducible.
      *
      * A listing never reports the same name twice, whatever mix of spellings
-     * and implied/explicit directories produced it.
+     * and implied/explicit directories produced it. Deduplication happens on
+     * the stored name, before it is clipped to ObjectInfo::name, so two names
+     * that differ only past that capacity are the one case that comes back as
+     * a pair of identical entries -- see the name-length note below.
      *
      * readNext() is a cursor over a snapshot taken at open() (and re-taken
      * on an explicit reset=true, matching POSIX rewinddir, which refreshes
@@ -135,7 +141,12 @@ public:
      *    enumeration *and* for lookup alike. This is what lets a test seed
      *    "/App.uapp" and have code that scans "/" and opens "/" + name find
      *    it. A real filesystem would treat a trailing slash as requiring a
-     *    directory.
+     *    directory. (Repeated *interior* separators are not a divergence:
+     *    "a//b" and "a/b" are one object here as they are on POSIX and FatFs.)
+     *  - **A file may be created under a directory that does not exist.**
+     *    Writing "a/b/c.txt" implies "a" and "a/b" rather than failing with
+     *    ENOENT, which is the flip side of implied directories above. mkdir()
+     *    the parents first if a test needs the ENOENT branch.
      *  - **No "." / ".." resolution.** Both are ordinary path segments, so
      *    "a/b" and "a/./b" are different places.
      *  - **Directory rename is not modelled** -- it returns false rather
@@ -165,8 +176,10 @@ public:
 
         /// Creates this one directory, and fails when its parent is missing
         /// or a file already occupies the name -- as the simulator's
-        /// non-recursive ::mkdir does. Use IFileSystem::mkdir() for the
-        /// parents-too behaviour.
+        /// non-recursive ::mkdir does. True when the directory already
+        /// exists, the root included: ::mkdir gives EEXIST there, which the
+        /// simulator reports as success once the target is confirmed to be a
+        /// directory. Use IFileSystem::mkdir() for the parents-too behaviour.
         bool create() override;
         bool open() override;
         bool isOpen() const override;
@@ -198,29 +211,47 @@ public:
     std::unique_ptr<SDK::Interface::IDirectory> dir(const char* path) override;
     /// True for an existing file OR directory: IFileSystem::exist() asks
     /// about filesystem objects, not files specifically. An empty path names
-    /// nothing and is false, as stat("") is; "/" is the root and is true.
+    /// nothing and is false, as FatFs f_stat("") is FR_INVALID_NAME; "/" is
+    /// the root and is true. (The simulator says true for "" because it
+    /// prepends a sandbox root; the device is what this models.)
     bool exist(const char* path) const override;
     /// Removes an existing file, or an existing and empty directory.
     ///
     /// Returns false when there is nothing there to remove, a path removed
     /// earlier included: such an entry lingers in the backing map with its
     /// `exists` flag cleared, and reporting success for work not done is a
-    /// bad thing to write assertions against.
+    /// bad thing to write assertions against. rename() and copy() read the
+    /// same flag.
     bool remove(const char* path) override;
+    /// Moves an existing file. False when the source is missing OR was removed
+    /// earlier (a tombstone is not a source -- the same rule remove() follows),
+    /// and false when the destination cannot hold a file: the root, an
+    /// existing directory, or a path under a file. An existing *file* at the
+    /// destination is overwritten, as std::rename does. Source and destination
+    /// that canonicalise to one key succeed and leave the file alone, also as
+    /// std::rename does.
     bool rename(const char* oldPath, const char* newPath) override;
+    /// As rename(), but leaves the source in place. Copying an object onto
+    /// itself leaves it as it was; the simulator empties it instead, opening
+    /// the destination for truncation before reading the source.
     bool copy(const char* oldPath, const char* newPath) override;
     /// Populates @p item for an existing file or directory. @c name receives
     /// the leaf name, not the path handed in -- the same convention the
     /// simulator's objectInfo() and every readNext() follow.
     bool objectInfo(const char* path, ObjectInfo& item) const override;
 
-    void seedFile(const std::string& path, std::string content);
+    /// Places a file directly, bypassing IFile. False -- and nothing is
+    /// recorded -- when the name cannot hold a file (see canHoldFileAt), so a
+    /// test cannot seed the fake into a state the device cannot reach.
+    bool seedFile(const std::string& path, std::string content);
     std::string readFile(const std::string& path) const;
 
-    /// Canonical lookup key for @p path: leading and trailing '/' stripped,
-    /// so "/a/b", "a/b" and "a/b/" are one object and the root is "". This is
-    /// applied at every entry point, which is what makes a name returned by a
-    /// listing openable as "/" + name. No "." / ".." resolution.
+    /// Canonical lookup key for @p path: runs of '/' collapsed to one, leading
+    /// and trailing ones dropped, so "/a/b", "a/b", "a//b" and "a/b/" are one
+    /// object and the root is "". This is applied at every entry point, which
+    /// is what makes a name returned by a listing openable as "/" + name --
+    /// for any name short enough to survive ObjectInfo::name; a clipped one
+    /// names nothing. No "." / ".." resolution.
     static std::string canonicalPath(const std::string& path);
     /// Directory of a canonical @p path: everything before its last '/', or
     /// "" (the root) when it has none.
@@ -230,6 +261,11 @@ public:
 
     /// True when an existing file sits at @p canonical (already canonicalised).
     bool fileExistsAt(const std::string& canonical) const;
+    /// True when a file may occupy @p canonical: it is not the root, no
+    /// directory already holds the name (EISDIR), and no ancestor is a file
+    /// (ENOTDIR). The mirror of mkdir()'s chain walk -- between them, one name
+    /// can never be both a file and a directory.
+    bool canHoldFileAt(const std::string& canonical) const;
     /// True when @p path is the root, was created via mkdir(), or is implied
     /// by an existing file living under it.
     bool directoryExists(const std::string& path) const;

--- a/Tests/Host/support/KernelTestDoubles_test.cpp
+++ b/Tests/Host/support/KernelTestDoubles_test.cpp
@@ -49,6 +49,61 @@ TEST(InMemoryFileSystem, RenameWhileClosedLeavesHandleCountsAlone)
     EXPECT_EQ(fs.openHandles["dir/b.txt"], 0u);
 }
 
+// rename() may keep a handle open, being the same file under a new name, and
+// migrates the count with it. setPath() names a DIFFERENT file, so it closes
+// instead: a handle carried across the change would release a bucket it never
+// took, underflowing size_t and taking the leak instrumentation with it.
+TEST(InMemoryFileSystem, SetPathOnAnOpenFileClosesItRatherThanRetargeting)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("a.txt", "AAA");
+    fs.seedFile("b.txt", "BBB");
+
+    auto f = fs.file("a.txt");
+    ASSERT_TRUE(f->open(/*wMode=*/true));
+    ASSERT_EQ(fs.openHandles["a.txt"], 1u);
+
+    f->setPath("b.txt");
+    EXPECT_FALSE(f->isOpen()) << "the handle no longer refers to what it opened";
+    EXPECT_EQ(fs.openHandles["a.txt"], 0u) << "the old bucket is released, not stranded";
+    EXPECT_EQ(fs.openHandles["b.txt"], 0u) << "and the new path was never opened";
+
+    size_t bw = 0;
+    EXPECT_FALSE(f->write("ZZ", 2, bw)) << "a closed handle cannot write";
+    EXPECT_EQ(fs.readFile("b.txt"), "BBB") << "b.txt must not be touched";
+    EXPECT_EQ(fs.readFile("a.txt"), "AAA");
+
+    EXPECT_FALSE(f->close()) << "already closed";
+    EXPECT_EQ(fs.openHandles["b.txt"], 0u) << "no size_t underflow to SIZE_MAX";
+    EXPECT_EQ(fs.openHandles["a.txt"], 0u);
+}
+
+// close() reports whether it closed something, so EXPECT_TRUE(h->close())
+// has a failing mode: a handle never opened, or one naming a path that does
+// not exist, answers false. The simulator's File::close() and
+// Directory::close() both do.
+TEST(InMemoryFileSystem, ClosingWhatWasNeverOpenedFails)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("a.txt", "x");
+    ASSERT_TRUE(fs.mkdir("d"));
+
+    EXPECT_FALSE(fs.file("a.txt")->close()) << "never opened";
+    EXPECT_FALSE(fs.file("never-seeded.txt")->close());
+    EXPECT_FALSE(fs.dir("d")->close()) << "never opened";
+    EXPECT_FALSE(fs.dir("does-not-exist")->close());
+
+    auto f = fs.file("a.txt");
+    ASSERT_TRUE(f->open());
+    EXPECT_TRUE(f->close()) << "an open handle closes";
+    EXPECT_FALSE(f->close()) << "but not twice";
+
+    auto d = fs.dir("d");
+    ASSERT_TRUE(d->open());
+    EXPECT_TRUE(d->close());
+    EXPECT_FALSE(d->close()) << "but not twice";
+}
+
 // The closeGate fault hook fails an open handle's close() and leaves it open
 // (FatFs f_close semantics: a failed sync keeps the FIL valid and its
 // lock-table entry held); once the gate is lifted, close() drains normally.
@@ -202,6 +257,54 @@ TEST(InMemoryDirectory, AListedNameIsOpenableAsSlashPlusName)
     EXPECT_EQ(fs.readFile(path), contents);
 }
 
+// Both listing guarantees -- a name joins back onto its parent, and a name
+// appears once -- hold up to ObjectInfo::name and stop there. A name too long
+// to survive the copy comes back clipped, so it names nothing, and two names
+// differing only past that capacity come back as one repeated entry. Pinned
+// because the documented rules are stated with this boundary attached, and a
+// test that scans and then opens is the pattern that meets it.
+TEST(InMemoryDirectory, ListingGuaranteesStopAtTheNameCapacity)
+{
+    constexpr size_t kCap = SDK::Interface::IFileSystem::skMaxPathLen; // incl. NUL
+    InMemoryFileSystem fs;
+    const std::string fits(kCap - 1, 'a');       // 255: survives intact
+    const std::string tooLong(kCap, 'b');        // 256: clipped to 255
+    fs.seedFile("d/" + fits, "x");
+    fs.seedFile("d/" + tooLong, "y");
+
+    auto dir = fs.dir("d");
+    ASSERT_TRUE(dir->open());
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    size_t joinable = 0;
+    size_t clipped = 0;
+    while (dir->readNext(item)) {
+        const std::string name(item.name);
+        EXPECT_EQ(name.size(), kCap - 1) << "both clip or fit at the capacity";
+        if (fs.exist(("d/" + name).c_str())) {
+            ++joinable;
+        } else {
+            ++clipped;
+        }
+    }
+    ASSERT_TRUE(dir->close());
+    EXPECT_EQ(joinable, 1u) << "the name that fits joins back onto its parent";
+    EXPECT_EQ(clipped, 1u) << "the one that does not names nothing";
+
+    // Two names differing only past the capacity: one name, reported twice.
+    InMemoryFileSystem twins;
+    twins.seedFile("d/" + std::string(kCap, 'c') + "ONE", "1");
+    twins.seedFile("d/" + std::string(kCap, 'c') + "TWO", "2");
+    auto twinDir = twins.dir("d");
+    ASSERT_TRUE(twinDir->open());
+    std::vector<std::string> seen;
+    while (twinDir->readNext(item)) {
+        seen.push_back(item.name);
+    }
+    ASSERT_TRUE(twinDir->close());
+    ASSERT_EQ(seen.size(), 2u);
+    EXPECT_EQ(seen[0], seen[1]) << "the one case where a listing repeats a name";
+}
+
 // However a name is arrived at -- two spellings of one file, an implied
 // directory that is also an explicit one -- a listing reports it once.
 TEST(InMemoryDirectory, AListingNeverReportsTheSameNameTwice)
@@ -271,6 +374,11 @@ TEST(InMemoryDirectory, CreateDoesNotInventParents)
 
     EXPECT_TRUE(fs.mkdir("p/q/r")) << "IFileSystem::mkdir does create parents";
     EXPECT_TRUE(fs.exist("p/q"));
+
+    // The root is already a directory, which ::mkdir reports as EEXIST and
+    // the simulator turns into success once it confirms the target is one.
+    EXPECT_TRUE(fs.dir("/")->create()) << "the root exists, so creating it succeeds";
+    EXPECT_TRUE(fs.dir("")->create());
 }
 
 // A name cannot be a file and a directory at once, so mkdir() over an
@@ -288,6 +396,54 @@ TEST(InMemoryDirectory, MkdirRefusesANameAFileAlreadyHolds)
 
     // The parents mkdir() creates are subject to the same rule.
     EXPECT_FALSE(fs.mkdir("a.txt/below"));
+}
+
+// One name is never both a file and a directory, whichever way it is
+// approached: mkdir() and create() refuse a name a file holds, a write-open
+// gets EISDIR on the real backend, and seedFile() cannot plant what IFile
+// cannot open.
+TEST(InMemoryDirectory, AFileCannotShadowADirectory)
+{
+    InMemoryFileSystem fs;
+    ASSERT_TRUE(fs.mkdir("d"));
+    fs.seedFile("d/inner.txt", "child");
+
+    EXPECT_FALSE(fs.file("d")->open(/*wMode=*/true)) << "EISDIR: \"d\" is a directory";
+    EXPECT_FALSE(fs.seedFile("d", "clobber")) << "and seeding cannot do it either";
+
+    // The directory is intact, and nothing reports "d" as a file.
+    EXPECT_EQ(listDir(fs, "/"), (std::vector<std::string>{ "d/" }));
+    EXPECT_EQ(listDir(fs, "d"), (std::vector<std::string>{ "inner.txt" }));
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    ASSERT_TRUE(fs.objectInfo("d", item));
+    EXPECT_TRUE(item.isDir);
+
+    // An implied directory holds the name just as firmly as an mkdir'd one.
+    InMemoryFileSystem implied;
+    implied.seedFile("imp/child.txt", "x");
+    EXPECT_FALSE(implied.file("imp")->open(/*wMode=*/true));
+    EXPECT_FALSE(implied.seedFile("imp", "clobber"));
+
+    // ...and the root is a directory too.
+    EXPECT_FALSE(fs.file("/")->open(/*wMode=*/true));
+}
+
+// The mirror image: nothing may live under a name a file already holds.
+// mkdir() and create() already refuse; a write-open and seedFile() must too.
+TEST(InMemoryDirectory, NothingCanBeCreatedUnderAFile)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("a.txt", "x");
+
+    EXPECT_FALSE(fs.mkdir("a.txt/below"));
+    EXPECT_FALSE(fs.dir("a.txt/below")->create());
+    EXPECT_FALSE(fs.file("a.txt/below/deep.bin")->open(/*wMode=*/true))
+        << "ENOTDIR: an ancestor is a file";
+    EXPECT_FALSE(fs.seedFile("a.txt/below/deep.bin", "y"));
+
+    EXPECT_EQ(fs.readFile("a.txt"), "x") << "the file is untouched";
+    EXPECT_FALSE(fs.dir("a.txt")->open()) << "and never became a directory";
+    EXPECT_EQ(listDir(fs, "/"), (std::vector<std::string>{ "a.txt" }));
 }
 
 // Repointing an open handle must not keep serving the old directory's entries
@@ -324,7 +480,8 @@ TEST(InMemoryFileSystem, ExistSeparatesTheRootFromAnEmptyPath)
 {
     InMemoryFileSystem fs;
     EXPECT_TRUE(fs.exist("/")) << "the root exists even when nothing is seeded";
-    EXPECT_FALSE(fs.exist("")) << "an empty path names nothing, as stat(\"\") does not";
+    EXPECT_FALSE(fs.exist(""))
+        << "an empty path names nothing, as FatFs f_stat(\"\") is FR_INVALID_NAME";
     EXPECT_FALSE(fs.exist(nullptr));
 
     SDK::Interface::IFileSystem::ObjectInfo item{};
@@ -483,6 +640,144 @@ TEST(InMemoryFileSystem, RemoveReportsWhetherAnythingWasRemoved)
     EXPECT_FALSE(fs.remove("a.txt")) << "already gone";
     EXPECT_FALSE(fs.remove("never-existed.txt"));
     EXPECT_FALSE(fs.remove(nullptr));
+}
+
+// rename()/copy() follow the same rule remove() does: an entry whose `exists`
+// flag is cleared is a tombstone, not a file. Taking one as a source would
+// claim success for work not done, and would carry the tombstone onto the
+// destination, destroying a live file there.
+TEST(InMemoryFileSystem, RenameAndCopyRefuseAnAlreadyRemovedSource)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("gone.txt", "x");
+    fs.seedFile("live.txt", "IMPORTANT");
+    ASSERT_TRUE(fs.remove("gone.txt"));
+
+    EXPECT_FALSE(fs.rename("gone.txt", "live.txt")) << "a tombstone is not a source";
+    EXPECT_EQ(fs.readFile("live.txt"), "IMPORTANT") << "and must not destroy the destination";
+    EXPECT_TRUE(fs.exist("live.txt"));
+
+    EXPECT_FALSE(fs.copy("gone.txt", "c.txt"));
+    EXPECT_FALSE(fs.exist("c.txt")) << "no tombstone propagated to the destination";
+
+    // A path that never existed at all already failed; the two now agree.
+    EXPECT_FALSE(fs.rename("never.txt", "x.txt"));
+    EXPECT_FALSE(fs.copy("never.txt", "x.txt"));
+}
+
+// A destination that cannot hold a file is refused rather than silently
+// swallowing the source: the root, an existing directory, or a path under a
+// file. An existing *file* is still overwritten, as std::rename does.
+TEST(InMemoryFileSystem, RenameAndCopyRefuseADestinationThatCannotHoldAFile)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("src.txt", "SRC");
+    ASSERT_TRUE(fs.mkdir("d"));
+    fs.seedFile("blocker.txt", "B");
+
+    EXPECT_FALSE(fs.rename("src.txt", "")) << "the root is not a file destination";
+    EXPECT_FALSE(fs.rename("src.txt", "/"));
+    EXPECT_FALSE(fs.rename("src.txt", "d")) << "an existing directory";
+    EXPECT_FALSE(fs.rename("src.txt", "blocker.txt/under")) << "under a file";
+    EXPECT_FALSE(fs.copy("src.txt", ""));
+    EXPECT_FALSE(fs.copy("src.txt", "d"));
+    EXPECT_EQ(fs.readFile("src.txt"), "SRC") << "every refusal left the source alone";
+    EXPECT_EQ(listDir(fs, "/"),
+              (std::vector<std::string>{ "blocker.txt", "d/", "src.txt" }));
+
+    // Overwriting a plain file is still allowed, as std::rename does it.
+    EXPECT_TRUE(fs.rename("src.txt", "blocker.txt"));
+    EXPECT_EQ(fs.readFile("blocker.txt"), "SRC");
+    EXPECT_FALSE(fs.exist("src.txt"));
+}
+
+// Source and destination can name one object through two spellings, which is
+// one key in the backing map. Moving an entry onto itself would leave it
+// unspecified and then erase it, so the call would report success and take
+// the file with it. std::rename succeeds and leaves the file alone.
+TEST(InMemoryFileSystem, RenamingAFileOntoItselfKeepsIt)
+{
+    for (const char* destination : { "a.txt", "/a.txt", "a.txt/", "/a.txt/" }) {
+        InMemoryFileSystem fs;
+        fs.seedFile("a.txt", "PAYLOAD");
+
+        EXPECT_TRUE(fs.rename("a.txt", destination)) << destination;
+        EXPECT_TRUE(fs.exist("a.txt")) << destination << " must not remove the file";
+        EXPECT_EQ(fs.readFile("a.txt"), "PAYLOAD") << destination;
+        EXPECT_EQ(listDir(fs, "/"), (std::vector<std::string>{ "a.txt" })) << destination;
+    }
+
+    // The same key reached through a collapsed separator, at depth.
+    InMemoryFileSystem nested;
+    nested.seedFile("d/a.txt", "PAYLOAD");
+    EXPECT_TRUE(nested.rename("d/a.txt", "d//a.txt"));
+    EXPECT_EQ(nested.readFile("d/a.txt"), "PAYLOAD");
+
+    // copy() has the same one-key case. Its contract is that the file is left
+    // as it was -- deliberately unlike the simulator, which truncates the
+    // destination before reading the source and so empties it. Nothing about
+    // the current implementation can violate this, since a self-copy-assign
+    // is a no-op; the assertion is here to pin the contract, not to guard it.
+    InMemoryFileSystem copied;
+    copied.seedFile("a.txt", "PAYLOAD");
+    EXPECT_TRUE(copied.copy("a.txt", "/a.txt"));
+    EXPECT_EQ(copied.readFile("a.txt"), "PAYLOAD");
+}
+
+// Renaming across a rehash of the backing map. Padded to the load-factor
+// boundary so the destination insert is guaranteed to rehash rather than
+// merely able to.
+//
+// This pins the outcome, not the mechanism. rename() must erase by key rather
+// than through the iterator that found the source, because a rehash
+// invalidates every iterator into an unordered_map -- but libstdc++ keeps its
+// nodes across a rehash, so erasing through the stale iterator still happens
+// to work here and no assertion below can see the difference. The rule is
+// upheld by construction; treat this as documentation of the path, not as its
+// guard.
+TEST(InMemoryFileSystem, RenameMovesAnEntryAcrossARehash)
+{
+    InMemoryFileSystem fs;
+    fs.files.max_load_factor(1.0f);
+    fs.seedFile("src.txt", "PAYLOAD");
+    for (size_t n = 0; fs.files.size() < fs.files.bucket_count(); ++n) {
+        fs.seedFile("pad/f" + std::to_string(n) + ".txt", "x");
+    }
+    const size_t bucketsBefore = fs.files.bucket_count();
+    const size_t sizeBefore = fs.files.size();
+
+    ASSERT_TRUE(fs.rename("src.txt", "dst.txt"));
+
+    EXPECT_GT(fs.files.bucket_count(), bucketsBefore) << "the insert did rehash";
+    EXPECT_EQ(fs.files.size(), sizeBefore) << "one entry moved, none gained or lost";
+    EXPECT_EQ(fs.readFile("dst.txt"), "PAYLOAD");
+    EXPECT_FALSE(fs.exist("src.txt"));
+}
+
+// Repeated interior separators are not a divergence: "a//b" and "a/b" are one
+// object, as on POSIX and FatFs. Splitting them apart would leave an empty
+// path segment, which enumerates as an entry with no name -- something no
+// backend can show, and which no caller could join back onto its parent.
+TEST(InMemoryDirectory, RepeatedSeparatorsCollapse)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("a//b.txt", "x");
+
+    EXPECT_TRUE(fs.exist("a//b.txt"));
+    EXPECT_TRUE(fs.exist("a/b.txt")) << "one object, however it is spelled";
+    EXPECT_EQ(fs.readFile("a/b.txt"), "x");
+    EXPECT_EQ(listDir(fs, "a"), (std::vector<std::string>{ "b.txt" }));
+    EXPECT_EQ(listDir(fs, "a//"), (std::vector<std::string>{ "b.txt" }));
+
+    // Every listed name still joins back onto its parent.
+    auto dir = fs.dir("a");
+    ASSERT_TRUE(dir->open());
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    ASSERT_TRUE(dir->readNext(item));
+    ASSERT_TRUE(dir->close());
+    ASSERT_GT(std::strlen(item.name), 0u) << "a listing never yields an empty name";
+    const std::string joined = std::string("a/") + item.name;
+    EXPECT_TRUE(fs.exist(joined.c_str())) << joined;
 }
 
 TEST(InMemoryDirectory, RemovedFilesDisappearFromListings)

--- a/Tests/Host/support/KernelTestDoubles_test.cpp
+++ b/Tests/Host/support/KernelTestDoubles_test.cpp
@@ -10,6 +10,10 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
+#include <string>
+#include <vector>
+
 using SDK::TestSupport::InMemoryFileSystem;
 
 // The open-handle instrumentation is keyed by path: an IFile::rename() on an
@@ -64,4 +68,493 @@ TEST(InMemoryFileSystem, CloseGateFailsCloseAndKeepsHandleOpen)
     fs.closeGate = nullptr;
     EXPECT_TRUE(f->close());
     EXPECT_EQ(fs.openHandles["dir/a.txt"], 0u);
+}
+
+// ---------------------------------------------------------------------------
+// InMemoryDirectory
+//
+// The fake's directory enumeration is what makes SDK code that scans a
+// directory testable at all (VariantConfig's sandbox-root scan being the
+// first such caller). These pin its contract, since suites that build on it
+// can only be as trustworthy as it is.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Collect a whole directory listing as "name" / "name/" (trailing slash
+/// marking a subdirectory), in enumeration order.
+std::vector<std::string> listDir(InMemoryFileSystem& fs, const char* path)
+{
+    std::vector<std::string> out;
+    auto dir = fs.dir(path);
+    if (!dir || !dir->open()) {
+        return out;
+    }
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    while (dir->readNext(item)) {
+        out.push_back(std::string(item.name) + (item.isDir ? "/" : ""));
+    }
+    dir->close();
+    return out;
+}
+
+} // namespace
+
+TEST(InMemoryDirectory, ListsDirectChildrenOnly)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("Activity/morning.fit", "aaa");
+    fs.seedFile("Activity/evening.fit", "bb");
+    fs.seedFile("Settings/app.json", "x");
+
+    EXPECT_EQ(listDir(fs, "Activity"),
+              (std::vector<std::string>{ "evening.fit", "morning.fit" }));
+}
+
+TEST(InMemoryDirectory, ReportsSubdirectoriesWithIsDirSet)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("root/file.txt", "x");
+    fs.seedFile("root/nested/deep.txt", "y");
+
+    // "nested" is implied by its child's path -- no mkdir needed -- and must
+    // come back flagged as a directory, not as a file.
+    EXPECT_EQ(listDir(fs, "root"), (std::vector<std::string>{ "file.txt", "nested/" }));
+}
+
+TEST(InMemoryDirectory, DoesNotFlattenNestedFilesIntoTheParent)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("a/b/c/deep.txt", "x");
+
+    EXPECT_EQ(listDir(fs, "a"), (std::vector<std::string>{ "b/" }));
+    EXPECT_EQ(listDir(fs, "a/b"), (std::vector<std::string>{ "c/" }));
+    EXPECT_EQ(listDir(fs, "a/b/c"), (std::vector<std::string>{ "deep.txt" }));
+}
+
+TEST(InMemoryDirectory, RootCanBeSpelledSlashOrEmpty)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("a.txt", "x");
+    fs.seedFile("sub/inner.txt", "z");
+
+    const std::vector<std::string> expected{ "a.txt", "sub/" };
+    EXPECT_EQ(listDir(fs, "/"), expected);
+    EXPECT_EQ(listDir(fs, ""), expected) << R"("" and "/" name the same place)";
+}
+
+// A documented divergence, pinned so it is a known quantity: leading and
+// trailing slashes are not significant, so a file seeded as "/x" is the same
+// object as one seeded as "x". This is deliberate -- it is what lets a test
+// seed "/App.uapp" and have production code that scans "/" find it -- but a
+// real filesystem would not do this.
+TEST(InMemoryDirectory, AbsoluteAndRelativeSpellingsShareTheRoot)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("/leading-slash.txt", "x");
+    fs.seedFile("bare.txt", "y");
+
+    EXPECT_EQ(listDir(fs, "/"),
+              (std::vector<std::string>{ "bare.txt", "leading-slash.txt" }));
+}
+
+// The spellings are interchangeable at every depth, not just at the root, and
+// for lookup as well as for enumeration. Both halves matter: a scanner that
+// lists a directory and then opens "/" + name is the pattern this fake exists
+// to support, and it only works if the two agree.
+TEST(InMemoryDirectory, SpellingsAgreeAtEveryDepthAndForLookupToo)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("/App/nested.txt", "x");
+
+    const std::vector<std::string> expected{ "nested.txt" };
+    EXPECT_EQ(listDir(fs, "App"), expected);
+    EXPECT_EQ(listDir(fs, "/App"), expected);
+    EXPECT_EQ(listDir(fs, "/App/"), expected);
+
+    EXPECT_TRUE(fs.exist("App/nested.txt"));
+    EXPECT_TRUE(fs.exist("/App/nested.txt"));
+    EXPECT_EQ(fs.readFile("App/nested.txt"), "x");
+}
+
+// A name handed back by a listing must be openable as "/" + name. Every
+// directory-scanning caller does exactly this, so if the two disagree a test
+// gets a scan that finds names it cannot then read -- silently, because the
+// open just fails and the caller takes its not-found branch.
+TEST(InMemoryDirectory, AListedNameIsOpenableAsSlashPlusName)
+{
+    InMemoryFileSystem fs;
+    const std::string contents = "seeded without a leading slash";
+    fs.seedFile("bare.txt", contents);
+
+    auto dir = fs.dir("/");
+    ASSERT_TRUE(dir->open());
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    ASSERT_TRUE(dir->readNext(item));
+    dir->close();
+
+    const std::string path = std::string("/") + item.name;
+    EXPECT_TRUE(fs.exist(path.c_str())) << path << " came out of a listing of \"/\"";
+    auto file = fs.file(path.c_str());
+    ASSERT_TRUE(file && file->open());
+    EXPECT_EQ(file->size(), contents.size());
+    file->close();
+    EXPECT_EQ(fs.readFile(path), contents);
+}
+
+// However a name is arrived at -- two spellings of one file, an implied
+// directory that is also an explicit one -- a listing reports it once.
+TEST(InMemoryDirectory, AListingNeverReportsTheSameNameTwice)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("/App/a.txt", "x");
+    fs.seedFile("App/b.txt", "y");   // the same directory, spelled differently
+    ASSERT_TRUE(fs.mkdir("App"));    // and now explicitly created as well
+    fs.seedFile("/solo.txt", "z");
+    fs.seedFile("solo.txt", "z");    // the same file, spelled differently
+
+    EXPECT_EQ(listDir(fs, "/"), (std::vector<std::string>{ "App/", "solo.txt" }));
+    EXPECT_EQ(listDir(fs, "App"), (std::vector<std::string>{ "a.txt", "b.txt" }));
+}
+
+// A documented divergence: "." and ".." are ordinary segments, so a path
+// spelled through one is a different place rather than the same one.
+TEST(InMemoryDirectory, DotSegmentsAreNotResolved)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("a/b/c.txt", "x");
+
+    EXPECT_FALSE(fs.exist("a/./b/c.txt"));
+    EXPECT_FALSE(fs.exist("a/b/../b/c.txt"));
+
+    // They are stored and enumerated as literal names, not resolved away.
+    fs.seedFile("a/./d.txt", "y");
+    EXPECT_EQ(listDir(fs, "a"), (std::vector<std::string>{ "./", "b/" }));
+    EXPECT_EQ(listDir(fs, "a/."), (std::vector<std::string>{ "d.txt" }));
+}
+
+// isHidden is derived from a leading '.' the way the POSIX simulator derives
+// it, rather than being left permanently false.
+TEST(InMemoryDirectory, DotPrefixedNamesReportAsHidden)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("d/.hidden", "x");
+    fs.seedFile("d/plain.txt", "y");
+
+    auto dir = fs.dir("d");
+    ASSERT_TRUE(dir->open());
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    ASSERT_TRUE(dir->readNext(item));
+    EXPECT_STREQ(item.name, ".hidden");
+    EXPECT_TRUE(item.isHidden);
+    ASSERT_TRUE(dir->readNext(item));
+    EXPECT_STREQ(item.name, "plain.txt");
+    EXPECT_FALSE(item.isHidden);
+    dir->close();
+
+    ASSERT_TRUE(fs.objectInfo("d/.hidden", item));
+    EXPECT_TRUE(item.isHidden);
+}
+
+// IDirectory::create() is the simulator's single non-recursive ::mkdir, not
+// IFileSystem::mkdir's parents-too behaviour. Pinned because the two sit next
+// to each other and quietly differ.
+TEST(InMemoryDirectory, CreateDoesNotInventParents)
+{
+    InMemoryFileSystem fs;
+    EXPECT_FALSE(fs.dir("x/y/z")->create()) << "parent \"x/y\" does not exist";
+    EXPECT_FALSE(fs.exist("x"));
+
+    EXPECT_TRUE(fs.dir("x")->create());
+    EXPECT_TRUE(fs.dir("x/y")->create());
+    EXPECT_TRUE(fs.exist("x/y"));
+
+    EXPECT_TRUE(fs.mkdir("p/q/r")) << "IFileSystem::mkdir does create parents";
+    EXPECT_TRUE(fs.exist("p/q"));
+}
+
+// A name cannot be a file and a directory at once, so mkdir() over an
+// existing file fails rather than recording both and leaving the fake able to
+// show a listing the device cannot produce.
+TEST(InMemoryDirectory, MkdirRefusesANameAFileAlreadyHolds)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("a.txt", "x");
+
+    EXPECT_FALSE(fs.mkdir("a.txt"));
+    EXPECT_FALSE(fs.dir("a.txt")->create());
+    EXPECT_FALSE(fs.dir("a.txt")->open()) << "still just a file";
+    EXPECT_EQ(listDir(fs, "/"), (std::vector<std::string>{ "a.txt" }));
+
+    // The parents mkdir() creates are subject to the same rule.
+    EXPECT_FALSE(fs.mkdir("a.txt/below"));
+}
+
+// Repointing an open handle must not keep serving the old directory's entries
+// under the new path -- a combination no real backend can show.
+TEST(InMemoryDirectory, SetPathInvalidatesAScanInProgress)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("one/a.txt", "x");
+    fs.seedFile("two/b.txt", "y");
+
+    auto dir = fs.dir("one");
+    ASSERT_TRUE(dir->open());
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    ASSERT_TRUE(dir->readNext(item));
+    ASSERT_STREQ(item.name, "a.txt");
+
+    dir->setPath("two");
+    EXPECT_FALSE(dir->isOpen()) << "the handle no longer refers to what it opened";
+    EXPECT_FALSE(dir->readNext(item)) << "and must not keep serving \"one\"";
+
+    ASSERT_TRUE(dir->open());
+    ASSERT_TRUE(dir->readNext(item));
+    EXPECT_STREQ(item.name, "b.txt");
+}
+
+TEST(InMemoryFileSystem, ANullPathYieldsNoHandleForEitherKind)
+{
+    InMemoryFileSystem fs;
+    EXPECT_EQ(fs.file(nullptr), nullptr);
+    EXPECT_EQ(fs.dir(nullptr), nullptr) << "dir() and file() agree on a null path";
+}
+
+TEST(InMemoryFileSystem, ExistSeparatesTheRootFromAnEmptyPath)
+{
+    InMemoryFileSystem fs;
+    EXPECT_TRUE(fs.exist("/")) << "the root exists even when nothing is seeded";
+    EXPECT_FALSE(fs.exist("")) << "an empty path names nothing, as stat(\"\") does not";
+    EXPECT_FALSE(fs.exist(nullptr));
+
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    EXPECT_FALSE(fs.objectInfo("", item));
+    EXPECT_FALSE(fs.objectInfo(nullptr, item));
+}
+
+TEST(InMemoryDirectory, EnumerationOrderIsSortedAndReproducible)
+{
+    // The backing store is an unordered_map, so without an explicit ordering
+    // anything that picks the "first" matching entry would be a coin flip.
+    InMemoryFileSystem fs;
+    for (const char* name : { "zulu", "alpha", "mike", "bravo", "yankee" }) {
+        fs.seedFile(std::string("d/") + name + ".txt", "x");
+    }
+
+    const std::vector<std::string> expected{
+        "alpha.txt", "bravo.txt", "mike.txt", "yankee.txt", "zulu.txt"
+    };
+    EXPECT_EQ(listDir(fs, "d"), expected);
+    EXPECT_EQ(listDir(fs, "d"), expected) << "and stable across repeated listings";
+}
+
+TEST(InMemoryDirectory, ReportsEntrySize)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("d/a.txt", std::string(1234, 'x'));
+
+    auto dir = fs.dir("d");
+    ASSERT_TRUE(dir->open());
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    ASSERT_TRUE(dir->readNext(item));
+    EXPECT_STREQ(item.name, "a.txt");
+    EXPECT_EQ(item.size, 1234u);
+    EXPECT_FALSE(item.isDir);
+}
+
+TEST(InMemoryDirectory, MkdirMakesAnEmptyDirectoryEnumerable)
+{
+    InMemoryFileSystem fs;
+    ASSERT_TRUE(fs.mkdir("Debug"));
+
+    EXPECT_TRUE(fs.exist("Debug"));
+    EXPECT_EQ(listDir(fs, "/"), (std::vector<std::string>{ "Debug/" }));
+
+    // Assert the open, then the emptiness. An empty listDir() result would
+    // also be what a failed open() produces, so on its own it cannot tell an
+    // empty directory from an unopenable one.
+    auto created = fs.dir("Debug");
+    ASSERT_TRUE(created->open()) << "an mkdir'd directory must be openable";
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    EXPECT_FALSE(created->readNext(item)) << "created, but empty";
+    EXPECT_TRUE(created->close());
+}
+
+TEST(InMemoryDirectory, MkdirCreatesParentsAndSucceedsWhenAlreadyPresent)
+{
+    InMemoryFileSystem fs;
+    ASSERT_TRUE(fs.mkdir("a/b/c"));
+    EXPECT_TRUE(fs.exist("a"));
+    EXPECT_TRUE(fs.exist("a/b"));
+    EXPECT_TRUE(fs.exist("a/b/c"));
+
+    // IFileSystem::mkdir is documented as succeeding when the directory
+    // already exists, which callers rely on to "just ensure it's there".
+    EXPECT_TRUE(fs.mkdir("a/b/c"));
+
+    EXPECT_FALSE(fs.mkdir(nullptr));
+}
+
+TEST(InMemoryDirectory, OpeningAMissingDirectoryFails)
+{
+    InMemoryFileSystem fs;
+    auto dir = fs.dir("nope");
+    ASSERT_TRUE(dir != nullptr);
+    EXPECT_FALSE(dir->open());
+    EXPECT_FALSE(dir->exist());
+}
+
+TEST(InMemoryDirectory, ReadNextOnAClosedDirectoryFails)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("d/a.txt", "x");
+
+    auto dir = fs.dir("d");
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    EXPECT_FALSE(dir->readNext(item)) << "not open yet";
+
+    ASSERT_TRUE(dir->open());
+    ASSERT_TRUE(dir->readNext(item));
+    ASSERT_TRUE(dir->close());
+    EXPECT_FALSE(dir->readNext(item)) << "closed again";
+}
+
+// IDirectory::readNext(reset=true) rewinds WITHOUT reading: item is left
+// untouched and the return value reflects only whether the rewind worked.
+// Easy to get subtly wrong, and a caller that assumed otherwise would read a
+// phantom first entry.
+TEST(InMemoryDirectory, ResetRewindsWithoutConsumingAnEntry)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("d/a.txt", "x");
+    fs.seedFile("d/b.txt", "y");
+
+    auto dir = fs.dir("d");
+    ASSERT_TRUE(dir->open());
+
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    ASSERT_TRUE(dir->readNext(item));
+    ASSERT_STREQ(item.name, "a.txt");
+    ASSERT_TRUE(dir->readNext(item));
+    ASSERT_STREQ(item.name, "b.txt");
+    EXPECT_FALSE(dir->readNext(item)) << "exhausted";
+
+    SDK::Interface::IFileSystem::ObjectInfo untouched{};
+    std::strncpy(untouched.name, "SENTINEL", sizeof(untouched.name) - 1);
+    EXPECT_TRUE(dir->readNext(untouched, /*reset=*/true));
+    EXPECT_STREQ(untouched.name, "SENTINEL") << "a reset must not write into item";
+
+    ASSERT_TRUE(dir->readNext(item));
+    EXPECT_STREQ(item.name, "a.txt") << "and the cursor is back at the start";
+}
+
+TEST(InMemoryDirectory, SnapshotIsTakenAtOpenNotLive)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("d/a.txt", "x");
+
+    auto dir = fs.dir("d");
+    ASSERT_TRUE(dir->open());
+
+    fs.seedFile("d/b.txt", "y"); // appears after the scan began
+
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    ASSERT_TRUE(dir->readNext(item));
+    EXPECT_STREQ(item.name, "a.txt");
+    EXPECT_FALSE(dir->readNext(item)) << "mid-scan additions do not appear";
+
+    // ...but an explicit rewind re-snapshots, so they do then.
+    ASSERT_TRUE(dir->readNext(item, /*reset=*/true));
+    ASSERT_TRUE(dir->readNext(item));
+    ASSERT_TRUE(dir->readNext(item));
+    EXPECT_STREQ(item.name, "b.txt");
+}
+
+// remove() reports whether it actually removed something. A path removed
+// earlier still has an entry in the backing map, with its `exists` flag
+// cleared, and answering from the entry's presence alone would claim success
+// for work not done -- a bad thing to write assertions against.
+TEST(InMemoryFileSystem, RemoveReportsWhetherAnythingWasRemoved)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("a.txt", "x");
+
+    EXPECT_TRUE(fs.remove("a.txt"));
+    EXPECT_FALSE(fs.remove("a.txt")) << "already gone";
+    EXPECT_FALSE(fs.remove("never-existed.txt"));
+    EXPECT_FALSE(fs.remove(nullptr));
+}
+
+TEST(InMemoryDirectory, RemovedFilesDisappearFromListings)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("d/a.txt", "x");
+    fs.seedFile("d/b.txt", "y");
+
+    ASSERT_TRUE(fs.remove("d/a.txt"));
+    EXPECT_EQ(listDir(fs, "d"), (std::vector<std::string>{ "b.txt" }));
+}
+
+TEST(InMemoryDirectory, RemoveRefusesANonEmptyDirectory)
+{
+    InMemoryFileSystem fs;
+    ASSERT_TRUE(fs.mkdir("d"));
+    fs.seedFile("d/a.txt", "x");
+
+    EXPECT_FALSE(fs.remove("d")) << "FatFs f_unlink refuses a populated directory";
+
+    ASSERT_TRUE(fs.remove("d/a.txt"));
+    EXPECT_TRUE(fs.remove("d")) << "empty now";
+    EXPECT_FALSE(fs.exist("d"));
+}
+
+// A documented divergence from a real filesystem, pinned so it stays a known
+// quantity rather than a surprise: a directory that exists only because a
+// file lives under it goes away with that file. mkdir() is what makes one
+// outlive its children.
+TEST(InMemoryDirectory, AnImpliedDirectoryVanishesWithItsLastChild)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("implied/a.txt", "x");
+    ASSERT_TRUE(fs.exist("implied"));
+
+    ASSERT_TRUE(fs.remove("implied/a.txt"));
+    EXPECT_FALSE(fs.exist("implied"))
+        << "implied directories are only as durable as their contents";
+
+    InMemoryFileSystem explicitFs;
+    ASSERT_TRUE(explicitFs.mkdir("kept"));
+    explicitFs.seedFile("kept/a.txt", "x");
+    ASSERT_TRUE(explicitFs.remove("kept/a.txt"));
+    EXPECT_TRUE(explicitFs.exist("kept")) << "an mkdir'd directory survives";
+}
+
+TEST(InMemoryDirectory, ObjectInfoDistinguishesDirectoriesFromFiles)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("d/a.txt", "hello");
+
+    SDK::Interface::IFileSystem::ObjectInfo item{};
+    ASSERT_TRUE(fs.objectInfo("d/a.txt", item));
+    EXPECT_FALSE(item.isDir);
+    EXPECT_EQ(item.size, 5u);
+    // The leaf name, not the path asked about: the same convention the
+    // simulator's objectInfo() and readNext() both use.
+    EXPECT_STREQ(item.name, "a.txt");
+
+    ASSERT_TRUE(fs.objectInfo("d", item));
+    EXPECT_TRUE(item.isDir);
+    EXPECT_STREQ(item.name, "d");
+
+    EXPECT_FALSE(fs.objectInfo("d/missing.txt", item));
+}
+
+TEST(InMemoryDirectory, DirectoryRenameFailsRatherThanLying)
+{
+    InMemoryFileSystem fs;
+    fs.seedFile("d/a.txt", "x");
+
+    auto dir = fs.dir("d");
+    EXPECT_FALSE(dir->rename("e")) << "not modelled; must not silently orphan contents";
+    EXPECT_TRUE(fs.exist("d/a.txt"));
 }

--- a/Tests/Host/variant/VariantConfig_test.cpp
+++ b/Tests/Host/variant/VariantConfig_test.cpp
@@ -1,0 +1,380 @@
+/**
+ ******************************************************************************
+ * @file    VariantConfig_test.cpp
+ * @brief   Tests for the app-side variant reader's sandbox-root scan.
+ ******************************************************************************
+ *
+ * Config's constructor picks which .uapp in the sandbox root defines this
+ * app's identity, following the mixed-directory determinism rules: any real
+ * (non-alias) .uapp means the app runs as its classic self; otherwise the
+ * first alias-flagged .uapp is the variant; and an unreadable candidate
+ * counts as real. Those rules decide what a user sees their activity called,
+ * so they are worth pinning.
+ *
+ * Every case here goes through a real directory scan, which InMemoryFileSystem
+ * only supports now that it enumerates seeded files. Because most of these
+ * expect the app to run classic -- the same answer a scan that saw nothing
+ * would give -- they assert the scan is live before trusting its verdict.
+ *
+ ******************************************************************************
+ */
+
+#include "SDK/Variant/VariantConfig.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "KernelTestDoubles.hpp"
+
+using SDK::TestSupport::KernelFixture;
+
+namespace {
+
+// On-disk .uapp layout, mirroring the private constants in VariantConfig.cpp.
+// Duplicated deliberately: if the reader's offsets drift from the format,
+// these tests should fail rather than drift along with it.
+constexpr uint32_t kFlagVariantAlias = 0x40;
+constexpr size_t   kFlagsOffset      = 20;
+constexpr size_t   kPayloadOffset    = 48 + 3600 + 900;
+constexpr size_t   kConfigSizeOffset = kPayloadOffset + 17;
+constexpr size_t   kConfigOffset     = kPayloadOffset + 32;
+constexpr uint32_t kPayloadVersion   = 1;
+
+void putU32(std::string& blob, size_t offset, uint32_t value)
+{
+    if (blob.size() < offset + sizeof(value)) {
+        blob.resize(offset + sizeof(value), '\0');
+    }
+    for (size_t i = 0; i < sizeof(value); ++i) {
+        blob[offset + i] = static_cast<char>((value >> (8 * i)) & 0xFFu);
+    }
+}
+
+/// A real (non-alias) app binary: flags without the alias bit, no payload.
+std::string realUapp()
+{
+    std::string blob(kPayloadOffset, '\0');
+    putU32(blob, kFlagsOffset, 0);
+    return blob;
+}
+
+/// An alias .uapp carrying @p json as its embedded variant config.
+std::string aliasUapp(const std::string& json, uint32_t payloadVersion = kPayloadVersion)
+{
+    std::string blob(kConfigOffset + json.size(), '\0');
+    putU32(blob, kFlagsOffset, kFlagVariantAlias);
+    putU32(blob, kPayloadOffset, payloadVersion);
+    putU32(blob, kConfigSizeOffset, static_cast<uint32_t>(json.size()));
+    std::memcpy(&blob[kConfigOffset], json.data(), json.size());
+    return blob;
+}
+
+const char* kWalkJson =
+    R"({"schema":1,"name":"Walk","fit":{"sport":11,"subSport":0},)"
+    R"("features":{"showCadence":true,"autoLapMetres":1000}})";
+
+/// Assert that the sandbox root really enumerates @p expected.
+///
+/// Every "runs classic" expectation below is also exactly what a scan that
+/// saw *nothing* produces, so on its own such a test cannot tell a correct
+/// decision from a dead enumerator or a path the fake failed to resolve.
+/// Calling this first makes each one prove its fixture is live.
+void expectSandboxLists(SDK::TestSupport::InMemoryFileSystem& fs,
+                        const std::vector<std::string>& expected)
+{
+    std::vector<std::string> seen;
+    auto dir = fs.dir("/");
+    ASSERT_TRUE(dir && dir->open()) << "the sandbox root must be scannable";
+    SDK::Interface::IFileSystem::ObjectInfo item {};
+    while (dir->readNext(item)) {
+        seen.push_back(item.name);
+    }
+    dir->close();
+    EXPECT_EQ(seen, expected) << "the scan under test did not see what was seeded";
+}
+
+} // namespace
+
+// --------------------------------------------------------------------------
+// Identity selection
+// --------------------------------------------------------------------------
+
+TEST(VariantConfig, EmptySandboxIsTheClassicApp)
+{
+    KernelFixture fixture;
+    expectSandboxLists(fixture.fileSystem, {});
+
+    SDK::Variant::Config config(fixture.kernel);
+    EXPECT_FALSE(config.isVariant());
+    EXPECT_STREQ(config.name("Run"), "Run");
+}
+
+TEST(VariantConfig, ASingleRealAppIsTheClassicApp)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("/Running.uapp", realUapp());
+    expectSandboxLists(fixture.fileSystem, { "Running.uapp" });
+
+    SDK::Variant::Config config(fixture.kernel);
+    EXPECT_FALSE(config.isVariant());
+    EXPECT_STREQ(config.name("Run"), "Run");
+}
+
+TEST(VariantConfig, ASingleAliasBecomesTheVariant)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("/Walk.uapp", aliasUapp(kWalkJson));
+
+    SDK::Variant::Config config(fixture.kernel);
+    ASSERT_TRUE(config.isVariant());
+    EXPECT_STREQ(config.name("Run"), "Walk");
+    EXPECT_EQ(config.fitSport(1), 11);
+    EXPECT_EQ(config.fitSubSport(7), 0);
+    EXPECT_TRUE(config.featureBool("showCadence", false));
+    EXPECT_EQ(config.featureU32("autoLapMetres", 0u), 1000u);
+}
+
+// The mixed-directory rule: a real binary alongside an alias means the app is
+// its classic self, whichever order the scan happens to encounter them in.
+// Both orderings are exercised because the scan short-circuits on the first
+// real app it sees, so only one of them takes the early-break path.
+TEST(VariantConfig, ARealAppAlongsideAnAliasWinsWhenItSortsFirst)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("/AAA-real.uapp", realUapp());
+    fixture.fileSystem.seedFile("/ZZZ-alias.uapp", aliasUapp(kWalkJson));
+    expectSandboxLists(fixture.fileSystem, { "AAA-real.uapp", "ZZZ-alias.uapp" });
+
+    SDK::Variant::Config config(fixture.kernel);
+    EXPECT_FALSE(config.isVariant());
+    EXPECT_STREQ(config.name("Run"), "Run");
+}
+
+TEST(VariantConfig, ARealAppAlongsideAnAliasWinsWhenItSortsLast)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("/AAA-alias.uapp", aliasUapp(kWalkJson));
+    fixture.fileSystem.seedFile("/ZZZ-real.uapp", realUapp());
+    expectSandboxLists(fixture.fileSystem, { "AAA-alias.uapp", "ZZZ-real.uapp" });
+
+    SDK::Variant::Config config(fixture.kernel);
+    EXPECT_FALSE(config.isVariant())
+        << "a real app discovered after an alias must still win";
+    EXPECT_STREQ(config.name("Run"), "Run");
+}
+
+// Degenerate case -- a sandbox root is meant to hold exactly one .uapp -- but
+// the reader still has to be deterministic about it rather than picking at
+// random. Note this pins "the first alias *encountered*": the fake enumerates
+// alphabetically so the test is reproducible, while the device enumerates in
+// directory-entry order. Do not read this as an alphabetical guarantee.
+TEST(VariantConfig, TheFirstAliasWinsWhenThereAreSeveral)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile(
+        "/AAA.uapp", aliasUapp(R"({"schema":1,"name":"First","fit":{"sport":11}})"));
+    fixture.fileSystem.seedFile(
+        "/ZZZ.uapp", aliasUapp(R"({"schema":1,"name":"Second","fit":{"sport":12}})"));
+
+    SDK::Variant::Config config(fixture.kernel);
+    ASSERT_TRUE(config.isVariant());
+    EXPECT_STREQ(config.name("Run"), "First");
+}
+
+TEST(VariantConfig, AnUnreadableCandidateCountsAsARealApp)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("/AAA.uapp", aliasUapp(kWalkJson));
+    // Shorter than kFlagsOffset + sizeof(u32), so the flags read fails
+    // outright rather than returning whatever bytes happen to be there.
+    fixture.fileSystem.seedFile("/truncated.uapp", "short");
+    expectSandboxLists(fixture.fileSystem, { "AAA.uapp", "truncated.uapp" });
+
+    SDK::Variant::Config config(fixture.kernel);
+    EXPECT_FALSE(config.isVariant())
+        << "a .uapp whose flags cannot be read must not be assumed to be an alias";
+}
+
+// A name too long to form a candidate path must be declined, not silently
+// truncated -- because a truncated path can name a *different, existing*
+// file, and adopting that file's identity is the failure this guards.
+//
+// The two seeds below are sized so that clipping the long one's path yields
+// exactly the short one's path:
+//   long  "/xxx...x.uapp"  (256 chars -- one over the buffer)
+//   clip  "/xxx...x.uap"   (255 chars -- what snprintf would leave behind)
+// The decoy ends ".uap", so it is never a candidate in its own right; the
+// only way to reach it is through the truncation being fixed here.
+TEST(VariantConfig, ANameTooLongToFormAPathIsNotSilentlyTruncatedIntoAnotherApp)
+{
+    KernelFixture fixture;
+
+    // ObjectInfo::name carries 255 chars plus a terminator, so a name of
+    // exactly 255 survives the listing with its extension intact and
+    // overflows only once the scan prepends its '/'.
+    const std::string longName = std::string(250, 'x') + ".uapp";
+    ASSERT_EQ(longName.size(), 255u);
+    const std::string longPath = "/" + longName;
+    const std::string clippedPath = longPath.substr(0, 255);
+    ASSERT_EQ(clippedPath, "/" + std::string(250, 'x') + ".uap");
+
+    const std::string wrongAlias =
+        aliasUapp(R"({"schema":1,"name":"WRONG","fit":{"sport":99}})");
+
+    // Positive control. "Runs classic" is also what a scan that saw nothing
+    // produces, so the decline below only means something once the same
+    // payload is known to be adoptable when its name is one character
+    // shorter -- isolating length as the sole reason for the difference.
+    // (The decoy itself ends ".uap" and so is never a candidate in its own
+    // right; truncation is the only way anything reaches it.)
+    {
+        const std::string longestThatFits = "/" + std::string(249, 'x') + ".uapp";
+        ASSERT_EQ(longestThatFits.size(), 255u);
+        KernelFixture control;
+        control.fileSystem.seedFile(longestThatFits, wrongAlias);
+        SDK::Variant::Config adopted(control.kernel);
+        ASSERT_TRUE(adopted.isVariant()) << "a name that fits must still be adopted";
+        ASSERT_STREQ(adopted.name("Run"), "WRONG");
+    }
+
+    fixture.fileSystem.seedFile(longPath, aliasUapp(kWalkJson));
+    fixture.fileSystem.seedFile(clippedPath, wrongAlias);
+    // Both are really there and really enumerated: the clipped one sorts
+    // first, being a prefix of the other.
+    expectSandboxLists(fixture.fileSystem,
+                       { clippedPath.substr(1), longPath.substr(1) });
+
+    SDK::Variant::Config config(fixture.kernel);
+
+    EXPECT_FALSE(config.isVariant())
+        << "an unformable path must be declined, not clipped into a neighbour";
+    EXPECT_STRNE(config.name("Run"), "WRONG")
+        << "the app must never adopt the identity of a file it reached by truncation";
+    EXPECT_STREQ(config.name("Run"), "Run");
+}
+
+// A declined name must not inherit the path of the entry scanned before it.
+// If a candidate buffer outlived the iteration that filled it, an entry whose
+// own path cannot be formed would be read against whatever the last entry
+// left behind, and the app would adopt that one -- the same wrong-identity
+// failure a truncated path causes, by another route.
+//
+// "AAA.uapp" sorts first and is a perfectly good alias, so it is exactly what
+// a stale buffer would be holding. The overlong entry that follows must still
+// force the classic path.
+TEST(VariantConfig, ADeclinedNameDoesNotInheritThePreviousCandidatesPath)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile(
+        "/AAA.uapp", aliasUapp(R"({"schema":1,"name":"STALE","fit":{"sport":11}})"));
+
+    // 255 chars: survives the listing intact, overflows only once '/' is
+    // prepended -- so its own path is never formed.
+    const std::string longName = std::string(250, 'z') + ".uapp";
+    ASSERT_EQ(longName.size(), 255u);
+    fixture.fileSystem.seedFile("/" + longName, aliasUapp(kWalkJson));
+    expectSandboxLists(fixture.fileSystem, { "AAA.uapp", longName });
+
+    SDK::Variant::Config config(fixture.kernel);
+    EXPECT_FALSE(config.isVariant())
+        << "an unformable candidate counts as a real app, whatever preceded it";
+    EXPECT_STRNE(config.name("Run"), "STALE")
+        << "the scan must not re-read the previous entry's path";
+    EXPECT_STREQ(config.name("Run"), "Run");
+}
+
+TEST(VariantConfig, NonUappFilesAreIgnored)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("/Walk.uapp", aliasUapp(kWalkJson));
+    fixture.fileSystem.seedFile("/notes.txt", "irrelevant");
+    fixture.fileSystem.seedFile("/uapp", "no extension, just the word");
+    fixture.fileSystem.seedFile("/.uapp", "extension but no name");
+
+    SDK::Variant::Config config(fixture.kernel);
+    ASSERT_TRUE(config.isVariant());
+    EXPECT_STREQ(config.name("Run"), "Walk");
+}
+
+// The scan skips directory entries. Reaching this guard at all needs a fake
+// that really enumerates, since the loop body is where it lives.
+TEST(VariantConfig, SubdirectoriesAreSkipped)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("/Walk.uapp", aliasUapp(kWalkJson));
+    // A directory that ends in ".uapp" would pass the extension test, so the
+    // isDir guard is the only thing stopping it being opened as a candidate.
+    fixture.fileSystem.seedFile("/Stale.uapp/leftover.bin", "junk");
+
+    SDK::Variant::Config config(fixture.kernel);
+    ASSERT_TRUE(config.isVariant());
+    EXPECT_STREQ(config.name("Run"), "Walk")
+        << "a directory named like an app must not be treated as one";
+}
+
+// --------------------------------------------------------------------------
+// Never brick a launch: a malformed alias falls back to classic defaults.
+// --------------------------------------------------------------------------
+
+TEST(VariantConfig, AnUnknownPayloadVersionFallsBackToClassic)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("/Walk.uapp", aliasUapp(kWalkJson, kPayloadVersion + 1));
+    expectSandboxLists(fixture.fileSystem, { "Walk.uapp" });
+
+    SDK::Variant::Config config(fixture.kernel);
+    EXPECT_FALSE(config.isVariant()) << "a shipped binary must not guess at a newer layout";
+    EXPECT_STREQ(config.name("Run"), "Run");
+}
+
+TEST(VariantConfig, AnUnknownSchemaFallsBackToClassic)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("/Walk.uapp", aliasUapp(R"({"schema":99,"name":"Future"})"));
+    expectSandboxLists(fixture.fileSystem, { "Walk.uapp" });
+
+    SDK::Variant::Config config(fixture.kernel);
+    EXPECT_FALSE(config.isVariant());
+    EXPECT_STREQ(config.name("Run"), "Run");
+}
+
+TEST(VariantConfig, MalformedJsonFallsBackToClassic)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("/Walk.uapp", aliasUapp(R"({"schema":1,"name":)"));
+    expectSandboxLists(fixture.fileSystem, { "Walk.uapp" });
+
+    SDK::Variant::Config config(fixture.kernel);
+    EXPECT_FALSE(config.isVariant());
+    EXPECT_STREQ(config.name("Run"), "Run");
+}
+
+TEST(VariantConfig, AZeroLengthConfigFallsBackToClassic)
+{
+    KernelFixture fixture;
+    fixture.fileSystem.seedFile("/Walk.uapp", aliasUapp(""));
+    expectSandboxLists(fixture.fileSystem, { "Walk.uapp" });
+
+    SDK::Variant::Config config(fixture.kernel);
+    EXPECT_FALSE(config.isVariant());
+}
+
+TEST(VariantConfig, MissingOptionalKeysLeaveCallerDefaultsInPlace)
+{
+    KernelFixture fixture;
+    // A valid variant that names itself but says nothing about FIT identity
+    // or features.
+    fixture.fileSystem.seedFile("/Hike.uapp", aliasUapp(R"({"schema":1,"name":"Hike"})"));
+
+    SDK::Variant::Config config(fixture.kernel);
+    ASSERT_TRUE(config.isVariant());
+    EXPECT_STREQ(config.name("Run"), "Hike");
+    EXPECT_EQ(config.fitSport(1), 1) << "unspecified sport keeps the family default";
+    EXPECT_EQ(config.fitSubSport(7), 7);
+    EXPECT_TRUE(config.featureBool("missing", true));
+    EXPECT_EQ(config.featureU32("missing", 42u), 42u);
+}


### PR DESCRIPTION
## The bug

`VariantConfig` can adopt the wrong app's identity. Its sandbox-root scan builds each candidate path from an enumerated name, and `ObjectInfo::name` is as wide as a whole path, so `"/" + name` need not fit in one. A clipped path can name a different, existing file, and if that file is an alias the app comes up calling itself by another activity's name and logging that activity's FIT sport.

Measuring the name before building the path fixes it, and also clears the `-Wformat-truncation` this line has been earning at the `-Os -Wall` every app build uses. Recovering the length from `snprintf`'s return would have fixed the behaviour but not the diagnostic, which is about the call rather than what the caller does with its result.

## Why the test double is in here

The bug was invisible because nothing could reach it. `InMemoryFileSystem`'s `IDirectory` is a stub whose `readNext()` always returns false, so code that walks a directory has its loop body unreachable from a test, and this scan is the only such caller in the tree. It had no host tests at all.

Making the fake enumerate is the first commit. The second is the one worth arguing about: once tests can lean on the fake, its habit of permitting states the device cannot reach stops being harmless. It would let one name be both a file and a directory, accept a removed path as a rename source and destroy whatever sat at the destination while returning true, and never fail a `close()`. Every refusal added there has a test that fails when the refusal is dropped, and each was settled by running the same call sequence against the simulator's `Mock::FileSystem` rather than against assumptions about what POSIX says.

## Risk

One change reaches past the fake's own tests: `close()` now returns false for a handle that is not open, matching the simulator and FatFs. Fourteen production sites propagate that return, and none currently reaches `close()` on an unopened handle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application discovery for long, unreadable, malformed, mixed, and conflicting entries.
  - Prevented stale or incomplete paths from being opened.
  - Added more deterministic handling for aliases, files, directories, and path variations.

- **Documentation**
  - Added guidance for testing directory scanning and filesystem behavior.

- **Tests**
  - Expanded coverage for application discovery, path handling, and in-memory filesystem operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

