### PR TITLE
fix(cmake): stop claiming a glance interface for every app

### DIFF
--- a/Docs/sdk-setup.md
+++ b/Docs/sdk-setup.md
@@ -307,9 +307,19 @@ If build files are generated in the wrong directory (e.g., root instead of build
         - PowerShell/Windows: python -c "import hashlib; print(hashlib.md5(b'MyApp').hexdigest().upper()[:16])"
       - Alternatively, acquire from the developer portal for published apps as described in [deploy.md](deploy.md).
       Replace "MyApp" with your app name. See [API reference](api-reference.rst) for details.
-    - `DEV_ID`: Device identifier, typically "UNAWatch".
-    - `APP_TYPE`: App type, e.g., "app".
-    - `APP_AUTOSTART`: "On" or "Off" (default "Off") to enable autostart.
+    - `DEV_ID`: developer identifier, passed to the app as a compile definition of the same name,
+      which the app may use as it sees fit. Every example and tutorial sets `"UNA"`.
+    - `APP_TYPE`: one of `Activity`, `Utility`, `Glance` or `Clockface`, spelled exactly. It sets
+      the type in the packed header, and the default for `APP_GLANCE_INTF` below.
+    - `APP_AUTOSTART`: enable autostart, default `Off`. Accepted values are `On`, `Off`, `True`,
+      `False`, `Yes`, `No`, `Y`, `N`, `1` and `0`, in any case; anything else stops the build
+      rather than being read as one or the other.
+    - `APP_GLANCE_INTF`: whether the packed header claims a glance interface (bit 5, `0x20`),
+      default following `APP_TYPE`: on for `Glance`, off for every other type. Most apps never
+      set it; set it only for a non-Glance app that genuinely serves glance data. Accepted
+      values as for `APP_AUTOSTART`.
+    - `APP_USE_ICONS`: whether the app ships launcher icons from `RESOURCES_PATH`, default `On`.
+      The `Glance*` examples set it `Off`. Accepted values as for `APP_AUTOSTART`.
     - Paths (adjust if reorganizing file structure):
       - `LIBS_PATH`: Path to libraries, default "../../Libs".
       - `OUTPUT_PATH`: Path for built files, default "../../../Output".

--- a/cmake/una-app.cmake
+++ b/cmake/una-app.cmake
@@ -322,6 +322,33 @@ function(una_app_build_gui TARGET_NAME)
     )
 endfunction()
 
+# Read a boolean app option: apply the default when the caller left it unset,
+# and reject a value that is neither on nor off.
+#
+# CMake defines a short list of false values and treats everything else as
+# true, so an unrecognised value -- a typo, or a word like "disabled" -- reads
+# as ON. These options decide what goes into the packed header, so a value that
+# cannot be read as a boolean stops the build rather than picking a side.
+# The accepted set is narrower than CMake's: an empty value, NOTFOUND and
+# IGNORE all count as false to CMake, but here they mean a caller wrote the
+# option and got it wrong, so they are rejected rather than read as off.
+function(una_app_bool_option NAME DEFAULT)
+    if(NOT DEFINED ${NAME})
+        set(${NAME} ${DEFAULT} PARENT_SCOPE)
+        return()
+    endif()
+
+    # TOUPPER settles the case, so the list is one entry per value, not per
+    # spelling: On, on and ON all arrive here as ON.
+    string(TOUPPER "${${NAME}}" VALUE)
+    set(ACCEPTED ON OFF TRUE FALSE YES NO Y N 1 0)
+    if(NOT VALUE IN_LIST ACCEPTED)
+        list(JOIN ACCEPTED " " SPELLINGS)
+        message(FATAL_ERROR
+            "${NAME} is '${${NAME}}', which is not a boolean; accepted in any case: ${SPELLINGS}")
+    endif()
+endfunction()
+
 # Main function to build a complete watch app
 function(una_app_build_app)
     set(OUTPUT_COPY_COMMANDS "")
@@ -337,10 +364,8 @@ function(una_app_build_app)
         list(APPEND APP_DEPENDS ${APP_NAME}GUI.elf)
     endif()
     set(APP_AUTOSTART_FLAG "")
-    if(NOT DEFINED APP_AUTOSTART)
-        set(APP_AUTOSTART Off)
-    endif()
-    if(${APP_AUTOSTART} STREQUAL On)
+    una_app_bool_option(APP_AUTOSTART Off)
+    if(APP_AUTOSTART)
         set(APP_AUTOSTART_FLAG "-autostart")
         message("App autostart is ON")
     else()
@@ -366,14 +391,12 @@ function(una_app_build_app)
     # with APP_GLANCE_INTF, which is what a non-Glance app that really does
     # serve glance data should set.
     set(APP_GLANCE_INTF_FLAG "")
-    if(NOT DEFINED APP_GLANCE_INTF)
-        if(${APP_TYPE} STREQUAL Glance)
-            set(APP_GLANCE_INTF On)
-        else()
-            set(APP_GLANCE_INTF Off)
-        endif()
+    if(APP_TYPE STREQUAL "Glance")
+        una_app_bool_option(APP_GLANCE_INTF On)
+    else()
+        una_app_bool_option(APP_GLANCE_INTF Off)
     endif()
