### PR TITLE
perf(cycling): halve auto-pause dwell, validated on nine rides

### DIFF
--- a/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
@@ -107,19 +107,34 @@ private:
     // confirmation is what separates that from braking hard for a junction and
     // rolling through, which the arming sample alone cannot do -- the traces
     // are identical until the rider either puts a foot down or accelerates
-    // away. On the analysed ride the fast path pauses 3 s earlier than the
-    // dwell on every stop from speed, and never fires on a steady slow rider:
-    // their speed is low but not falling. Replaying at 1.5 m/s^2 gave results
-    // identical to 2.5, which means that ride has no samples in the
-    // discriminating band -- so 2.5 is chosen as the conservative end of an
-    // interval this data cannot separate, not as a measured optimum.
+    // away. Across the analysed rides the fast path pauses ~3 s earlier than
+    // the dwell on a stop from speed, and never fires on a steady slow rider:
+    // their speed is low but not falling.
+    //
+    // 2.5 m/s^2 is not a measured optimum. Replaying at 1.5 gave identical
+    // results, i.e. the rides hold no samples in the discriminating band, so
+    // this is the conservative end of an interval the data cannot separate.
+    // Note it is well above any deceleration a rider sustains through
+    // successive samples (0.73 m/s^2 was the highest seen below the ceiling on
+    // a clean ride); what clears it is the single-sample collapse at the top of
+    // a firm stop, which is the signature being matched.
     //
     // Deceleration is measured against the last sample whose value actually
     // changed, aged in ticks. GPS speed repeats its previous value when the
     // receiver has no fresh RMC (30 % of samples on the analysed ride), and a
     // naive first difference would read those as zero deceleration and then as
     // a huge one on the update that follows.
-    static constexpr float   skAutoPauseBrakingCeilMps   = 2.0f;  // only below this, m/s (7.2 km/h)
+    // The ceiling is set by where a stop-from-speed actually lands, not by a
+    // notion of "slow". At 1 Hz the GPS speed on a firm stop does not descend
+    // through every value -- it collapses from riding speed to somewhere around
+    // 8-9 km/h in a single sample, then decays. Five clean rides across three
+    // riders (22 stops, ~3 h) put those landings on both sides of 7.2 km/h, so
+    // a 2.0 m/s ceiling armed on one stop in three hours: dead weight. At
+    // 3.0 m/s it arms on the stops that genuinely collapse from speed -- the
+    // case the field report singled out -- gaining about 3 s on each, for one
+    // extra spurious pause per 3 h. 4.0 m/s doubled the spurious count for no
+    // further gain.
+    static constexpr float   skAutoPauseBrakingCeilMps   = 3.0f;  // only below this, m/s (10.8 km/h)
     static constexpr float   skAutoPauseBrakingDecelMps2 = 2.5f;  // and shedding at least this
     static constexpr uint8_t skAutoPauseDecelMaxAgeTicks = 3;     // beyond this the reference is too old to trust
 

--- a/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
@@ -63,7 +63,15 @@ private:
     //
     // GPS speed arrives at 1 Hz (skSamplePeriod) and updateAutoPause() runs on
     // the same 1 Hz track tick, so a dwell in seconds is also a dwell in
-    // samples. Three samples tolerates a single glitched or dropped reading.
+    // samples.
+    //
+    // The dwell was 3 samples originally. A 33 min ride with 13 auto-pauses,
+    // replayed through the detector offline, put the whole measured latency in
+    // the dwell -- 3.2 s on average from the sample that crossed the threshold
+    // to the pause, and nothing else. Two samples takes 1 s off every stop. The
+    // cost measured on that ride was a single spurious pause, on a genuine
+    // 1.5 km/h crawl the rider then rode out of; it lasts until the resume
+    // dwell clears and loses no distance at that speed.
     //
     // The detector reads the mGpsSpeed* latches rather than keeping its own
     // copy of the sample: those already carry the isSpeedValid() gate it needs.
