### PR TITLE
fix(gui): put SensorStatusRow in SDK::GUI with the rest

### DIFF
--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
@@ -84,7 +84,7 @@ public:
     MainMenu &getMenu();
 
 private:
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 };
 
 #endif // MAINMENULAYOUT_HPP

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -33,11 +33,11 @@ public:
     void setBatteryLevel(uint8_t level);
 
     /** @brief Set the GPS / external-HR icon states (see SensorStatusRow). */
-    void setGps(SDK::Gui::SensorStatusRow::State state) { mSensorRow.setGps(state); }
-    void setHr(SDK::Gui::SensorStatusRow::State state)  { mSensorRow.setHr(state); }
+    void setGps(SDK::GUI::SensorStatusRow::State state) { mSensorRow.setGps(state); }
+    void setHr(SDK::GUI::SensorStatusRow::State state)  { mSensorRow.setHr(state); }
 
 protected:
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 
     // AM/PM suffix drawn next to the time in 12-hour format. Added here (rather
     // than in the generated base) so the layout stays in hand-written code; the

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
@@ -26,7 +26,7 @@ protected:
     using Menu = App::MenuNav::Root;
 
     bool mGpsFix = false;
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 
     MenuItemConfig mItems[Menu::ID_COUNT] {};
     MenuItemConfig mCenterItems[Menu::ID_COUNT] {};

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
@@ -156,12 +156,12 @@ void MainMenuLayout::showSensorRow(bool show)
 
 void MainMenuLayout::setGps(bool fix)
 {
-    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(fix));
+    mSensorRow.setGps(SDK::GUI::SensorStatusRow::gpsState(fix));
 }
 
 void MainMenuLayout::setHr(uint8_t accessoryState)
 {
-    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(accessoryState));
+    mSensorRow.setHr(SDK::GUI::SensorStatusRow::hrState(accessoryState));
 }
 
 // ---- Getters ---------------------------------------------------------------

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
@@ -28,7 +28,7 @@ void MainView::setupScreen()
     mSensorRow.setPosition(0, 52, 240, 24);
     mSensorRow.setIcons(BITMAP_SENSORGPSDARK_ID, BITMAP_SENSORGPSLIGHT_ID,
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
-    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(mGpsFix));
+    mSensorRow.setGps(SDK::GUI::SensorStatusRow::gpsState(mGpsFix));
 
     updateBackground(menuLayout.getSelectedItem());
 }
@@ -41,13 +41,13 @@ void MainView::tearDownScreen()
 void MainView::setGpsFix(bool state)
 {
     mGpsFix = state;
-    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(state));
+    mSensorRow.setGps(SDK::GUI::SensorStatusRow::gpsState(state));
     updateBackground(menuLayout.getSelectedItem());
 }
 
 void MainView::setAccessoryStatus(uint8_t state, const char* /*name*/)
 {
-    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(state));
+    mSensorRow.setHr(SDK::GUI::SensorStatusRow::hrState(state));
 }
 
 void MainView::setPositionId(uint16_t id)

--- a/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Cycling/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -153,7 +153,7 @@ void TrackView::handleKeyEvent(uint8_t key)
 
 void TrackView::setGpsFix(bool state)
 {
-    trackFaceStatus.setGps(SDK::Gui::SensorStatusRow::gpsState(state));
+    trackFaceStatus.setGps(SDK::GUI::SensorStatusRow::gpsState(state));
 }
 
 void TrackView::setAccessoryStatus(uint8_t state)