-    if(${APP_GLANCE_INTF} STREQUAL On)
+    if(APP_GLANCE_INTF)
         set(APP_GLANCE_INTF_FLAG "-glance_capable")
         message("App glance interface is ON")
     else()
@@ -391,11 +414,9 @@ function(una_app_build_app)
     endif()
 
     set(APP_ICON_ARGS "")
-    if(NOT DEFINED APP_USE_ICONS)
-        set(APP_USE_ICONS On)
-    endif()
+    una_app_bool_option(APP_USE_ICONS On)
 
-    if(${APP_USE_ICONS} STREQUAL On)
+    if(APP_USE_ICONS)
         list(APPEND APP_ICON_ARGS
             -normal_icon ${RESOURCES_PATH}/icon_60x60.png
             -small_icon ${RESOURCES_PATH}/icon_30x30.png

--- a/cmake/una-app.cmake
+++ b/cmake/una-app.cmake
@@ -350,6 +350,36 @@ function(una_app_build_app)
         set(APP_USER_NAME ${APP_NAME})
     endif()
 
+    # The packed header states two independent things: the app's type, and
+    # whether it exposes a glance interface (bit 5, 0x20). This flag used to be
+    # passed unconditionally, so every image claimed an interface it had no code
+    # for, and its two statements contradicted each other.
+    #
+    # The firmware resolves an app's role from those flags and has to pick an
+    # order when they disagree. Under the current order the glance bit outranks
+    # the Clockface type, so a watchface was taken for a glance; Activity and
+    # Utility are resolved before the bit is consulted and were unaffected.
+    #
+    # Default follows the type: a Glance app keeps the flag (redundant with its
+    # type, but it is the one place the claim is true, and dropping it would
+    # change bytes for apps already in the field). Everything else must opt in
+    # with APP_GLANCE_INTF, which is what a non-Glance app that really does
+    # serve glance data should set.
+    set(APP_GLANCE_INTF_FLAG "")
+    if(NOT DEFINED APP_GLANCE_INTF)
+        if(${APP_TYPE} STREQUAL Glance)
+            set(APP_GLANCE_INTF On)
+        else()
+            set(APP_GLANCE_INTF Off)
+        endif()
+    endif()
+    if(${APP_GLANCE_INTF} STREQUAL On)
+        set(APP_GLANCE_INTF_FLAG "-glance_capable")
+        message("App glance interface is ON")
+    else()
+        message("App glance interface is OFF")
+    endif()
+
     # APP_FILE_NAME pins the .uapp artifact name when the launcher name has to
     # change independently of it: the phone's OTA flow and the CI release zip
     # both key on the artifact name. Left undefined, app_merging.py derives it
@@ -377,7 +407,7 @@ function(una_app_build_app)
 
     add_custom_target(${APP_NAME}App ALL
         DEPENDS ${APP_DEPENDS}
-        COMMAND ${UNA_PYTHON_EXECUTABLE} ${SCRIPTS_PATH}/app_merging/app_merging.py ${APP_AUTOSTART_FLAG} ${APP_ICON_ARGS} -name ${APP_USER_NAME} ${APP_FILE_NAME_ARGS} -type ${APP_TYPE} -glance_capable -out ${CMAKE_CURRENT_BINARY_DIR} -appid ${APP_ID} -appver ${BUILD_VERSION} -scripts $ENV{UNA_SDK}/Libs/Source/AppSystem
+        COMMAND ${UNA_PYTHON_EXECUTABLE} ${SCRIPTS_PATH}/app_merging/app_merging.py ${APP_AUTOSTART_FLAG} ${APP_ICON_ARGS} -name ${APP_USER_NAME} ${APP_FILE_NAME_ARGS} -type ${APP_TYPE} ${APP_GLANCE_INTF_FLAG} -out ${CMAKE_CURRENT_BINARY_DIR} -appid ${APP_ID} -appver ${BUILD_VERSION} -scripts $ENV{UNA_SDK}/Libs/Source/AppSystem
         ${OUTPUT_COPY_COMMANDS}
         COMMENT "Merging ${APP_NAME} application"
     )


### PR DESCRIPTION
## Summary

`una_app_build_app()` passed `-glance_capable` to `app_merging.py` for every
app, so every `.uapp` set the glance-capable bit (bit 5, `0x20`) whether or not
the app serves glance data. None of the non-Glance example apps do — only the
six `Glance*` apps reference `SDK::Glance` at all.

The flag now follows `APP_TYPE`, and is overridable:

| `APP_TYPE`                     | `-glance_capable` |
|--------------------------------|-------------------|
| `Glance`                       | yes (unchanged)   |
| everything else                | no                |
| any, with `APP_GLANCE_INTF` on | yes               |

`APP_GLANCE_INTF` follows the same shape as the existing `APP_AUTOSTART` and
`APP_USE_ICONS` knobs, and is what a non-Glance app that genuinely serves glance
data should set. The second commit brings all three under one reader that
validates what it is given.

## Why it matters

A packed header states two independent things: the app's **type** (`-type`, one
of `Activity` / `Utility` / `Glance` / `Clockface`) and whether the app exposes
a **glance interface** (`-glance_capable`). Emitting the second unconditionally
made every image contradict itself — three of the four types shipped a header
claiming an interface the app has no code for.