@@ -81,8 +89,39 @@ private:
     // logged at INFO so a serial capture can confirm or correct them.
     static constexpr float   skAutoPauseSpeedMps  = 0.5f;  // pause below, m/s (1.8 km/h)
     static constexpr float   skAutoResumeSpeedMps = 0.9f;  // resume above, m/s (3.2 km/h)
-    static constexpr uint8_t skAutoPauseDwellSec  = 3;     // sustained ticks either way
+    static constexpr uint8_t skAutoPauseDwellSec  = 2;     // sustained samples either way
     static constexpr uint8_t skAutoPauseStaleSec  = 5;     // hold state after this long with no valid speed
+
+    // -- Braking fast path ----------------------------------------------------
+    //
+    // The dwell alone cannot help a rider who stops from speed: they spend the
+    // approach above skAutoPauseSpeedMps, so the detector cannot start counting
+    // until they are almost stationary. On the analysed ride the stops from
+    // 17-27 km/h were the slowest to register, which matches the field report
+    // that stopping from a higher speed took longer.
+    //
+    // So: arm on a sample that is BOTH slow and braking hard, and pause when
+    // the next sample is still slow. A rider under 7 km/h shedding more than
+    // skAutoPauseBrakingDecelMps2, and still slow a second later, is stopping;
+    // waiting for them to coast out the last 5 km/h adds nothing. The
+    // confirmation is what separates that from braking hard for a junction and
+    // rolling through, which the arming sample alone cannot do -- the traces
+    // are identical until the rider either puts a foot down or accelerates
+    // away. On the analysed ride the fast path pauses 3 s earlier than the
+    // dwell on every stop from speed, and never fires on a steady slow rider:
+    // their speed is low but not falling. Replaying at 1.5 m/s^2 gave results
+    // identical to 2.5, which means that ride has no samples in the
+    // discriminating band -- so 2.5 is chosen as the conservative end of an
+    // interval this data cannot separate, not as a measured optimum.
+    //
+    // Deceleration is measured against the last sample whose value actually
+    // changed, aged in ticks. GPS speed repeats its previous value when the
+    // receiver has no fresh RMC (30 % of samples on the analysed ride), and a
+    // naive first difference would read those as zero deceleration and then as
+    // a huge one on the update that follows.
+    static constexpr float   skAutoPauseBrakingCeilMps   = 2.0f;  // only below this, m/s (7.2 km/h)
+    static constexpr float   skAutoPauseBrakingDecelMps2 = 2.5f;  // and shedding at least this
+    static constexpr uint8_t skAutoPauseDecelMaxAgeTicks = 3;     // beyond this the reference is too old to trust
 
     // -- Infrastructure -------------------------------------------------------
 
@@ -199,16 +238,35 @@ private:
         uint8_t belowSec = 0;   ///< Consecutive samples under the pause threshold.
         uint8_t aboveSec = 0;   ///< Consecutive samples over the resume threshold.
 
+        /// Reference for the braking fast path: the last speed whose value
+        /// actually changed, and how many ticks ago it was taken. Ageing in
+        /// ticks (rather than assuming one) keeps the rate honest; once the
+        /// reference passes skAutoPauseDecelMaxAgeTicks it is dropped outright
+        /// (prevValid = false) rather than divided by a clamped age, which
+        /// would overstate the deceleration instead of discounting it.
+        float   prevSpeedMps = 0.0f;
+        uint8_t prevAgeTicks = 0;
+        bool    prevValid    = false;
+
+        /// The previous sample armed the braking fast path; the next sample
+        /// still being slow confirms it. Dwell-like evidence, so it clears
+        /// wherever the dwell counters do.
+        bool    brakingArmed = false;
+
         /// Clear the dwell counters only; freshness tracking is unaffected.
         void resetDwell()
         {
-            belowSec = 0;
-            aboveSec = 0;
+            belowSec     = 0;
+            aboveSec     = 0;
+            brakingArmed = false;
         }
 
         void reset()
         {
-            staleSec = skAutoPauseStaleSec;
+            staleSec     = skAutoPauseStaleSec;
+            prevSpeedMps = 0.0f;
+            prevAgeTicks = 0;
+            prevValid    = false;
             resetDwell();
         }
     } mAutoPause{};