@@ -184,6 +184,6 @@ void TrackView::setPausedTime(std::time_t seconds)
 void TrackView::updateHrIcon()
 {
     // In-activity: icon follows the live HR source, not the raw link state.
-    trackFaceStatus.setHr(SDK::Gui::SensorStatusRow::hrStateFromSource(
+    trackFaceStatus.setHr(SDK::GUI::SensorStatusRow::hrStateFromSource(
             mAccessoryState, mHrSource));
 }

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
@@ -85,7 +85,7 @@ public:
     MainMenu &getMenu();
 
 private:
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 };
 
 #endif // MAINMENULAYOUT_HPP

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -33,11 +33,11 @@ public:
     void setBatteryLevel(uint8_t level);
 
     /** @brief Set the GPS / external-HR icon states (see SensorStatusRow). */
-    void setGps(SDK::Gui::SensorStatusRow::State state) { mSensorRow.setGps(state); }
-    void setHr(SDK::Gui::SensorStatusRow::State state)  { mSensorRow.setHr(state); }
+    void setGps(SDK::GUI::SensorStatusRow::State state) { mSensorRow.setGps(state); }
+    void setHr(SDK::GUI::SensorStatusRow::State state)  { mSensorRow.setHr(state); }
 
 protected:
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 
     // AM/PM suffix drawn next to the time in 12-hour format. Added here (rather
     // than in the generated base) so the layout stays in hand-written code; the

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
@@ -26,7 +26,7 @@ protected:
     using Menu = App::MenuNav::Root;
 
     bool mGpsFix = false;
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 
     MenuItemConfig mItems[Menu::ID_COUNT] {};
     MenuItemConfig mCenterItems[Menu::ID_COUNT] {};

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
@@ -161,12 +161,12 @@ void MainMenuLayout::showSensorRow(bool show)
 
 void MainMenuLayout::setGps(bool fix)
 {
-    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(fix));
+    mSensorRow.setGps(SDK::GUI::SensorStatusRow::gpsState(fix));
 }
 
 void MainMenuLayout::setHr(uint8_t accessoryState)
 {
-    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(accessoryState));
+    mSensorRow.setHr(SDK::GUI::SensorStatusRow::hrState(accessoryState));
 }
 
 // ---- Getters ---------------------------------------------------------------

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
@@ -32,7 +32,7 @@ void MainView::setupScreen()
     mSensorRow.setPosition(0, 52, 240, 24);
     mSensorRow.setIcons(BITMAP_SENSORGPSDARK_ID, BITMAP_SENSORGPSLIGHT_ID,
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
-    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(mGpsFix));
+    mSensorRow.setGps(SDK::GUI::SensorStatusRow::gpsState(mGpsFix));
 
     updateBackground(menuLayout.getSelectedItem());
 }
@@ -45,13 +45,13 @@ void MainView::tearDownScreen()
 void MainView::setGpsFix(bool state)
 {
     mGpsFix = state;
-    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(state));
+    mSensorRow.setGps(SDK::GUI::SensorStatusRow::gpsState(state));
     updateBackground(menuLayout.getSelectedItem());
 }
 
 void MainView::setAccessoryStatus(uint8_t state, const char* /*name*/)
 {
-    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(state));
+    mSensorRow.setHr(SDK::GUI::SensorStatusRow::hrState(state));
 }
 
 void MainView::setPositionId(uint16_t id)

--- a/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Hiking/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -151,7 +151,7 @@ void TrackView::handleKeyEvent(uint8_t key)
 
 void TrackView::setGpsFix(bool state)
 {
-    trackFaceStatus.setGps(SDK::Gui::SensorStatusRow::gpsState(state));
+    trackFaceStatus.setGps(SDK::GUI::SensorStatusRow::gpsState(state));
 }
 
 void TrackView::setAccessoryStatus(uint8_t state)
