### PR TITLE
fix(simulator): drop dead locals and casts that lie about constness

### DIFF
--- a/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
+++ b/Libs/Source/Simulator/App/KernelMessageDispatcher.cpp
@@ -88,7 +88,6 @@ void KernelMessageDispatcher::appLifeCycleHandler(SDK::MessageBase* msg)
 
         case SDK::MessageType::REQUEST_APP_RUN_GUI: {
             LOG_DEBUG("Service requests GUI launch\n");
-            bool isGuiWasRun = true;
             bool status = true;
             msg->setResult(status ? SDK::MessageResult::SUCCESS : SDK::MessageResult::FAIL);
             mMessageMgr.signalCompletion(msg);
@@ -124,7 +123,7 @@ void KernelMessageDispatcher::appMsgHandler(SDK::MessageBase* msg)
 
             const uint32_t limit = std::min(
                 SDK::Message::RequestSystemSettings::skMaxHearRateTh,
-                static_cast<const uint32_t>(HeartRateZones::kMaxThreshold)
+                static_cast<uint32_t>(HeartRateZones::kMaxThreshold)
             );
 
             for (uint32_t i = 0; i < limit; i++) {
@@ -242,7 +241,6 @@ void KernelMessageDispatcher::appMsgHandler(SDK::MessageBase* msg)
 
         case SDK::MessageType::REQUEST_GLANCE_UPDATE: {
             LOG_DEBUG("Requests glance update\n");
-            auto* gl = static_cast<SDK::Message::RequestGlanceUpdate*>(msg);
 
             mMessageMgr.signalCompletion(msg, SDK::MessageResult::SUCCESS);
         } break;

--- a/Libs/Source/Simulator/Components/SensorDataQueue.cpp
+++ b/Libs/Source/Simulator/Components/SensorDataQueue.cpp
@@ -110,7 +110,7 @@ void Sensor::DataQueue::reinit(float period, uint32_t latency)
         return;
     }
 
-    const uint8_t* oldQueue    = (uint8_t*)mQueue;
+    uint8_t* oldQueue          = (uint8_t*)mQueue;
     const uint16_t oldCapacity = mCapacity;
 
     // Create a new queue

--- a/Libs/Source/Simulator/Components/SensorListener.cpp
+++ b/Libs/Source/Simulator/Components/SensorListener.cpp
@@ -66,7 +66,7 @@ void SensorListener::onSdlNewData(uint16_t                 handle,
         event->handle = handle;
         event->count  = strideCount;
         event->stride = stride;
-        memcpy((void*) event->data, (void*) dataPtr, strideCount * stride);
+        memcpy((void*) event->data, (const void*) dataPtr, strideCount * stride);
 
         if (!sendMessage(event)) {
             LOG_ERROR("Failed to send data. Handle %u. PID 0x%08X\n", handle, pid);

--- a/Libs/Source/Simulator/Components/Sensors/Gps/GpsDistance.cpp
+++ b/Libs/Source/Simulator/Components/Sensors/Gps/GpsDistance.cpp
@@ -92,7 +92,6 @@ const char* GpsDistance::sdcGetDescription(Sensor::Driver* driver)
 
 void GpsDistance::sensorRefresh()
 {
-    static float distance = 0.0;
     if (mTimer.check()) {
         LOG_DEBUG("ENTRY\n");
 

--- a/Libs/Source/Simulator/Components/Simulator/GpsStepCounterSimulator.cpp
+++ b/Libs/Source/Simulator/Components/Simulator/GpsStepCounterSimulator.cpp
@@ -94,7 +94,6 @@ namespace Simulator {
             }
 
             updateLocation();
-            IGps::LocationInfo loc = getLocation();
         }
     }
     


### PR DESCRIPTION
The two cast-qual sites in SensorDataQueue both trace back to one declaration: oldQueue is the buffer this function owns and frees, so const was never true of it, and every use had to cast the claim away again to get work done. Dropping it there removes both casts rather than papering over either. SensorListener casts a const source to void* for memcpy, whose source parameter is const void* and never wanted it stripped.

`const` on a `static_cast` to a scalar prvalue does nothing, which is what `-Wignored-qualifiers` is pointing at.

The dead locals are dead: `isGuiWasRun` and `gl` are assigned and never read, the static distance in `GpsDistance` is left over from an earlier accumulator, and the `loc` in the simulator task calls an accessor that only returns a member. Removing the call is safe because `getLocation` has no side effects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal simulator processing and removed unused state and variables.
  * Streamlined sensor data handling without changing queue migration or data-copy behavior.
  * Reduced unnecessary GPS simulator work while preserving location updates.

* **Bug Fixes**
  * Improved type handling for sensor and simulator data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->