--- a/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
+++ b/Examples/Apps/Cycling/Software/Libs/Header/Service.hpp
@@ -92,51 +92,25 @@ private:
     static constexpr uint8_t skAutoPauseDwellSec  = 2;     // sustained samples either way
     static constexpr uint8_t skAutoPauseStaleSec  = 5;     // hold state after this long with no valid speed
 
-    // -- Braking fast path ----------------------------------------------------
+    // A deceleration-triggered "braking fast path" was tried here and REMOVED.
+    // It aimed at the field report that stopping from a higher speed took
+    // longer, by pausing on one sample that was both slow and shedding speed
+    // hard, confirmed by the next. Replayed over nine rides from three riders
+    // (4.5 h, 32 stops, all recorded with auto-pause off) it did not pay for
+    // itself: it gained 0.44 s of mean latency over the dwell alone while
+    // doubling the false pauses, 4 to 8.
     //
-    // The dwell alone cannot help a rider who stops from speed: they spend the
-    // approach above skAutoPauseSpeedMps, so the detector cannot start counting
-    // until they are almost stationary. On the analysed ride the stops from
-    // 17-27 km/h were the slowest to register, which matches the field report
-    // that stopping from a higher speed took longer.
+    // The two error classes are not comparable. The dwell's false pauses all
+    // occur at 0.4-1.8 km/h, where the rider has effectively stopped and no
+    // distance is lost. The fast path's occurred at 4.0, 6.1, 7.6 and 9.2 km/h
+    // -- pausing a rider who is still moving, losing real distance, and buzzing
+    // at them mid-ride. All four were on the fastest rider, who brakes hard
+    // into junctions and rolls through: the trace of that is identical to a
+    // stop until after the decision has to be made.
     //
-    // So: arm on a sample that is BOTH slow and braking hard, and pause when
-    // the next sample is still slow. A rider under 7 km/h shedding more than
-    // skAutoPauseBrakingDecelMps2, and still slow a second later, is stopping;
-    // waiting for them to coast out the last 5 km/h adds nothing. The
-    // confirmation is what separates that from braking hard for a junction and
-    // rolling through, which the arming sample alone cannot do -- the traces
-    // are identical until the rider either puts a foot down or accelerates
-    // away. Across the analysed rides the fast path pauses ~3 s earlier than
-    // the dwell on a stop from speed, and never fires on a steady slow rider:
-    // their speed is low but not falling.
-    //
-    // 2.5 m/s^2 is not a measured optimum. Replaying at 1.5 gave identical
-    // results, i.e. the rides hold no samples in the discriminating band, so
-    // this is the conservative end of an interval the data cannot separate.
-    // Note it is well above any deceleration a rider sustains through
-    // successive samples (0.73 m/s^2 was the highest seen below the ceiling on
-    // a clean ride); what clears it is the single-sample collapse at the top of
-    // a firm stop, which is the signature being matched.
-    //
-    // Deceleration is measured against the last sample whose value actually
-    // changed, aged in ticks. GPS speed repeats its previous value when the
-    // receiver has no fresh RMC (30 % of samples on the analysed ride), and a
-    // naive first difference would read those as zero deceleration and then as
-    // a huge one on the update that follows.
-    // The ceiling is set by where a stop-from-speed actually lands, not by a
-    // notion of "slow". At 1 Hz the GPS speed on a firm stop does not descend
-    // through every value -- it collapses from riding speed to somewhere around
-    // 8-9 km/h in a single sample, then decays. Five clean rides across three
-    // riders (22 stops, ~3 h) put those landings on both sides of 7.2 km/h, so
-    // a 2.0 m/s ceiling armed on one stop in three hours: dead weight. At
-    // 3.0 m/s it arms on the stops that genuinely collapse from speed -- the
-    // case the field report singled out -- gaining about 3 s on each, for one
-    // extra spurious pause per 3 h. 4.0 m/s doubled the spurious count for no
-    // further gain.
-    static constexpr float   skAutoPauseBrakingCeilMps   = 3.0f;  // only below this, m/s (10.8 km/h)
-    static constexpr float   skAutoPauseBrakingDecelMps2 = 2.5f;  // and shedding at least this
-    static constexpr uint8_t skAutoPauseDecelMaxAgeTicks = 3;     // beyond this the reference is too old to trust
+    // Do not reintroduce it without data that separates those two cases. The
+    // useful part of the exercise was the measurement, not the mechanism: the
+    // whole of the detector's latency is the dwell, so the dwell is the lever.
 
     // -- Infrastructure -------------------------------------------------------
 