The firmware resolves an app's role from those flags, so it has to pick an order
when the two disagree. Under the current order the glance bit outranks the
`Clockface` type: an app packed as `-type Clockface` is taken for a glance and
never routed as a watchface. `Activity` and `Utility` are resolved before the
bit is consulted, which is the only reason this stayed invisible until now.

So a stock SDK cannot currently produce a working watchface, however correctly
the app itself is written.

<sub>Reviewers with firmware access: the precedence sits in the app component's
type-resolution helper.</sub>

## Boolean options are read as booleans, and validated

Second commit. `APP_AUTOSTART`, `APP_USE_ICONS` and `APP_GLANCE_INTF` were read
with `${VAR} STREQUAL On`, which matches the single spelling `On` and reads
every other way of writing the same thing as off:

| written                                 | before           | after           |
|-----------------------------------------|------------------|-----------------|
| `On`                                    | on               | on              |
| `ON`, `on`, `TRUE`, `YES`, `1`          | **off**          | on              |
| `Off`, `OFF`, `off`, `FALSE`, `NO`, `0` | off              | off             |
| `disabled`, `Onn`, `none`               | off              | **build stops** |
| empty                                   | `if()` syntax error | **build stops** |

`-DAPP_GLANCE_INTF=ON` — the spelling CMake's own documentation uses — read as
off, so the override this PR introduces would have quietly done nothing.

`if(VAR)` on its own is not enough. CMake defines a short list of false values
and treats every other value as true, so a typo, or a word like `disabled`,
reads as ON. These options decide what goes into the packed header, so
`una_app_bool_option()` rejects a value that cannot be read as a boolean rather
than picking a side:

```text
APP_USE_ICONS is 'disabled', which is not a boolean; accepted in any case:
ON OFF TRUE FALSE YES NO Y N 1 0
```

The accepted set is narrower than CMake's: an empty value, `NOTFOUND` and
`IGNORE` count as false to CMake, but here they mean the caller wrote the option
and got it wrong. Meson, Bazel and Kconfig reject a non-boolean for a typed
option; CMake accepts anything — `option()` included, which stores
`FOO:BOOL=maybe` and reads it as true — so the check has to be written out.

`${APP_TYPE} STREQUAL Glance` had a second problem: an undefined `APP_TYPE`
expands to nothing, leaving `if()` with two arguments and aborting on `Unknown
arguments specified`. `APP_TYPE STREQUAL "Glance"` evaluates false instead. The
comparison stays case-sensitive, which matches `app_merging.py` — its `-type`
choices are case-sensitive too, so CMake and the packer reject the same input.

## Compatibility

`Glance` apps are deliberately left byte-identical — the claim is true for them,
and they are already in the field.

`Activity` and `Utility` apps lose a bit that was never meaningful for them.
Because their type is resolved before the bit is consulted, nothing about how
they are treated changes; queries that test the bit on its own now answer
correctly for them instead of unconditionally yes.

The second commit changes no packed image at all: every caller in the repository
— `Alarm`, `Timer` and the six `Glance*` apps — already writes exactly `On` or
`Off`.

Worth a look from whoever owns the phone/OTA side, in case anything there keys
off bit `0x20` in the header rather than off the type.

## Verification

Built before and after on this branch:

| App             | `APP_TYPE`  | Before | After  |
|-----------------|-------------|--------|--------|
| `GlanceBattery` | `Glance`    | `0x22` | `0x22` |
| `Stopwatch`     | `Utility`   | `0x21` | `0x01` |
| scratch app     | `Clockface` | `0x23` | `0x03` |

There is no `Clockface` app in `Examples/` yet, so that row comes from a
throwaway app built locally against this branch.

The option handling was driven by extracting `una_app_bool_option()` and the
three option blocks from `una-app.cmake` rather than retyping them, so what ran
is what ships: each of the three options over all twelve accepted spellings, the
glance default still following `APP_TYPE` (`Glance` on, `Activity`, `Utility`
and `Clockface` off), and `disabled`, `Onn` and `none` each stopping the run
before the option is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app packaging so glance capability is automatically configured based on the app type.
  * Non-glance apps no longer receive glance-specific packaging settings by default.
  * Explicit glance interface settings continue to override automatic behavior.
  * Invalid boolean packaging options are now rejected with a clear configuration error instead of being silently accepted.

* **Documentation**
  * Clarified supported app types, boolean values, developer identifiers, and packaging options.
  * Documented glance interface and launcher icon settings, including their defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->