@@ -163,6 +163,6 @@ void TrackView::setAccessoryStatus(uint8_t state)
 void TrackView::updateHrIcon()
 {
     // In-activity: icon follows the live HR source, not the raw link state.
-    trackFaceStatus.setHr(SDK::Gui::SensorStatusRow::hrStateFromSource(
+    trackFaceStatus.setHr(SDK::GUI::SensorStatusRow::hrStateFromSource(
             mAccessoryState, mHrSource));
 }

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
@@ -85,7 +85,7 @@ public:
     MainMenu &getMenu();
 
 private:
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 };
 
 #endif // MAINMENULAYOUT_HPP

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -33,11 +33,11 @@ public:
     void setBatteryLevel(uint8_t level);
 
     /** @brief Set the GPS / external-HR icon states (see SensorStatusRow). */
-    void setGps(SDK::Gui::SensorStatusRow::State state) { mSensorRow.setGps(state); }
-    void setHr(SDK::Gui::SensorStatusRow::State state)  { mSensorRow.setHr(state); }
+    void setGps(SDK::GUI::SensorStatusRow::State state) { mSensorRow.setGps(state); }
+    void setHr(SDK::GUI::SensorStatusRow::State state)  { mSensorRow.setHr(state); }
 
 protected:
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 
     // AM/PM suffix drawn next to the time in 12-hour format. Added here (rather
     // than in the generated base) so the layout stays in hand-written code; the

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
@@ -25,7 +25,7 @@ protected:
     using Menu = App::MenuNav::Root;
 
     bool mGpsFix = false;
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 
     MenuItemConfig mItems[Menu::ID_COUNT] {};
     MenuItemConfig mCenterItems[Menu::ID_COUNT] {};

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
@@ -162,12 +162,12 @@ void MainMenuLayout::showSensorRow(bool show)
 
 void MainMenuLayout::setGps(bool fix)
 {
-    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(fix));
+    mSensorRow.setGps(SDK::GUI::SensorStatusRow::gpsState(fix));
 }
 
 void MainMenuLayout::setHr(uint8_t accessoryState)
 {
-    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(accessoryState));
+    mSensorRow.setHr(SDK::GUI::SensorStatusRow::hrState(accessoryState));
 }
 
 // ---- Getters ---------------------------------------------------------------

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
@@ -28,7 +28,7 @@ void MainView::setupScreen()
     mSensorRow.setPosition(0, 52, 240, 24);
     mSensorRow.setIcons(BITMAP_SENSORGPSDARK_ID, BITMAP_SENSORGPSLIGHT_ID,
                         BITMAP_SENSORHRDARK_ID, BITMAP_SENSORHRLIGHT_ID);
-    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(mGpsFix));
+    mSensorRow.setGps(SDK::GUI::SensorStatusRow::gpsState(mGpsFix));
 
     updateBackground(menuLayout.getSelectedItem());
 }
@@ -41,13 +41,13 @@ void MainView::tearDownScreen()
 void MainView::setGpsFix(bool state)
 {
     mGpsFix = state;
-    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(state));
+    mSensorRow.setGps(SDK::GUI::SensorStatusRow::gpsState(state));
     updateBackground(menuLayout.getSelectedItem());
 }
 
 void MainView::setAccessoryStatus(uint8_t state, const char* /*name*/)
 {
-    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(state));
+    mSensorRow.setHr(SDK::GUI::SensorStatusRow::hrState(state));
 }
 
 void MainView::setPositionId(uint16_t id)

--- a/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Running/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -181,7 +181,7 @@ void TrackView::handleKeyEvent(uint8_t key)
 
 void TrackView::setGpsFix(bool state)
 {
-    trackFaceStatus.setGps(SDK::Gui::SensorStatusRow::gpsState(state));
+    trackFaceStatus.setGps(SDK::GUI::SensorStatusRow::gpsState(state));
 }
 
 void TrackView::setAccessoryStatus(uint8_t state)
@@ -193,6 +193,6 @@ void TrackView::setAccessoryStatus(uint8_t state)
 void TrackView::updateHrIcon()
 {
     // In-activity: icon follows the live HR source, not the raw link state.
-    trackFaceStatus.setHr(SDK::Gui::SensorStatusRow::hrStateFromSource(
+    trackFaceStatus.setHr(SDK::GUI::SensorStatusRow::hrStateFromSource(
             mAccessoryState, mHrSource));
 }

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
@@ -84,7 +84,7 @@ public:
     MainMenu &getMenu();
 
 private:
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 };
 
 #endif // MAINMENULAYOUT_HPP

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -33,11 +33,11 @@ public:
     void setBatteryLevel(uint8_t level);
 
     /** @brief Set the external-HR icon state (see SensorStatusRow). Treadmill is HR-only. */
-    void setHr(SDK::Gui::SensorStatusRow::State state)  { mSensorRow.setHr(state); }
-    void setGps(SDK::Gui::SensorStatusRow::State state) { mSensorRow.setGps(state); }
+    void setHr(SDK::GUI::SensorStatusRow::State state)  { mSensorRow.setHr(state); }
+    void setGps(SDK::GUI::SensorStatusRow::State state) { mSensorRow.setGps(state); }
 
 protected:
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 
     // AM/PM suffix drawn next to the time in 12-hour format. Added here (rather
     // than in the generated base) so the layout stays in hand-written code; the

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
@@ -23,7 +23,7 @@ public:
 protected:
     using Menu = App::MenuNav::Root;
 
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 
     MenuItemConfig mItems[Menu::ID_COUNT] {};
     MenuItemConfig mCenterItems[Menu::ID_COUNT] {};

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
@@ -157,12 +157,12 @@ void MainMenuLayout::showSensorRow(bool show)
 
 void MainMenuLayout::setGps(bool fix)
 {
-    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(fix));
+    mSensorRow.setGps(SDK::GUI::SensorStatusRow::gpsState(fix));
 }
 
 void MainMenuLayout::setHr(uint8_t accessoryState)
 {
-    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(accessoryState));
+    mSensorRow.setHr(SDK::GUI::SensorStatusRow::hrState(accessoryState));
 }
 
 // ---- Getters ---------------------------------------------------------------

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
@@ -37,7 +37,7 @@ void MainView::setupScreen()
 
 void MainView::setAccessoryStatus(uint8_t state, const char* /*name*/)
 {
-    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(state));
+    mSensorRow.setHr(SDK::GUI::SensorStatusRow::hrState(state));
 }
 
 void MainView::tearDownScreen()