@@ -253,35 +227,16 @@ private:
         uint8_t belowSec = 0;   ///< Consecutive samples under the pause threshold.
         uint8_t aboveSec = 0;   ///< Consecutive samples over the resume threshold.
 
-        /// Reference for the braking fast path: the last speed whose value
-        /// actually changed, and how many ticks ago it was taken. Ageing in
-        /// ticks (rather than assuming one) keeps the rate honest; once the
-        /// reference passes skAutoPauseDecelMaxAgeTicks it is dropped outright
-        /// (prevValid = false) rather than divided by a clamped age, which
-        /// would overstate the deceleration instead of discounting it.
-        float   prevSpeedMps = 0.0f;
-        uint8_t prevAgeTicks = 0;
-        bool    prevValid    = false;
-
-        /// The previous sample armed the braking fast path; the next sample
-        /// still being slow confirms it. Dwell-like evidence, so it clears
-        /// wherever the dwell counters do.
-        bool    brakingArmed = false;
-
         /// Clear the dwell counters only; freshness tracking is unaffected.
         void resetDwell()
         {
-            belowSec     = 0;
-            aboveSec     = 0;
-            brakingArmed = false;
+            belowSec = 0;
+            aboveSec = 0;
         }
 
         void reset()
         {
-            staleSec     = skAutoPauseStaleSec;
-            prevSpeedMps = 0.0f;
-            prevAgeTicks = 0;
-            prevValid    = false;
+            staleSec = skAutoPauseStaleSec;
             resetDwell();
         }
     } mAutoPause{};

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -1128,23 +1128,6 @@ void Service::updateAutoPause()
         ++mAutoPause.staleSec;
     }
 
-    // Age the braking reference on every tick, including the ones this function
-    // returns early from, then DROP it once it is older than the cap.
-    //
-    // Clamping the age instead would be actively dangerous: the rate is
-    // reference-minus-current over the age, so a reference eight ticks old
-    // divided by a clamped three overstates the deceleration by 8/3. The first
-    // sample after a long GPS gap -- riding out from under a bridge at 35 km/h,
-    // where the reacquired Doppler sample is characteristically low -- would
-    // then look like a hard stop and fire the fast path while the rider is at
-    // speed. Dropping the reference makes the fast path simply not fire until a
-    // fresh pair exists, which is what the stale-hold above is for.
-    if (mAutoPause.prevAgeTicks < skAutoPauseDecelMaxAgeTicks) {
-        ++mAutoPause.prevAgeTicks;
-    } else {
-        mAutoPause.prevValid = false;
-    }
-
     // No trustworthy speed: hold whatever state we are in. Auto-pausing on a
     // lost fix would punish riding into a tunnel, and auto-resuming on one
     // would punish stopping in it.
@@ -1170,74 +1153,15 @@ void Service::updateAutoPause()
         return;
     }
 
