### PR TITLE
fix(cmake): key the GUI merge on the GUI target, not on TouchGFX

### DIFF
--- a/cmake/una-app.cmake
+++ b/cmake/una-app.cmake
@@ -331,9 +331,13 @@ function(una_app_build_app)
         )
     endforeach()
 
-    # Final app merging
+    # Final app merging. The merge needs the GUI ELF packed first, so ask whether
+    # one was built rather than whether TouchGFX built it: a CustomGUI app sets no
+    # TOUCHGFX_PATH, and keying on that left app_merging.py racing the packer.
+    # TOUCHGFX_PATH stays for apps calling this before una_app_build_gui(), where
+    # the target does not exist yet and DEPENDS resolves at generate time.
     set(APP_DEPENDS ${APP_NAME}Service.elf)
-    if(DEFINED TOUCHGFX_PATH)
+    if(TARGET ${APP_NAME}GUI.elf OR DEFINED TOUCHGFX_PATH)
         list(APPEND APP_DEPENDS ${APP_NAME}GUI.elf)
     endif()
     set(APP_AUTOSTART_FLAG "")


### PR DESCRIPTION
Rationale: moving forward with `CustomGUI`, which is not represented in this repo presently

`una_app_build_app()` lists what the merge step must wait for, and adds the GUI ELF only when `TOUCHGFX_PATH` is defined. That asks whether the app uses TouchGFX. What it needs to know is whether `una_app_build_gui()` built a GUI ELF.

The two matched while TouchGFX was the only way to draw one. Since cb1ae1f1 the SDK also ships the `CustomGUI` entry point, which needs only a Gui class taking the kernel and a run(), and leaves the app to own the message loop. An app using it builds a GUI ELF and sets no `TOUCHGFX_PATH`, so the merge target never depends on that ELF: the generated makefile lists Service.elf alone.

The ELF is still built, because `add_executable` puts it in all. What is missing is the ordering, so `app_merging.py` races the post-build step that packs Tmp/*.gui. "make <App>App" fails outright with "Missing .gui file", which is required for every type but Glance, and a full parallel make succeeds or fails depending on scheduling order. Both outcomes were observed on one tree.

Glances are why that file is optional, and they are unaffected: a glance app has no GUI ELF by design. Its service asks the kernel for the glance geometry, sends a list of SDK::Glance controls with RequestGlanceUpdate, and the kernel draws them, so there is no app framebuffer and no GUI process to wait for.

if(TARGET) asks CMake the question directly. `TOUCHGFX_PATH` stays in the condition for apps that call `una_app_build_app()` before `una_app_build_gui()`, where the target does not exist yet and add_custom_target resolves DEPENDS at generate time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CustomGUI build support by ensuring the final application correctly includes the GUI component when available.
  * Preserved existing behavior for configurations set before the target is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->