--- a/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Treadmill/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -142,7 +142,7 @@ void TrackView::updateHrIcon()
 {
     // In-activity: icon follows the live HR source, not the raw link state.
     // Treadmill is HR-only — no GPS icon to update.
-    trackFaceStatus.setHr(SDK::Gui::SensorStatusRow::hrStateFromSource(
+    trackFaceStatus.setHr(SDK::GUI::SensorStatusRow::hrStateFromSource(
             mAccessoryState, mHrSource));
 }
 

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/MainMenuLayout.hpp
@@ -84,7 +84,7 @@ public:
     MainMenu &getMenu();
 
 private:
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 };
 
 #endif // MAINMENULAYOUT_HPP

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/containers/TrackFaceStatus.hpp
@@ -33,10 +33,10 @@ public:
     void setBatteryLevel(uint8_t level);
 
     /** @brief Set the external-HR icon state (see SensorStatusRow). */
-    void setHr(SDK::Gui::SensorStatusRow::State state) { mSensorRow.setHr(state); }
+    void setHr(SDK::GUI::SensorStatusRow::State state) { mSensorRow.setHr(state); }
 
 protected:
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 
     // AM/PM suffix drawn next to the time in 12-hour format. Added here (rather
     // than in the generated base) so the layout stays in hand-written code; the

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/include/gui/main_screen/MainView.hpp
@@ -22,7 +22,7 @@ public:
 protected:
     using Menu = App::MenuNav::Root;
 
-    SDK::Gui::SensorStatusRow mSensorRow;
+    SDK::GUI::SensorStatusRow mSensorRow;
 
     MenuItemConfig mItems[Menu::ID_COUNT] {};
     MenuItemConfig mCenterItems[Menu::ID_COUNT] {};

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/containers/MainMenuLayout.cpp
@@ -163,12 +163,12 @@ void MainMenuLayout::showSensorRow(bool show)
 
 void MainMenuLayout::setGps(bool fix)
 {
-    mSensorRow.setGps(SDK::Gui::SensorStatusRow::gpsState(fix));
+    mSensorRow.setGps(SDK::GUI::SensorStatusRow::gpsState(fix));
 }
 
 void MainMenuLayout::setHr(uint8_t accessoryState)
 {
-    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(accessoryState));
+    mSensorRow.setHr(SDK::GUI::SensorStatusRow::hrState(accessoryState));
 }
 
 // ---- Getters ---------------------------------------------------------------

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/main_screen/MainView.cpp
@@ -38,7 +38,7 @@ void MainView::tearDownScreen()
 
 void MainView::setAccessoryStatus(uint8_t state, const char* /*name*/)
 {
-    mSensorRow.setHr(SDK::Gui::SensorStatusRow::hrState(state));
+    mSensorRow.setHr(SDK::GUI::SensorStatusRow::hrState(state));
 }
 
 void MainView::setPositionId(uint16_t id)