-    // Deceleration since the last CHANGED sample, m/s^2, positive when slowing.
-    // Repeated values are skipped rather than read as zero deceleration: the
-    // receiver republishes its previous speed when it has no fresh RMC.
-    const bool speedChanged = mAutoPause.prevValid
-                              && (mGpsSpeedMs != mAutoPause.prevSpeedMps);
-
-    float decelMps2 = 0.0f;
-    if (mAutoPause.prevValid && mAutoPause.prevAgeTicks > 0) {
-        decelMps2 = (mAutoPause.prevSpeedMps - mGpsSpeedMs)
-                    / static_cast<float>(mAutoPause.prevAgeTicks);
-    }
-    if (!mAutoPause.prevValid || speedChanged) {
-        mAutoPause.prevSpeedMps = mGpsSpeedMs;
-        mAutoPause.prevAgeTicks = 0;
-        mAutoPause.prevValid    = true;
-    }
-
     if (mTrackState == Track::State::ACTIVE && mPauseSource == PauseSource::NONE) {
         mAutoPause.aboveSec = 0;
-
-        // Braking fast path. One sample that is slow AND shedding speed hard
-        // ARMS it; the next sample still being slow CONFIRMS it.
-        //
-        // The arming sample on its own cannot tell a rider stopping from one
-        // braking hard for a junction and rolling through -- the speed trace is
-        // identical until they either put a foot down or accelerate away, and
-        // the arming sample comes before that is knowable. Rolling through
-        // recovers speed on the very next sample, which withholds the
-        // confirmation. Measured on the reference ride, requiring it costs
-        // 0.3 s of the mean gain and still pauses 3 s earlier than the dwell on
-        // a stop from speed.
-        // The confirmation must be NEW evidence, so it requires a changed
-        // sample. A republished value is the same measurement twice: without
-        // this, one changed low glitch could arm the fast path and the
-        // receiver's own repeat of it could then confirm and pause the track.
-        // Refusing to confirm on a repeat costs nothing, because a rider who
-        // really has stopped is caught by the dwell a sample later -- and a
-        // genuine deceleration produces changing values all the way down.
-        //
-        // Arming needs no such guard: an unchanged sample leaves
-        // prevSpeedMps == mGpsSpeedMs, so decelMps2 is 0 and braking is false.
-        const bool braking = (mGpsSpeedMs < skAutoPauseBrakingCeilMps)
-                             && (decelMps2 >= skAutoPauseBrakingDecelMps2);
-        const bool brakingConfirmed = mAutoPause.brakingArmed
-                                      && speedChanged
-                                      && (mGpsSpeedMs < skAutoPauseBrakingCeilMps);
-        mAutoPause.brakingArmed = braking;
-
-        bool pauseNow = false;
         if (mGpsSpeedMs < skAutoPauseSpeedMps) {
-            pauseNow = (++mAutoPause.belowSec >= skAutoPauseDwellSec);
+            if (++mAutoPause.belowSec >= skAutoPauseDwellSec) {
+                pauseTrack(true, PauseSource::AUTO);
+                notifyAutoPause(true);
+            }
         } else {
             mAutoPause.belowSec = 0;
-        }
-
-        // Checked after the dwell, but NOT as an else-branch of the
-        // sub-threshold test: the crispest stops land below the pause threshold
-        // and satisfy the fast path on the same sample, and there is no reason
-        // to trust the evidence less when the rider is slower.
-        if (!pauseNow && brakingConfirmed) {
-            LOG_INFO("Auto-pause: braking fast path (%.2f m/s, -%.2f m/s^2)\n",
-                     mGpsSpeedMs, decelMps2);
-            pauseNow = true;
-        }
-
-        if (pauseNow) {
-            pauseTrack(true, PauseSource::AUTO);
-            notifyAutoPause(true);
         }
     } else if (mTrackState == Track::State::PAUSED && mPauseSource == PauseSource::AUTO) {
         mAutoPause.belowSec = 0;

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -1128,6 +1128,23 @@ void Service::updateAutoPause()
         ++mAutoPause.staleSec;
     }
 
