### PR TITLE
fix(appsystem): stop nothrow new pulling the exception runtime into every app

### DIFF
--- a/Libs/Source/AppSystem/system.cpp
+++ b/Libs/Source/AppSystem/system.cpp
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <cstdint>
 #include <cstddef>
+#include <new>
 #include <atomic>
 #include <cstdlib>
 #include <cassert>
@@ -461,6 +462,52 @@ void operator delete(void* ptr, std::size_t) noexcept
  * @note    Marked @c noexcept to match freestanding constraints.
  */
 void operator delete[](void* ptr, std::size_t) noexcept
+{
+    operator delete[](ptr);
+}
+
+/**
+ * @brief   Nothrow new forwarding to @ref operator new.
+ * @param   size Number of bytes to allocate.
+ * @return  Pointer to allocated memory; @c nullptr on failure.
+ * @note    Supplied so the link does not take libstdc++'s version, whose
+ *          try/catch body pulls the exception runtime and ARM unwinder into a
+ *          @c -fno-exceptions app. To re-measure: delete these four and rebuild
+ *          any app reaching @c new(std::nothrow), such as
+ *          @c Examples/Apps/Running, and both come back. One app's GUI blob
+ *          carried 152 further symbols and 9,356 more bytes of @c .text that
+ *          way, but the size is per-app: one that also links @c std::string
+ *          keeps the runtime regardless.
+ */
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept
+{
+    return operator new(size);
+}
+
+/**
+ * @brief   Nothrow array new forwarding to @ref operator new[].
+ * @param   size Number of bytes to allocate.
+ * @return  Pointer to allocated memory; @c nullptr on failure.
+ */
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept
+{
+    return operator new[](size);
+}
+
+/**
+ * @brief   Nothrow delete forwarding to @ref operator delete.
+ * @param   ptr Pointer to memory to be freed (nullable).
+ */
+void operator delete(void* ptr, const std::nothrow_t&) noexcept
+{
+    operator delete(ptr);
+}
+
+/**
+ * @brief   Nothrow array delete forwarding to @ref operator delete[].
+ * @param   ptr Pointer to memory to be freed (nullable).
+ */
+void operator delete[](void* ptr, const std::nothrow_t&) noexcept
 {
     operator delete[](ptr);
 }


### PR DESCRIPTION
`-fno-exceptions` never reaches precompiled libstdc++, so every app has been carrying ~10 KB of exception runtime and ~1 KB startup heap allocation for a catch that can't fire. `system.cpp` already replaces the other allocation operators, omitting the `nothrow` ones is what let the link fall through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory allocation compatibility for builds that do not use exception handling.
  * Prevented unnecessary exception-runtime and ARM unwinder dependencies during linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->