--- a/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
+++ b/Examples/Apps/Workout/Software/Apps/TouchGFX-GUI/gui/src/track_screen/TrackView.cpp
@@ -105,7 +105,7 @@ void TrackView::setAccessoryStatus(uint8_t state)
 void TrackView::updateHrIcon()
 {
     // In-activity: icon follows the live HR source, not the raw link state.
-    trackFaceStatus.setHr(SDK::Gui::SensorStatusRow::hrStateFromSource(
+    trackFaceStatus.setHr(SDK::GUI::SensorStatusRow::hrStateFromSource(
             mAccessoryState, mHrSource));
 }
 

--- a/Libs/Header/SDK/GUI/SensorStatusRow.hpp
+++ b/Libs/Header/SDK/GUI/SensorStatusRow.hpp
@@ -25,8 +25,8 @@
  ******************************************************************************
  */
 
-#ifndef __SDK_GUI_SENSOR_STATUS_ROW_HPP
-#define __SDK_GUI_SENSOR_STATUS_ROW_HPP
+#ifndef SDK_GUI_SENSOR_STATUS_ROW_HPP
+#define SDK_GUI_SENSOR_STATUS_ROW_HPP
 
 #include <touchgfx/Application.hpp>
 #include <touchgfx/Bitmap.hpp>
@@ -35,9 +35,7 @@
 
 #include "SDK/SensorLayer/DataParsers/SensorDataParserHeartRateEx.hpp"  // HeartRateEx::Source
 
-namespace SDK
-{
-namespace Gui
+namespace SDK::GUI
 {
 
 class SensorStatusRow : public touchgfx::Container
@@ -230,7 +228,6 @@ private:
     }
 };
 
-}  // namespace Gui
-}  // namespace SDK
+} // namespace SDK::GUI
 
-#endif  // __SDK_GUI_SENSOR_STATUS_ROW_HPP
+#endif  // SDK_GUI_SENSOR_STATUS_ROW_HPP


### PR DESCRIPTION
`SensorStatusRow` sits in `SDK::Gui`, while everything else under
`Libs/Header/SDK/GUI/` is in `SDK::GUI`. Two namespaces that differ only in case,
in one directory, is a trap waiting for the next person to add a file there. This
moves the odd one out.

## Why this direction

| | declared in | uses | files |
|---|---|---|---|
| `SDK::GUI` | `Button.hpp`, `Color.hpp`, `Config.hpp` | 468 | 131 |
| `SDK::Gui` | `SensorStatusRow.hpp` | 53 | 30 |

`SDK::GUI` also came first -- the three headers landed together in `fe911165`
(2026-04-26), `SensorStatusRow` two months later in `9a43b240`, with both a
different case and the older nested-namespace syntax. It reads as a slip rather
than a second convention: nothing else was ever added to `SDK::Gui`, and the SDK
library itself never references it (`TouchGFXCommandProcessor.cpp` and the
simulator `Kernel.cpp` both reach for `SDK::GUI::Button`).

The declaration adopts the C++17 form its siblings use. The class stays one level
up, because `SDK::GUI::Button` and friends are namespaces of constants while this
is a type:

```cpp
namespace SDK::GUI
{
class SensorStatusRow : public touchgfx::Container { ... };
} // namespace SDK::GUI
```

## The header guard, while the file is open

`__SDK_GUI_SENSOR_STATUS_ROW_HPP` also loses its leading underscores. Identifiers
beginning with a double underscore are reserved to the implementation, so that
name was never ours to define. The macro appears only in this file, so nothing
else moves.

## Scope

31 files: the header plus 30 call sites across `Cycling`, `Hiking`, `Running`,
`Treadmill` and `Workout`. Nothing else in the repository refers to the name --
not the tutorials, not the docs, and no other example app.

Only the fully qualified `SDK::Gui::` was replaced, never a bare `Gui`. Every app
has its own unrelated `Gui` namespace in `gui/common/GuiConfig.hpp`, which the
tutorials document as `Gui::Config::...`; a careless rename would have taken that
with it.

## Tested

- `Cycling` and `Workout` simulators build clean. Both use the widget.
- `git grep SDK::Gui` returns nothing.
- Behaviour is untouched: the diff changes namespace and guard lines only.