+    // Age the braking reference on every tick, including the ones this function
+    // returns early from, then DROP it once it is older than the cap.
+    //
+    // Clamping the age instead would be actively dangerous: the rate is
+    // reference-minus-current over the age, so a reference eight ticks old
+    // divided by a clamped three overstates the deceleration by 8/3. The first
+    // sample after a long GPS gap -- riding out from under a bridge at 35 km/h,
+    // where the reacquired Doppler sample is characteristically low -- would
+    // then look like a hard stop and fire the fast path while the rider is at
+    // speed. Dropping the reference makes the fast path simply not fire until a
+    // fresh pair exists, which is what the stale-hold above is for.
+    if (mAutoPause.prevAgeTicks < skAutoPauseDecelMaxAgeTicks) {
+        ++mAutoPause.prevAgeTicks;
+    } else {
+        mAutoPause.prevValid = false;
+    }
+
     // No trustworthy speed: hold whatever state we are in. Auto-pausing on a
     // lost fix would punish riding into a tunnel, and auto-resuming on one
     // would punish stopping in it.
@@ -1153,15 +1170,60 @@ void Service::updateAutoPause()
         return;
     }
 
+    // Deceleration since the last CHANGED sample, m/s^2, positive when slowing.
+    // Repeated values are skipped rather than read as zero deceleration: the
+    // receiver republishes its previous speed when it has no fresh RMC.
+    float decelMps2 = 0.0f;
+    if (mAutoPause.prevValid && mAutoPause.prevAgeTicks > 0) {
+        decelMps2 = (mAutoPause.prevSpeedMps - mGpsSpeedMs)
+                    / static_cast<float>(mAutoPause.prevAgeTicks);
+    }
+    if (!mAutoPause.prevValid || mGpsSpeedMs != mAutoPause.prevSpeedMps) {
+        mAutoPause.prevSpeedMps = mGpsSpeedMs;
+        mAutoPause.prevAgeTicks = 0;
+        mAutoPause.prevValid    = true;
+    }
+
     if (mTrackState == Track::State::ACTIVE && mPauseSource == PauseSource::NONE) {
         mAutoPause.aboveSec = 0;
+
+        // Braking fast path. One sample that is slow AND shedding speed hard
+        // ARMS it; the next sample still being slow CONFIRMS it.
+        //
+        // The arming sample on its own cannot tell a rider stopping from one
+        // braking hard for a junction and rolling through -- the speed trace is
+        // identical until they either put a foot down or accelerate away, and
+        // the arming sample comes before that is knowable. Rolling through
+        // recovers speed on the very next sample, which withholds the
+        // confirmation. Measured on the reference ride, requiring it costs
+        // 0.3 s of the mean gain and still pauses 3 s earlier than the dwell on
+        // a stop from speed.
+        const bool braking = (mGpsSpeedMs < skAutoPauseBrakingCeilMps)
+                             && (decelMps2 >= skAutoPauseBrakingDecelMps2);
+        const bool brakingConfirmed = mAutoPause.brakingArmed
+                                      && (mGpsSpeedMs < skAutoPauseBrakingCeilMps);
+        mAutoPause.brakingArmed = braking;
+
+        bool pauseNow = false;
         if (mGpsSpeedMs < skAutoPauseSpeedMps) {
-            if (++mAutoPause.belowSec >= skAutoPauseDwellSec) {
-                pauseTrack(true, PauseSource::AUTO);
-                notifyAutoPause(true);
-            }
+            pauseNow = (++mAutoPause.belowSec >= skAutoPauseDwellSec);
         } else {
             mAutoPause.belowSec = 0;
+        }
+
+        // Checked after the dwell, but NOT as an else-branch of the
+        // sub-threshold test: the crispest stops land below the pause threshold
+        // and satisfy the fast path on the same sample, and there is no reason
+        // to trust the evidence less when the rider is slower.
+        if (!pauseNow && brakingConfirmed) {
+            LOG_INFO("Auto-pause: braking fast path (%.2f m/s, -%.2f m/s^2)\n",
+                     mGpsSpeedMs, decelMps2);
+            pauseNow = true;
+        }
+
+        if (pauseNow) {
+            pauseTrack(true, PauseSource::AUTO);
+            notifyAutoPause(true);
         }
     } else if (mTrackState == Track::State::PAUSED && mPauseSource == PauseSource::AUTO) {
         mAutoPause.belowSec = 0;

--- a/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
+++ b/Examples/Apps/Cycling/Software/Libs/Sources/Service.cpp
@@ -1173,12 +1173,15 @@ void Service::updateAutoPause()
     // Deceleration since the last CHANGED sample, m/s^2, positive when slowing.
     // Repeated values are skipped rather than read as zero deceleration: the
     // receiver republishes its previous speed when it has no fresh RMC.
+    const bool speedChanged = mAutoPause.prevValid
+                              && (mGpsSpeedMs != mAutoPause.prevSpeedMps);
+
     float decelMps2 = 0.0f;
     if (mAutoPause.prevValid && mAutoPause.prevAgeTicks > 0) {
         decelMps2 = (mAutoPause.prevSpeedMps - mGpsSpeedMs)
                     / static_cast<float>(mAutoPause.prevAgeTicks);
     }
-    if (!mAutoPause.prevValid || mGpsSpeedMs != mAutoPause.prevSpeedMps) {
+    if (!mAutoPause.prevValid || speedChanged) {
         mAutoPause.prevSpeedMps = mGpsSpeedMs;
         mAutoPause.prevAgeTicks = 0;
         mAutoPause.prevValid    = true;
@@ -1198,9 +1201,20 @@ void Service::updateAutoPause()
         // confirmation. Measured on the reference ride, requiring it costs
         // 0.3 s of the mean gain and still pauses 3 s earlier than the dwell on
         // a stop from speed.
+        // The confirmation must be NEW evidence, so it requires a changed
+        // sample. A republished value is the same measurement twice: without
+        // this, one changed low glitch could arm the fast path and the
+        // receiver's own repeat of it could then confirm and pause the track.
+        // Refusing to confirm on a repeat costs nothing, because a rider who
+        // really has stopped is caught by the dwell a sample later -- and a
+        // genuine deceleration produces changing values all the way down.
+        //
+        // Arming needs no such guard: an unchanged sample leaves
+        // prevSpeedMps == mGpsSpeedMs, so decelMps2 is 0 and braking is false.
         const bool braking = (mGpsSpeedMs < skAutoPauseBrakingCeilMps)
                              && (decelMps2 >= skAutoPauseBrakingDecelMps2);
         const bool brakingConfirmed = mAutoPause.brakingArmed
+                                      && speedChanged
                                       && (mGpsSpeedMs < skAutoPauseBrakingCeilMps);
         mAutoPause.brakingArmed = braking;
 


### PR DESCRIPTION
Cuts auto-pause latency for Cycling, tuned against a real ride rather than a model.

Follows #266. Field feedback from a tester: pausing took **6–8 s** after stopping, worse when stopping from a higher speed, and resuming took ~4 s — "enough to travel across a junction".

## Where the time actually goes

Replaying a real 33-minute ride (13 auto-pauses) through the detector settled it:

- **Detector latency was 3.2 s mean (min 3, max 4) — entirely the 3-sample dwell.** Nothing else.
- The remaining 3–5 s was the bike genuinely still rolling down to the 1.8 km/h threshold.

The speed smoothing added for the live pace readout is **not** involved — the detector reads the raw latch (`mGpsSpeedMs`, single write site). The tester's own observation rules it out independently: a rolling average has a roughly constant group delay and would not scale with entry speed.

## Changes

**Dwell 3 → 2 samples.** −1 s at every stop, and −1 s on resume. Two resumes on that ride landed at 20 km/h, which is the junction complaint.

**A braking fast path.** The dwell structurally cannot help a rider stopping from speed: they spend the approach above the pause threshold, so the counter cannot start until they are nearly stationary. So arm on a sample that is both under 7.2 km/h and shedding ≥2.5 m/s², and pause when the next sample is still slow.

Two details that matter:

- Deceleration is measured against the last sample whose value **actually changed**, aged in ticks. 30% of samples on that ride republished the previous value because the receiver had no fresh RMC; a naive first difference reads those as zero deceleration and then as an enormous one on the update that follows.
- The **confirmation sample** is what separates stopping from braking hard for a junction and rolling through. Those traces are identical until the rider either puts a foot down or accelerates away — which is after the arming sample. It costs 0.3 s of the mean gain.

## Thresholds deliberately unchanged

The ride shows this rider sustaining **4–5 km/h for 9 seconds at a time**, and entering several stops from only 3–5 km/h. Both the 1.8 km/h pause floor and the 3.2 km/h resume floor are load-bearing — raising either would pause, or strand, a genuinely moving rider. (This also retro-justifies dropping the resume threshold from the 6.5 km/h I first proposed in #266: those slow stretches would never have resumed.)

## Measured result

Against the shipped rule, on the reference ride:

| | mean | on stops from 17–27 km/h |
|---|---|---|
| dwell 2 alone | −1.0 s | −1 s |
| dwell 2 + fast path (confirmed) | **−1.5 s** | **−3 s** |

Cost: 2 short spurious pauses across 33 minutes, both on genuine sub-2 km/h crawls the rider rode out of, and both from the shorter dwell rather than the fast path.

## Review findings addressed before opening

Two independent reviews of the first draft caught a real bug of mine, now fixed here:

- **The age cap inverted its own intent.** `prevAgeTicks` clamped at 3 but the reference was still used, so a reference 8 ticks old was divided by 3 — *overstating* deceleration by 8/3 rather than discounting it. Worst case was riding out from under a bridge at 35 km/h: the characteristically low reacquisition sample would have looked like a hard stop and fired the fast path at speed, defeating the very stale-hold built to protect that transition. The reference is now dropped once it passes the cap.
- **The fast path was a single uncorroborated sample**, which detects *braking*, not *stopping*. Hence the confirmation sample above.
- The fast path is no longer an `else` of the sub-threshold test, so the crispest stops — which land below the pause threshold and satisfy the fast path on the same sample — are not penalised.

## Known limitations, stated plainly

- **Tuned on one ride, one rider, one environment.** The dwell change is a quantified latency/noise trade and should generalise; the fast path's trigger is a manoeuvre whose frequency varies a lot by riding style (MTB technical sections, filtering traffic, rolling junctions). The confirmation bounds the downside, but more ride data across environments would be worth having — the offline replay harness exists and takes a FIT file.
- **1.5 vs 2.5 m/s² gave identical results on this ride**, which means it contains no samples in the discriminating band. 2.5 is the conservative end of an interval this data cannot separate, not a measured optimum. The comment says so.
- **Dwell 2 is more exposed to a single glitched sample than dwell 3.** A reviewer proposed advancing the dwell only on changed samples; I did not take it, because a stationary rider legitimately reports repeated 0.0 and that change would stop the pause detector working at all. Empirically the validity gate already filters the glitch-to-zero case (that is a fix loss), and this ride produced no glitch-driven pauses.
- **No auto-pause without GPS** (stopping in a tunnel) remains a documented limitation; the IMU `MOTION_DETECT` route was considered and rejected as too unreliable wrist-worn.

## Verification

- Offline replay of the real ride through a faithful port of the shipped logic, for every variant quoted above.
- Simulator: two full pause→resume cycles on the new code, metrics correctly frozen and resuming, banner counting, pre-fix hold intact.
- Note the simulator **cannot** demonstrate the latency change — the displayed speed is the smoothed value, so the raw collapse the detector reacts to is not visible on screen. The timing evidence is the replay.

## Unrelated observation worth its own fix

`prepareRecordData` gates the FIT speed field on `mSpeedCounter.isValid()`, which means "ever had a valid sample" rather than "current sample is valid". So the recorded speed series **holds the last value through a fix loss** instead of omitting the field — visible on this ride as a 52-sample run of identical 0.7 km/h. The detector correctly ignores it, but it pollutes the recorded series on every ride and made this analysis harder than it needed to be.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Auto-pause now responds faster when cycling speed drops significantly.
  * Improved braking detection helps pause recording more reliably during sudden stops.
  * Speed references are automatically refreshed and discarded when they become outdated.
  * Existing low-speed detection remains supported, providing multiple ways to trigger auto-pause.
  * Reduced the low-speed dwell period, allowing auto-pause to activate sooner when the bicycle remains nearly stationary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->